### PR TITLE
[BUGFIX] Pouvoir gérer un nombre important de review apps. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
       }
     },
     "scalingo-review-app-manager": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-0.2.0.tgz",
-      "integrity": "sha512-qolSfrihit3hCicqlz5oJPRxdpVFwJ2pKboRGUJtGt+RCdgq0wJZ2+Y26mT7bOjOE3EtqwJghOg0svXnzM4AZg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-0.3.0.tgz",
+      "integrity": "sha512-znOHVWRICbLN8U5eU/Pi6V0cWvIwl5sh6cVQWTxy+plXCN+iF7LtmpHcRn3NGPJosGdP+FzgXagCBCtprjc6XA==",
       "requires": {
         "cron": "^1.8.2",
         "scalingo": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dotenv": "^8.2.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "scalingo-review-app-manager": "^0.2.0",
+    "scalingo-review-app-manager": "^0.3.0",
     "tsscmp": "^1.0.6"
   },
   "engines": {


### PR DESCRIPTION
## Problème 
Scalingo impose une restriction sur le nombre d'opérations en cours d'exécution (ex: scaling, création, suppression d'apps), cf. #4.  
 
## Solution 
La dernière version de la dépendance [scalingo-review-app-manager]( https://github.com/1024pix/scalingo-review-app-manager/pull/1) dont dépend Pix Bot, tient compte de cette limite. 

Cette PR effectue la montée de version. 