### PR TITLE
[FEATURE] Ajout d'une route pour récupérer les PR ouverte

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Services provided by Pix Bot:
 *1/* Get the sources
 
 ```
-git clone git@github.com:1024pix/pix-botgit && cd pix-bot
+git clone git@github.com:1024pix/pix-bot.git && cd pix-bot
 ```
 
 *2/* Execute the configuration script:

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,10 @@ module.exports = (function() {
     slack: {
       requestSigningSecret: process.env.SLACK_SIGNING_SECRET,
       botToken: process.env.SLACK_BOT_TOKEN,
+    },
+
+    github: {
+      token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
     }
   };
 

--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -1,6 +1,7 @@
 const commands = require('../services/slack/commands');
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
+const github = require('../services/github');
 
 module.exports = {
 
@@ -49,5 +50,10 @@ module.exports = {
         return null;
     }
   },
+
+  async getPullRequests(request, h) {
+    const label = request.payload.text;
+    return github.getPullRequests(label);
+  }
 
 };

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -23,5 +23,11 @@ module.exports = [
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
     config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/pull-requests',
+    handler: slackbotController.getPullRequests,
+    config: slackConfig
   }
 ];

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const _ = require('lodash');
-const githubToken = process.env.GITHUB_PERSONNAL_ACCESS_TOKEN;
+const config = require('../config');
+
 const color = {
     'team-evaluation': '#FDEEC1',
     'team-prescription': '#F2B2A8',
@@ -16,7 +17,8 @@ function getUrlForGithub(label) {
 
 async function getDataFromGithub (label) {
     const url = getUrlForGithub(label);
-    const config ={
+    const githubToken = config.github.token;
+    const config = {
         headers: {
             'Authorization': 'token ' + githubToken
         }

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+const _ = require('lodash');
+const githubToken = process.env.GITHUB_PERSONNAL_ACCESS_TOKEN;
+const color = {
+    'team-evaluation': '#FDEEC1',
+    'team-prescription': '#F2B2A8',
+    'team-captains': '#a6ea5d',
+    'team-certif': '#B7CEF5',
+    'team-acces': '#A2DCC1',
+};
+
+function getUrlForGithub(label) {
+    label = label.replace(/ /g, '%20');
+    return `https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:${label}`;
+}
+
+async function getDataFromGithub (label) {
+    const url = getUrlForGithub(label);
+    const config ={
+        headers: {
+            'Authorization': 'token ' + githubToken
+        }
+    };
+    return axios.get(url, config)
+        .then(response => {
+            return response.data.items;
+        })
+        .catch(error => {
+            console.log(error);
+        });
+}
+
+function createResponseForSlack(pullRequests, label) {
+    const resp = {
+        response_type: 'in_channel',
+        text: 'PRs à review pour '+label,
+        attachments: []
+    };
+    pullRequests.forEach((prs) => {
+        resp.attachments.push({
+            color: color[label],
+            pretext: '',
+            fields: [
+                { value: `<${prs.html_url}|${prs.title}>`, short: false},
+            ],
+        });
+    });
+    return resp;
+}
+
+module.exports = {
+
+    async getPullRequests(label) {
+        const pullRequests = await getDataFromGithub(label);
+        return createResponseForSlack(pullRequests, label)
+    }
+};

--- a/sample.env
+++ b/sample.env
@@ -53,7 +53,7 @@ GITHUB_USERNAME=__CHANGE_ME__
 # presence: required
 # type: String
 # default: none
-GITHUB_PERSONNAL_ACCESS_TOKEN=__CHANGE_ME__
+GITHUB_PERSONAL_ACCESS_TOKEN=__CHANGE_ME__
 
 # Sentry API key used to finalize declared releases
 #

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,7 +16,7 @@ function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
   echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONNAL_ACCESS_TOKEN}@github.com/1024pix/pix.git" "${REPOSITORY_FOLDER}"
+  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/1024pix/pix.git" "${REPOSITORY_FOLDER}"
   echo "Cloned repository to temporary directory"
 
   cd "${REPOSITORY_FOLDER}" || exit 1

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -1,0 +1,45 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+const githubService = require('../../../lib/services/github');
+
+describe('#getPullRequests', function() {
+    const items = [
+        { html_url: 'http://test1.fr', title: 'PR1'},
+        { html_url: 'http://test2.fr', title: 'PR2'},
+    ];
+    before(() => {
+        sinon.stub(axios, 'get').resolves({ data: { items: items } });
+    });
+
+    it('should return the response for slack', async function() {
+        // given
+        const expectedResponse = {
+            response_type: 'in_channel',
+            text: 'PRs à review pour team-certif',
+            attachments: [
+                {color: '#B7CEF5', pretext: '', fields: [{value: '<http://test1.fr|PR1>', short: false}]},
+                {color: '#B7CEF5', pretext: '', fields: [{value: '<http://test2.fr|PR2>', short: false}]}
+            ]
+        };
+
+        // when
+        const response = await githubService.getPullRequests('team-certif');
+
+        // then
+        expect(response).to.deep.equal(expectedResponse);
+    });
+
+    it('should call the Github API with the label without space', async function() {
+        // given
+        const expectedUrl = 'https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:Tech%20Review%20Needed';
+
+        // when
+        const response = await githubService.getPullRequests('Tech Review Needed');
+
+        // then
+        sinon.assert.calledWith(axios.get, expectedUrl);
+    });
+
+});


### PR DESCRIPTION
Ajout d'une route /slack/pull-requests qui retourne la liste des PR ouvertes d'après un label