### PR TITLE
[BUGFIX] La procédure de MEP échoue tout à la fin au moment de finaliser la release Sentry associée à la MEP

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,7 +34,7 @@ function update_production_branch {
 }
 
 function finalize_release_on_sentry {
-    npx sentry-cli releases -o pix finalize "${VERSION_ NUMBER}"
+    npx sentry-cli releases -o pix finalize "${VERSION_NUMBER}"
     echo "Finalized release on Sentry"
 }
 


### PR DESCRIPTION
Un espace qui s'est glissé sur une variable 🤦‍♂️