### PR TITLE
[FEATURE] Ajout de l'API pour la commande slack /a11y-tip

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,11 @@ module.exports = (function() {
 
     github: {
       token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+    },
+
+    googleSheet: {
+      key: process.env.GOOGLE_SHEET_API_KEY,
+      idA11Y: process.env.GOOGLE_SHEET_A11Y
     }
   };
 

--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -2,6 +2,7 @@ const commands = require('../services/slack/commands');
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
 const github = require('../services/github');
+const googleSheet = require('../services/google-sheet');
 
 module.exports = {
 
@@ -54,6 +55,10 @@ module.exports = {
   async getPullRequests(request, h) {
     const label = request.pre.payload.text;
     return github.getPullRequests(label);
+  },
+
+  async getAccessibilityTip() {
+    return googleSheet.getA11YTip();
   }
 
 };

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -29,5 +29,11 @@ module.exports = [
     path: '/slack/commands/pull-requests',
     handler: slackbotController.getPullRequests,
     config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/accessibility-tip',
+    handler: slackbotController.getAccessibilityTip,
+    config: slackConfig
   }
 ];

--- a/lib/services/google-sheet.js
+++ b/lib/services/google-sheet.js
@@ -1,19 +1,17 @@
 const axios = require('axios');
 const _ = require('lodash');
 const settings = require('../config');
+const URL_SPREADSHEET_API = 'https://sheets.googleapis.com/v4/spreadsheets/';
+const SPREADSHEET_VALUES = 'tips!A1:E500';
 
 function getGoogleSheetAPIURL() {
-    return `https://sheets.googleapis.com/v4/spreadsheets/${settings.googleSheet.idA11Y}/values/tips!A1:E500?key=${settings.googleSheet.key}`;
+    return `${URL_SPREADSHEET_API}${settings.googleSheet.idA11Y}/values/${SPREADSHEET_VALUES}?key=${settings.googleSheet.key}`;
 }
 async function getDataFromGoogleSheet (label) {
     const url = getGoogleSheetAPIURL();
     return axios.get(url)
-        .then(response => {
-            return response.data.values;
-        })
-        .catch(error => {
-            console.log(error);
-        });
+        .then(response => response.data.values)
+        .catch(error => console.log(error));
 }
 function createResponseForSlack(tip) {
     const resp = {

--- a/lib/services/google-sheet.js
+++ b/lib/services/google-sheet.js
@@ -1,0 +1,72 @@
+const axios = require('axios');
+const _ = require('lodash');
+const settings = require('../config');
+
+function getGoogleSheetAPIURL() {
+    return `https://sheets.googleapis.com/v4/spreadsheets/${settings.googleSheet.idA11Y}/values/tips!A1:E500?key=${settings.googleSheet.key}`;
+}
+async function getDataFromGoogleSheet (label) {
+    const url = getGoogleSheetAPIURL();
+    return axios.get(url)
+        .then(response => {
+            return response.data.values;
+        })
+        .catch(error => {
+            console.log(error);
+        });
+}
+function createResponseForSlack(tip) {
+    const resp = {
+        response_type: 'in_channel',
+        "blocks": [
+            {
+                "type": "divider"
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":a11y: Tip A11Y :a11y:"
+                }
+            },
+            {
+                "type": "divider"
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": `:book: *${tip['Titre'].toUpperCase()}* :book: \n _${tip['Sujet']}_ `
+                }
+            },
+            {
+                "type": "divider"
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": `${tip['Message']} \n :link: : ${tip['Lien']} \n :pix_logo: : ${tip['Tips Pix'] || '-'}`
+                }
+            },
+            {
+                "type": "divider"
+            }
+        ]
+    }
+    return resp;
+}
+
+function getOneRandomTip(tipsFromGoogleSheet) {
+    const titles = tipsFromGoogleSheet.shift();
+    const randomTip = tipsFromGoogleSheet[Math.floor(Math.random() * (tipsFromGoogleSheet.length))];
+    return _.zipObject(titles, randomTip);
+}
+module.exports = {
+
+    async getA11YTip() {
+        const tipsFromGoogleSheet = await getDataFromGoogleSheet();
+        const tip = getOneRandomTip(tipsFromGoogleSheet);
+        return createResponseForSlack(tip);
+    }
+};

--- a/sample.env
+++ b/sample.env
@@ -147,3 +147,25 @@ SLACK_SIGNING_SECRET=__CHANGE_ME__
 # type: String
 # default: none
 SLACK_BOT_TOKEN=__CHANGE_ME__
+
+# Google API Key for Sheet API
+#
+# If not present, Slackbot command /a11y-tip will fail.
+#
+# Cf. https://api.slack.com/apps
+#
+# presence: required
+# type: String
+# default: none
+GOOGLE_SHEET_API_KEY=__CHANGE_ME__
+
+# Google Sheet for A11Y
+#
+# If not present, Slackbot command /a11y-tip will fail.
+#
+# Cf. https://api.slack.com/apps
+#
+# presence: required
+# type: String
+# default: none
+GOOGLE_SHEET_A11Y=__CHANGE_ME__

--- a/sample.env
+++ b/sample.env
@@ -124,13 +124,12 @@ AUTHORIZATION_TOKEN=lorem-ipsum
 
 # =================
 # SLACK INTEGRATION
-# =================
-
-# Slack "Pix Bot" application request signing secret.
-#
 # If not present, Slack features & interactions will fail.
 #
 # Cf. https://api.slack.com/apps
+# =================
+
+# Slack "Pix Bot" application request signing secret.
 #
 # presence: required
 # type: String
@@ -139,10 +138,6 @@ SLACK_SIGNING_SECRET=__CHANGE_ME__
 
 # Slack "Pix Bot" bot token.
 #
-# If not present, Slackbot features (actions & interactives) will fail.
-#
-# Cf. https://api.slack.com/apps
-#
 # presence: required
 # type: String
 # default: none
@@ -150,20 +145,12 @@ SLACK_BOT_TOKEN=__CHANGE_ME__
 
 # Google API Key for Sheet API
 #
-# If not present, Slackbot command /a11y-tip will fail.
-#
-# Cf. https://api.slack.com/apps
-#
 # presence: required
 # type: String
 # default: none
 GOOGLE_SHEET_API_KEY=__CHANGE_ME__
 
 # Google Sheet for A11Y
-#
-# If not present, Slackbot command /a11y-tip will fail.
-#
-# Cf. https://api.slack.com/apps
 #
 # presence: required
 # type: String

--- a/test/unit/services/google-sheet_test.js
+++ b/test/unit/services/google-sheet_test.js
@@ -1,0 +1,80 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+const googleSheet = require('../../../lib/services/google-sheet');
+
+describe('#getA11YTip', function() {
+    const data =
+        {
+            "range": "tips!A1:E500",
+            "majorDimension": "ROWS",
+            "values": [
+                [
+                    "Titre",
+                    "Sujet",
+                    "Message",
+                    "Lien",
+                    "Tips Pix"
+                ],
+                [
+                    "Traduire aussi le contenu masqué",
+                    "Les langues",
+                    "Il faut aussi penser à traduire : les attributs `alt`, les `aria-label`, les `title`, les `title` et `desc` des svg, etc.",
+                    "https://www.accede-web.com/notices/html-css-javascript/3-langues/3-3-veiller-a-traduire-les-contenus-masques/"
+                ]
+            ]
+        }
+    ;
+    before(() => {
+        sinon.stub(axios, 'get').resolves({ data });
+    });
+
+    it('should return the response for slack', async function() {
+        // given
+        const expectedResponse = {
+            response_type: 'in_channel',
+            "blocks": [
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": ":a11y: Tip A11Y :a11y:"
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": `:book: *${data.values[1][0].toUpperCase()}* :book: \n _${data.values[1][1]}_ `
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": `${data.values[1][2]} \n :link: : ${data.values[1][3]} \n :pix_logo: : -`
+                    }
+                },
+                {
+                    "type": "divider"
+                }
+            ]
+        };
+        // when
+        const response = await googleSheet.getA11YTip('team-certif');
+
+        // then
+        expect(response).to.deep.equal(expectedResponse);
+    });
+
+});


### PR DESCRIPTION
💡 Objectif 💡
- Pouvoir avoir un tip sur l'a11y via une commande slack

🚗 Fonctionnement 🚗 
- Ajout d'une route API  /slack/commands/accessibility-tip
- Connexion simple à un Google Sheet avec les tips : https://docs.google.com/spreadsheets/d/1rZoiXlbBeVMEDuirn6V-SLtgD8rYqlc5Sfr0m7AKJeU/edit#gid=0
- Choix aléatoire d'un tip
- Création du message au format slack