### PR TITLE
[FEATURE] Vérifier l'état de la CI lors des publications et déploiements d'une release.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -30,11 +30,18 @@ module.exports = (function() {
     googleSheet: {
       key: process.env.GOOGLE_SHEET_API_KEY,
       idA11Y: process.env.GOOGLE_SHEET_A11Y
+    },
+
+    circleCi: {
+      authorizationToken: process.env.CIRCLE_CI_TOKEN,
+      baseUrl: 'https://circleci.com/api/v2',
+      projectSlug: 'gh%2F1024pix%2Fpix'
     }
   };
 
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
+    config.circleCi.authorizationToken = 'Circle CI dummy token';
   }
 
   return config;

--- a/lib/services/circle-ci.js
+++ b/lib/services/circle-ci.js
@@ -1,0 +1,28 @@
+const axios = require('axios');
+const { circleCi } = require('../config');
+
+const headers = {
+  Accept: 'application/json',
+  'Circle-Token': circleCi.authorizationToken
+};
+
+async function _getDevPipelineId() {
+  const { data } = await axios.get(`${circleCi.baseUrl}/project/${circleCi.projectSlug}/pipeline`, {
+    params: { branch: 'dev' },
+    headers
+  });
+  return data.items[0].id;
+}
+
+async function _getPipelineWorkflowStatus(pipelineId) {
+  const { data } = await axios.get(`${circleCi.baseUrl}/pipeline/${pipelineId}/workflow`, { headers });
+  return data.items[0].status;
+}
+
+module.exports = {
+  async isDevGreen() {
+    const pipelineId = await _getDevPipelineId();
+    const workflowStatus = await _getPipelineWorkflowStatus(pipelineId);
+    return workflowStatus === 'success';
+  }
+};

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -28,8 +28,12 @@ module.exports = {
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
-    // TODO: Check CI status before deployment
-    deploy(releaseTag);
+    if (!circleCiService.isDevGreen()) {
+      // TODO: Add a slack message or maybe we can use the return message to inform user about failing CI.
+      console.err('Failed to deploy: `dev` branch status is not success on CircleCI.');
+    } else {
+      deploy(releaseTag);
+    }
     return {
       "response_action": "clear"
     };

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -28,6 +28,7 @@ module.exports = {
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
+    // TODO: Check CI status before deployment
     deploy(releaseTag);
     return {
       "response_action": "clear"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -135,6 +135,7 @@ update_all_pix_modules_version
 complete_change_log
 create_a_release_commit
 push_commit_to_remote_dev
+# TODO: Wait CI status here
 echo "== Publish release =="
 checkout_master
 fetch_and_rebase

--- a/test/unit/services/circle-ci_test.js
+++ b/test/unit/services/circle-ci_test.js
@@ -17,7 +17,7 @@ describe('#isDevGreen', function() {
   });
 
   afterEach(() => {
-    sinon.restore();
+    axiosGetStub.restore();
   });
 
   it('should call Circle CI to get latest dev pipeline ID', async function() {

--- a/test/unit/services/circle-ci_test.js
+++ b/test/unit/services/circle-ci_test.js
@@ -1,0 +1,73 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+const circleCiService = require('../../../lib/services/circle-ci');
+
+describe('#isDevGreen', function() {
+  let axiosGetStub;
+  const successWorkflowItem = { status: 'success' };
+  const failWorkflowItem = { status: 'fail' };
+
+  beforeEach(() => {
+    const pipelineItem = { id: 'pipeline_id' };
+    axiosGetStub = sinon.stub(axios, 'get');
+    axiosGetStub.onFirstCall().resolves({ data: { items: [pipelineItem] } });
+    axiosGetStub.onSecondCall().resolves({ data: { items: [successWorkflowItem]}});
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should call Circle CI to get latest dev pipeline ID', async function() {
+    // when
+    await circleCiService.isDevGreen();
+
+    // then
+    sinon.assert.calledWith(axios.get, 'https://circleci.com/api/v2/project/gh%2F1024pix%2Fpix/pipeline', {
+      params: { branch: 'dev' },
+      headers: {
+        Accept: 'application/json',
+        'Circle-Token': 'Circle CI dummy token'
+      }
+    })
+  });
+
+  it('should call Circle CI to get latest pipeline workflow status', async function() {
+    // when
+    await circleCiService.isDevGreen();
+
+    // then
+    sinon.assert.calledWith(axios.get, 'https://circleci.com/api/v2/pipeline/pipeline_id/workflow', {
+      headers: {
+        Accept: 'application/json',
+        'Circle-Token': 'Circle CI dummy token'
+      }
+    });
+  });
+
+  it('should return true when latest pipeline workflow status is `success`', async function() {
+    // given
+    axiosGetStub.onSecondCall().resolves({ data: { items: [successWorkflowItem] } });
+
+    // when
+    const isDevGreen = await circleCiService.isDevGreen();
+
+    // then
+    expect(isDevGreen).to.eql(true);
+  });
+
+  it('should return false when latest pipeline workflow status is `fail`', async function() {
+    // given
+    axiosGetStub.onSecondCall().resolves({ data: { items: [failWorkflowItem] } });
+
+    // when
+    const isDevGreen = await circleCiService.isDevGreen();
+
+    // then
+    expect(isDevGreen).to.eql(false);
+  });
+
+});
+

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -5,12 +5,17 @@ const axios = require('axios');
 const githubService = require('../../../lib/services/github');
 
 describe('#getPullRequests', function() {
+    let axiosGetStub;
     const items = [
         { html_url: 'http://test1.fr', title: 'PR1'},
         { html_url: 'http://test2.fr', title: 'PR2'},
     ];
     before(() => {
-        sinon.stub(axios, 'get').resolves({ data: { items: items } });
+        axiosGetStub = sinon.stub(axios, 'get');
+        axiosGetStub.resolves({ data: { items: items } });
+    });
+    after(() => {
+        axiosGetStub.restore();
     });
 
     it('should return the response for slack', async function() {

--- a/test/unit/services/google-sheet_test.js
+++ b/test/unit/services/google-sheet_test.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const googleSheet = require('../../../lib/services/google-sheet');
 
 describe('#getA11YTip', function() {
+    let axiosGetStub;
     const data =
         {
             "range": "tips!A1:E500",
@@ -27,7 +28,12 @@ describe('#getA11YTip', function() {
         }
     ;
     before(() => {
-        sinon.stub(axios, 'get').resolves({ data });
+        axiosGetStub = sinon.stub(axios, 'get');
+        axiosGetStub.resolves({ data });
+    });
+
+    after(() => {
+        axiosGetStub.restore();
     });
 
     it('should return the response for slack', async function() {


### PR DESCRIPTION
## :unicorn: Problème
La CI est lancée à chaque commit sur `dev`.
Actuellement, si le workflow déclenché par ce commit échoue, nous n'avons aucun retour lors de la mise en production, bien que celle-ci soit bloquée.
Lors de la création / publication de la release, nous ne faisons aucune vérification de l'état du workflow. Ainsi, il est possible d'indiquer que la release se soit correctement déroulée alors que la CI soit en échec.

## :robot: Solution
GitHub offre une API permettant de récupérer l'état des vérifications (checks) d'un tag.
On utilise l'API pour :

-  vérifier l'état de la CI **avant** le déploiement d'une release sur Production
-  attendre la CI **après** création de la release (mais **avant** son déploiement sur Recette)

Un message d'erreur sur Slack est posté en cas d'échec de la CI liée à la création / déploiement d'une release.

## :rainbow: Remarques
Le script de publication de la release contient à la fois la création **et** le déploiement.
On coupe le script en deux afin d'ajouter la vérification de la CI entre les 2 étapes.

## :100: Pour tester
A définir
