### PR TITLE
Publier une release et la déployer en recette depuis la commande Slack `/publish-release`.

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -4,7 +4,17 @@ const viewSubmissions = require('../services/slack/view-submissions');
 
 module.exports = {
 
-  deployRelease(request, h) {
+  publishRelease(request) {
+    const payload = request.pre.payload;
+
+    commands.publishRelease(payload);
+
+    return {
+      "text": "Commande de publication d'une release bien reçue."
+    };
+  },
+
+  deployRelease(request) {
     const payload = request.pre.payload;
 
     commands.deployRelease(payload);
@@ -14,7 +24,7 @@ module.exports = {
     };
   },
 
-  interactiveEndpoint(request, h) {
+  interactiveEndpoint(request) {
     const payload = JSON.parse(request.payload.payload);
 
     const interactionType = payload.type;

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -4,6 +4,20 @@ const slackbotController = require('../controllers/slack');
 module.exports = [
   {
     method: 'POST',
+    path: '/slack/commands/publish-release',
+    handler: slackbotController.publishRelease,
+    config: {
+      payload: {
+        allow: 'application/x-www-form-urlencoded',
+        parse: false
+      },
+      pre: [
+        { method: verifySlackRequest, assign: 'payload' }
+      ]
+    }
+  },
+  {
+    method: 'POST',
     path: '/slack/commands/deploy-release',
     handler: slackbotController.deployRelease,
     config: {

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -3,6 +3,21 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
 module.exports = {
+
+  async publish(versionType) {
+    try {
+      const scriptsDirectory = `${process.cwd()}/scripts`;
+      const { stdout, stderr } = await exec(`${scriptsDirectory}/publish.sh ${versionType}`);
+
+      console.log(stdout);
+      console.error(stderr);
+
+      return { message: 'Release published 🎁', stdout, stderr };
+    } catch (err) {
+      console.error(err);
+    }
+  },
+
   async deploy(releaseTag) {
     try {
       const scriptsDirectory = `${process.cwd()}/scripts`;

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -1,7 +1,23 @@
-const { deploy } = require('../releases');
+const { deploy, publish } = require('../releases');
 const axios = require('axios');
 
 module.exports = {
+
+  publishRelease(payload) {
+    publish(payload.text).then(() => {
+      const options = {
+        method: 'POST',
+        url: payload.response_url,
+        headers: {
+          'content-type': 'application/json',
+        },
+        data: {
+          "text": `Le script de publication de la release ${payload.text} s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`
+        }
+      };
+      axios(options);
+    });
+  },
 
   deployRelease(payload) {
     deploy(payload.text).then(() => {
@@ -18,5 +34,4 @@ module.exports = {
       axios(options);
     });
   }
-
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -910,8 +910,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "axios": "^0.19.2",
     "crypto": "^1.0.1",
     "dotenv": "^8.2.0",
+    "lodash": "^4.17.15",
+    "moment": "^2.24.0",
     "scalingo-review-app-manager": "^0.1.2"
   },
   "engines": {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -12,16 +12,27 @@ YELLOW="\033[1;33m"
 BLUE="\033[1;34m"
 CYAN="\033[1;36m"
 
-# Common functions
-function get_package_version {
-    node -p -e "require('./package.json').version"
+function install_ssh_key_for_git_operations {
+  mkdir -p ~/.ssh
+  ssh-keyscan -H github.com > ~/.ssh/known_hosts
+  echo "${SSH_KEY}" | base64 -d > ~/.ssh/id_rsa
+  chmod 400 ~/.ssh/id_rsa
 }
 
-function checkout_dev {
-    git checkout dev >> /dev/null 2>&1
+function clone_repository_and_move_inside {
+  REPOSITORY_FOLDER=$(mktemp -d)
+  echo "Created temporary directory $REPOSITORY_FOLDER"
+
+  git clone git@github.com:1024pix/pix.git "$REPOSITORY_FOLDER"
+  echo "Cloned repository to temporary directory"
+
+  cd "$REPOSITORY_FOLDER"
+  echo "Moved to repository folder"
 }
 
-function fetch_and_rebase {
-    git fetch --tags
-    git pull --rebase
+function configure_git_user_information {
+  git config user.name "$GIT_USER_NAME"
+  git config user.email "$GIT_USER_EMAIL"
+  echo "Set Git user information"
 }
+

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,30 +8,6 @@ VERSION_NUMBER=$1
 
 echo "Version number ${VERSION_NUMBER}"
 
-function install_ssh_key_for_git_operations {
-  mkdir -p ~/.ssh
-  ssh-keyscan -H github.com > ~/.ssh/known_hosts
-  echo "$SSH_KEY" | base64 -d > ~/.ssh/id_rsa
-  chmod 400 ~/.ssh/id_rsa
-}
-
-function clone_repository_and_move_inside {
-  REPOSITORY_FOLDER=$(mktemp -d)
-  echo "Created temporary directory $REPOSITORY_FOLDER"
-
-  git clone git@github.com:1024pix/pix.git "$REPOSITORY_FOLDER"
-  echo "Cloned repository to temporary directory"
-
-  cd "$REPOSITORY_FOLDER"
-  echo "Moved to repository folder"
-}
-
-function configure_git_user_information {
-  git config user.name "$GIT_USER_NAME"
-  git config user.email "$GIT_USER_EMAIL"
-  echo "Set Git user information"
-}
-
 function get_release_commit_hash {
     local commit_hash
 
@@ -62,11 +38,6 @@ function finalize_release_on_sentry {
     echo "Finalized release on Sentry"
 }
 
-function delete_repository_folder {
-  rm -rf "$REPOSITORY_FOLDER"
-  echo "Deleted temporary folder"
-}
-
 echo "Start deploying version ${VERSION_NUMBER}…"
 
 install_ssh_key_for_git_operations
@@ -75,6 +46,5 @@ configure_git_user_information
 get_release_commit_hash
 update_production_branch
 finalize_release_on_sentry
-delete_repository_folder
 
 echo -e "Release deployment ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -1,0 +1,89 @@
+#! /usr/bin/env node
+const axios = require('axios');
+const moment = require('moment');
+const _ = require('lodash');
+const fs = require('fs');
+
+const CHANGELOG_FILE = 'CHANGELOG.md';
+const CHANGELOG_HEADER_LINES = 2;
+
+function buildRequestObject() {
+  return 'https://api.github.com/repos/1024pix/pix/pulls?state=closed&sort=updated&direction=desc';
+}
+
+function getTheLastCommitOnMaster() {
+  return 'https://api.github.com/repos/1024pix/pix/commits/master';
+}
+
+function getTheCommitDate(RawDataCommit) {
+  return RawDataCommit.commit.committer.date;
+}
+
+function displayPullRequest(pr) {
+  return `- [#${pr.number}](${pr.html_url}) ${pr.title}`;
+}
+
+function orderPr(listPR) {
+  const typeOrder = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
+  return _.sortBy(listPR, (pr) => {
+    const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
+    const typeIndex = _.indexOf(typeOrder, typeOfPR);
+    return typeIndex < 0 ? Number.MAX_VALUE : typeIndex;
+  });
+}
+
+function filterPullRequest(pullrequests, dateOfLastMEP) {
+  return pullrequests.filter((PR) => PR.merged_at > dateOfLastMEP);
+}
+
+function getHeadOfChangelog(tagVersion) {
+  const date = ' (' + moment().format('DD/MM/YYYY') + ')';
+  return '## v' + tagVersion + date + '\n';
+}
+
+function main() {
+  const tagVersion = process.argv[2];
+  let dateOfLastMEP;
+
+  axios(getTheLastCommitOnMaster())
+    .then(({ data: lastCommit }) => {
+      dateOfLastMEP = getTheCommitDate(lastCommit);
+      return axios(buildRequestObject());
+    })
+    .then(({ data: pullRequests }) => {
+      const newChangeLogLines = [];
+
+      newChangeLogLines.push(getHeadOfChangelog(tagVersion));
+      const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+
+      const orderedPR = orderPr(pullRequestsSinceLastMEP);
+      newChangeLogLines.push(...orderedPR.map(displayPullRequest));
+      newChangeLogLines.push('');
+
+      const currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
+
+      currentChangeLog.splice(CHANGELOG_HEADER_LINES, 0, ...newChangeLogLines);
+
+      console.log(`Writing to ${CHANGELOG_FILE}`);
+
+      fs.writeFileSync(CHANGELOG_FILE, currentChangeLog.join('\n'));
+    })
+    .catch((e)=>{
+      console.log(e);
+      process.exit(1);
+    });
+}
+
+/*=================== tests =============================*/
+
+if (process.env.NODE_ENV !== 'test') {
+  main();
+} else {
+  module.exports = {
+    displayPullRequest,
+    filterPullRequest,
+    orderPr,
+    getHeadOfChangelog,
+    getTheCommitDate,
+  };
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+CWD_DIR=$(pwd)
+
+echo "${CWD_DIR}"
+
+source "${CWD_DIR}/scripts/common.sh"
+
+function get_package_version() {
+  node -p -e "require('./package.json').version"
+}
+
+NEW_VERSION_TYPE=$1
+OLD_PACKAGE_VERSION=$(get_package_version)
+
+function ensure_no_uncommited_changes_are_present() {
+  if [ -n "$(git status --porcelain)" ]; then
+    echo -e "${RED}You have uncommitted changes!${RESET_COLOR} Please commit or stash your changes first.\n"
+    git status
+    exit 1
+  fi
+  echo "Git changes status OK"
+}
+
+function ensure_new_version_is_either_minor_or_patch_or_major() {
+  if [ "${NEW_VERSION_TYPE}" != "patch" -a "${NEW_VERSION_TYPE}" != "minor" -a "${NEW_VERSION_TYPE}" != "major" ]; then
+    echo -e "${RED}Wrong argument!${RESET_COLOR} Only ${GREEN}patch${RESET_COLOR}, ${GREEN}minor${RESET_COLOR} or ${GREEN}major${RESET_COLOR} is allowed.\n"
+    exit 1
+  fi
+
+  echo "Version type OK"
+}
+
+function checkout_dev() {
+  git checkout dev >>/dev/null 2>&1
+}
+
+function fetch_and_rebase() {
+  git fetch --tags
+  git pull --rebase
+}
+
+function update_version() {
+  (cd api/ && npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null)
+  (cd mon-pix/ && npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null)
+  (cd orga/ && npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null)
+  (cd certif/ && npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null)
+  (cd admin/ && npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null)
+  npm version "${NEW_VERSION_TYPE}" --git-tag-version=false >>/dev/null
+  NEW_PACKAGE_VERSION=$(get_package_version)
+
+  echo "Bumped versions in package files"
+}
+
+function complete_change_log() {
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}"
+
+  echo "Updated CHANGELOG.md"
+}
+
+# Update when adding a new app
+function create_a_release_commit() {
+  git add CHANGELOG.md package*.json api/package*json mon-pix/package*.json orga/package*.json certif/package*.json admin/package*.json --update
+  git commit --message "[RELEASE] A ${NEW_VERSION_TYPE} is being released from ${OLD_PACKAGE_VERSION} to ${NEW_PACKAGE_VERSION}."
+
+  echo "Created the release commit"
+}
+
+function push_commit_to_remote_dev() {
+  git push origin dev
+
+  echo "Pushed release commit on branch origin/dev"
+}
+
+function checkout_master() {
+  git checkout master >>/dev/null 2>&1
+
+  echo "Checked out branch master"
+}
+
+function create_a_merge_commit_of_dev_into_master_and_tag_it() {
+  git merge dev --no-edit
+  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
+
+  echo "Merged changes from dev into master and created annotated tag"
+}
+
+function push_commit_and_tag_to_remote_master() {
+  git push origin master
+  git push origin "v${NEW_PACKAGE_VERSION}"
+
+  echo "Pushed changes on branch origin/master with tag"
+}
+
+function publish_release_on_sentry() {
+  npx sentry-cli releases -o pix new -p pix-api "v${NEW_PACKAGE_VERSION}"
+  npx sentry-cli releases -o pix set-commits --commit "1024pix/pix@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
+
+  echo "Published release on Sentry"
+}
+
+echo -e "Preparing a new release.\n"
+
+echo "== Clone and move into Pix repository =="
+#install_ssh_key_for_git_operations
+clone_repository_and_move_inside
+configure_git_user_information
+echo "== Validate context =="
+#ensure_no_uncommited_changes_are_present
+ensure_new_version_is_either_minor_or_patch_or_major
+echo "== Package release =="
+checkout_dev
+fetch_and_rebase
+update_version
+complete_change_log
+create_a_release_commit
+push_commit_to_remote_dev
+echo "== Publish release =="
+checkout_master
+fetch_and_rebase
+create_a_merge_commit_of_dev_into_master_and_tag_it
+push_commit_and_tag_to_remote_master
+publish_release_on_sentry
+
+echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."


### PR DESCRIPTION
## Contexte

A l'image de la commande Slack `/deploy-release [release_tag]` qui permet d'installer les apps Pix sur l'environnement de production, nous aimerions rendre la publication et le déploiement sur l'environnement de recette d'une nouvelle _release_ accessible et exécutable au travers une nouvelle commande `/publish-release [version_type]`.

## Réalisation

Cette PR se contente de la version commande Slack et ne couvre pas la feature shortcut + model-based workflow proposé pour la procédure de déploiement.