### PR TITLE
[FEATURE] Permettre de déployer une ancienne version.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,7 +28,7 @@ function update_production_branch {
 
     annotated_version="${RELEASE_TAG}^{}"
     annotated_tag_hash="$(git rev-parse --quiet "${annotated_version}")"
-    git push origin "$annotated_tag_hash":prod
+    git push -f origin "$annotated_tag_hash":prod
 
     echo "Pushed changes on branch origin/prod"
 }


### PR DESCRIPTION
## Problème
Il n'est pas possible de revenir sur une version précédente de la production en utilisant pix-bot. 

## Solution  
Ajouter l'option `-f`  à la commande `git push` pour permettre de pousser la version que l'on souhaite en production. 