### PR TITLE
[INFRA] Montée de version de scalingo-review-app-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
       }
     },
     "scalingo-review-app-manager": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-0.3.0.tgz",
-      "integrity": "sha512-znOHVWRICbLN8U5eU/Pi6V0cWvIwl5sh6cVQWTxy+plXCN+iF7LtmpHcRn3NGPJosGdP+FzgXagCBCtprjc6XA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.0.tgz",
+      "integrity": "sha512-yNgeJ3b4cI3Ywm4sNjAUlLNHToiJFNNRL1Gx+v3OQqjzKb0Oi2QM4N74oz3WL0xzTmJfsKPadBjBqL5dcW0DWw==",
       "requires": {
         "cron": "^1.8.2",
         "scalingo": "^0.1.1"
@@ -1469,9 +1469,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/1024pix/pix-bot.git"
   },
-  "author": "Jérémy Buget",
+  "author": "GIP Pix",
   "license": "AGPL-3.0",
   "bugs": {
     "url": "https://github.com/1024pix/pix-bot/issues"
@@ -31,7 +31,7 @@
     "dotenv": "^8.2.0",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "scalingo-review-app-manager": "^0.3.0",
+    "scalingo-review-app-manager": "^1.0.0",
     "tsscmp": "^1.0.6"
   },
   "engines": {


### PR DESCRIPTION
Cette [nouvelle version](https://github.com/1024pix/scalingo-review-app-manager/releases/tag/v1.0.0) de `scalingo-review-app-manager` corrige des failles et permet de spécifier la time zone des _cron jobs_.