### PR TITLE
Permettre la mise en production de Pix.fr depuis Slack. 

### DIFF
--- a/lib/controllers/releases.js
+++ b/lib/controllers/releases.js
@@ -1,4 +1,4 @@
-const { deploy } = require('../services/releases');
+const { deploy, createAndDeployPixSite } = require('../services/releases');
 const config = require('../config');
 
 module.exports = {
@@ -15,6 +15,20 @@ module.exports = {
     const releaseTag = request.payload.release_tag;
 
     return deploy(releaseTag);
+  },
+
+  async createAndDeployPixSiteRelease(request, h) {
+    if (!request.payload || !request.payload.authorizationToken) {
+      return h.response().code(401);
+    }
+
+    if (request.payload.authorizationToken !== config.openApi.authorizationToken) {
+      return h.response().code(403);
+    }
+
+    const releaseType = request.payload.release_type;
+
+    return createAndDeployPixSite(releaseType);
   },
 
 };

--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -24,6 +24,16 @@ module.exports = {
     };
   },
 
+  createAndDeployPixSiteRelease(request, h) {
+    const payload = request.pre.payload;
+
+    commands.createAndDeployPixSiteRelease(payload);
+
+    return {
+      "text": "Commande de déploiement en production bien reçue."
+    };
+  },
+
   interactiveEndpoint(request) {
     const payload = JSON.parse(request.payload.payload);
 

--- a/lib/routes/releases.js
+++ b/lib/routes/releases.js
@@ -5,5 +5,10 @@ module.exports = [
     method: 'POST',
     path: '/releases',
     handler: releasesController.deployRelease
+  },
+  {
+    method: 'POST',
+    path: '/pix-site/releases',
+    handler: releasesController.createAndDeployPixSiteRelease
   }
 ];

--- a/lib/routes/releases.js
+++ b/lib/routes/releases.js
@@ -3,7 +3,7 @@ const releasesController = require('../controllers/releases');
 module.exports = [
   {
     method: 'POST',
-    path: '/releases',
+    path: '/pix-apps/releases',
     handler: releasesController.deployRelease
   },
   {

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -32,6 +32,20 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-site-release',
+    handler: slackbotController.createAndDeployPixSiteRelease,
+    config: {
+      payload: {
+        allow: 'application/x-www-form-urlencoded',
+        parse: false
+      },
+      pre: [
+        { method: verifySlackRequest, assign: 'payload' }
+      ]
+    }
+  },
+  {
+    method: 'POST',
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
   }

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -30,5 +30,19 @@ module.exports = {
     } catch (err) {
       console.error(err);
     }
+  },
+
+  async createAndDeployPixSite(releaseType) {
+    try {
+      const scriptsDirectory = `${process.cwd()}/scripts`;
+      const { stdout, stderr } = await exec(`${scriptsDirectory}/release-pix-site.sh ${releaseType}`);
+
+      console.log(stdout);
+      console.error(stderr);
+
+      return { message: 'Release deployed 🚀', stdout, stderr };
+    } catch (err) {
+      console.error(err);
+    }
   }
 };

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -1,4 +1,4 @@
-const { deploy, publish } = require('../releases');
+const { deploy } = require('../releases');
 const axios = require('axios');
 
 module.exports = {
@@ -21,6 +21,22 @@ module.exports = {
 
   deployRelease(payload) {
     deploy(payload.text).then(() => {
+      const options = {
+        method: 'POST',
+        url: payload.response_url,
+        headers: {
+          'content-type': 'application/json',
+        },
+        data: {
+          "text": `Le script de déploiement de la release ${payload.text} en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`
+        }
+      };
+      axios(options);
+    });
+  },
+
+  createAndDeployPixSiteRelease(payload) {
+    createAndDeployPixSite(payload.text).then(() => {
       const options = {
         method: 'POST',
         url: payload.response_url,

--- a/scripts/release-pix-site.sh
+++ b/scripts/release-pix-site.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+source "$(dirname $0)"/common.sh
+
+VERSION_TYPE=$1
+
+echo "Version type ${VERSION_TYPE}"
+
+function install_ssh_key_for_git_operations {
+  mkdir -p ~/.ssh
+  ssh-keyscan -H github.com > ~/.ssh/known_hosts
+  echo "$SSH_KEY" | base64 -d > ~/.ssh/id_rsa
+  chmod 400 ~/.ssh/id_rsa
+}
+
+function clone_repository_and_move_inside {
+  REPOSITORY_FOLDER=$(mktemp -d)
+  echo "Created temporary directory $REPOSITORY_FOLDER"
+
+  git clone git@github.com:1024pix/pix-site.git "$REPOSITORY_FOLDER"
+  echo "Cloned repository to temporary directory"
+
+  cd "$REPOSITORY_FOLDER"
+  echo "Moved to repository folder"
+}
+
+function configure_git_user_information {
+  git config user.name "$GIT_USER_NAME"
+  git config user.email "$GIT_USER_EMAIL"
+  echo "Set Git user information"
+}
+
+function install_required_packages {
+  npm install
+  echo "Install packages"
+}
+
+function create_and_deploy_release {
+  npm run release:${VERSION_TYPE}
+  echo "Deploy new release"
+}
+
+function delete_repository_folder {
+  rm -rf "$REPOSITORY_FOLDER"
+  echo "Deleted temporary folder"
+}
+
+echo "Start deploying version ${VERSION_TYPE}…"
+
+install_ssh_key_for_git_operations
+clone_repository_and_move_inside
+configure_git_user_information
+install_required_packages
+create_and_deploy_release
+delete_repository_folder
+
+echo -e "Release deployment ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/release-pix-site.sh
+++ b/scripts/release-pix-site.sh
@@ -8,21 +8,14 @@ VERSION_TYPE=$1
 
 echo "Version type ${VERSION_TYPE}"
 
-function install_ssh_key_for_git_operations {
-  mkdir -p ~/.ssh
-  ssh-keyscan -H github.com > ~/.ssh/known_hosts
-  echo "$SSH_KEY" | base64 -d > ~/.ssh/id_rsa
-  chmod 400 ~/.ssh/id_rsa
-}
-
 function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
-  echo "Created temporary directory $REPOSITORY_FOLDER"
+  echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone git@github.com:1024pix/pix-site.git "$REPOSITORY_FOLDER"
+  git clone git@github.com:1024pix/pix-site.git "${REPOSITORY_FOLDER}"
   echo "Cloned repository to temporary directory"
 
-  cd "$REPOSITORY_FOLDER"
+  cd "${REPOSITORY_FOLDER}"
   echo "Moved to repository folder"
 }
 
@@ -42,18 +35,11 @@ function create_and_deploy_release {
   echo "Deploy new release"
 }
 
-function delete_repository_folder {
-  rm -rf "$REPOSITORY_FOLDER"
-  echo "Deleted temporary folder"
-}
-
 echo "Start deploying version ${VERSION_TYPE}…"
 
-install_ssh_key_for_git_operations
 clone_repository_and_move_inside
 configure_git_user_information
 install_required_packages
 create_and_deploy_release
-delete_repository_folder
 
 echo -e "Release deployment ${GREEN}succeeded${RESET_COLOR}."


### PR DESCRIPTION
## :unicorn: Problème
Les mises en production de Pix-Site se font encore par un développeur. 

## :robot: Solution
Permettre à une application slack de lancer une mise en production. 
Ajout d'un nouvel endpoint : `/slack/commands/create-and-deploy-pix-site-release`