### PR TITLE
[BUGFIX] Mise en marche de la commande Slack `/pr-pix [team-name]`

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -52,7 +52,7 @@ module.exports = {
   },
 
   async getPullRequests(request, h) {
-    const label = request.payload.text;
+    const label = request.pre.payload.text;
     return github.getPullRequests(label);
   }
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -26,7 +26,7 @@ module.exports = [
   },
   {
     method: 'POST',
-    path: '/slack/pull-requests',
+    path: '/slack/commands/pull-requests',
     handler: slackbotController.getPullRequests,
     config: slackConfig
   }

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const _ = require('lodash');
-const config = require('../config');
+const settings = require('../config');
 
 const color = {
     'team-evaluation': '#FDEEC1',
@@ -17,7 +17,7 @@ function getUrlForGithub(label) {
 
 async function getDataFromGithub (label) {
     const url = getUrlForGithub(label);
-    const githubToken = config.github.token;
+    const githubToken = settings.github.token;
     const config = {
         headers: {
             'Authorization': 'token ' + githubToken


### PR DESCRIPTION
## Analyse

Il y avait 2 problèmes : 

1. collision de 2 variables de type `const` (l'une issue d'un import en en-tête du module, l'autre comme variable locale) au sein d'une méthode d'un méthode qui fait qu'on avait une erreur de type `variable inaccessible avant l'initialisation`

2. Pix Bot implémentant la procédure de vérification du token de l'appelant comme préconisé par la doc de Slack, celle-ci a été mutualisée dans un pre-handler Hapi.js, dont le but est de parser correctement l'éventuel payload de la requête et d'alimenter une variable de pre-handler `request.pre.handler`

> **Note personnelle** : le fait qu'il n'y ait qausiment pas de tests auto et qu'il n'y a pas de CI, ce type de double-bug malgré la revue de code est dommage, mais pas surprenant.

## Remarques

J'ai reproduit, débuggué, testé et fait foncionné chez moi en live et en local grâce à l'application Bot4Dev (espèce de version de staging de Pix Bot) et Ngrok. Je suis serein.

Par ailleurs, j'en ai profité pour renommer la route `/slack/pull-requests` en `/slack/commands/pull-requests` qui est le format sur lequel nous sommes initialement partis (mais qui ne se voit plus depuis qu'on a supprimé les commandes devenues obsolètes)