### PR TITLE
[BUGFIX] L'éco-mode des Review Apps intervient 2h plus tard que l'horaire défini

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -10,9 +10,10 @@ const init = async () => {
   const scalingoApiUrl = process.env.SCALINGO_API_URL;
   const stopCronTime = process.env.STOP_CRON_TIME;
   const restartCronTime = process.env.RESTART_CRON_TIME;
+  const timeZone = process.env.TIME_ZONE || 'Europe/Paris';
   const ignoredReviewApps = process.env.IGNORED_REVIEW_APPS ? process.env.IGNORED_REVIEW_APPS.split(',') : [];
 
-  const reviewAppManager = new ReviewAppManager(scalingoToken, scalingoApiUrl, { stopCronTime, restartCronTime, ignoredReviewApps });
+  const reviewAppManager = new ReviewAppManager(scalingoToken, scalingoApiUrl, { stopCronTime, restartCronTime, timeZone, ignoredReviewApps });
   await reviewAppManager.startEcoMode();
 
   await server.start();


### PR DESCRIPTION
Suite à la montée de version (majeure) de scalingo-review-app-manager, il est désormais possible de définir la zone de temps des jobs cron. Par défaut, il semblerait que les serveurs Outscale soient branchés sur l'heure de Paris + 2h. Afin de déclencher les actions sur les RA au bon moment, il convient de fixer la timezone.