### PR TITLE
[Cleanup] Séparer les tâches de publication et de déploiement d'une release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ npm start
 
 *5/* Develop and add wonderful features!
 
+*6/* Testing `publish` and `deploy` scripts
+You can specify the repository you want to use for `publish` and `deploy` on any GitHub repository.
+
+Prerequisites: The repository shall contain `dev`, `master` and `publish` branches.
+
+Command to run the `publish` script:
+```sh
+GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# REPOSITORY_NAME=#organization_name/repository_name# scripts/publish.sh (path|minor|major)
+```
+
+Command to run the `deploy` script:
+```sh
+GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# REPOSITORY_NAME=#organization_name/repository_name# NEW_PACKAGE_VERSION=#version_to_deploy# scripts/deploy.sh (recette|production)
+```
 ## License
 
 Copyright (c) 2020 GIP PIX.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Prerequisites: The repository shall contain `dev`, `master` and `publish` branch
 
 Command to run the `publish` script:
 ```sh
-GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# REPOSITORY_NAME=#organization_name/repository_name# scripts/publish.sh (path|minor|major)
+GITHUB_OWNER=#github_owner# GITHUB_REPOSITORY=#github_repository# GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# scripts/publish.sh (path|minor|major)
 ```
 
 Command to run the `deploy` script:
 ```sh
-GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# REPOSITORY_NAME=#organization_name/repository_name# NEW_PACKAGE_VERSION=#version_to_deploy# scripts/deploy.sh (recette|production)
+GITHUB_OWNER=#github_owner# GITHUB_REPOSITORY=#github_repository# GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# NEW_PACKAGE_VERSION=#version_to_deploy# scripts/deploy.sh (recette|production)
 ```
 ## License
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,17 +24,24 @@ module.exports = (function() {
     },
 
     github: {
-      token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+      token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
+      owner: process.env.GITHUB_OWNER,
+      repository: process.env.GITHUB_REPOSITORY,
     },
 
     googleSheet: {
       key: process.env.GOOGLE_SHEET_API_KEY,
       idA11Y: process.env.GOOGLE_SHEET_A11Y
-    }
+    },
+
   };
 
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
+
+    config.github.token = 'github-personal-access-token';
+    config.github.owner = 'github-owner';
+    config.github.repository = 'github-repository';
   }
 
   return config;

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -1,59 +1,69 @@
+const { Octokit } = require("@octokit/core");
 const axios = require('axios');
 const _ = require('lodash');
 const settings = require('../config');
 
 const color = {
-    'team-evaluation': '#FDEEC1',
-    'team-prescription': '#F2B2A8',
-    'team-captains': '#a6ea5d',
-    'team-certif': '#B7CEF5',
-    'team-acces': '#A2DCC1',
+  'team-evaluation': '#FDEEC1',
+  'team-prescription': '#F2B2A8',
+  'team-captains': '#a6ea5d',
+  'team-certif': '#B7CEF5',
+  'team-acces': '#A2DCC1',
 };
 
 function getUrlForGithub(label) {
-    label = label.replace(/ /g, '%20');
-    return `https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:${label}`;
+  label = label.replace(/ /g, '%20');
+  return `https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:${label}`;
 }
 
-async function getDataFromGithub (label) {
-    const url = getUrlForGithub(label);
-    const githubToken = settings.github.token;
-    const config = {
-        headers: {
-            'Authorization': 'token ' + githubToken
-        }
-    };
-    return axios.get(url, config)
-        .then(response => {
-            return response.data.items;
-        })
-        .catch(error => {
-            console.log(error);
-        });
+async function getDataFromGithub(label) {
+  const url = getUrlForGithub(label);
+  const githubToken = settings.github.token;
+  const config = {
+    headers: {
+      'Authorization': 'token ' + githubToken
+    }
+  };
+  return axios.get(url, config)
+    .then(response => {
+      return response.data.items;
+    })
+    .catch(error => {
+      console.log(error);
+    });
 }
 
 function createResponseForSlack(pullRequests, label) {
-    const resp = {
-        response_type: 'in_channel',
-        text: 'PRs à review pour '+label,
-        attachments: []
-    };
-    pullRequests.forEach((prs) => {
-        resp.attachments.push({
-            color: color[label],
-            pretext: '',
-            fields: [
-                { value: `<${prs.html_url}|${prs.title}>`, short: false},
-            ],
-        });
+  const resp = {
+    response_type: 'in_channel',
+    text: 'PRs à review pour ' + label,
+    attachments: []
+  };
+  pullRequests.forEach((prs) => {
+    resp.attachments.push({
+      color: color[label],
+      pretext: '',
+      fields: [
+        { value: `<${prs.html_url}|${prs.title}>`, short: false },
+      ],
     });
-    return resp;
+  });
+  return resp;
 }
 
 module.exports = {
 
-    async getPullRequests(label) {
-        const pullRequests = await getDataFromGithub(label);
-        return createResponseForSlack(pullRequests, label)
-    }
+  async getPullRequests(label) {
+    const pullRequests = await getDataFromGithub(label);
+    return createResponseForSlack(pullRequests, label)
+  },
+
+  async getLatestReleaseTag() {
+    const octokit = new Octokit({ auth: settings.github.token });
+    const latestReleases = await octokit.request('/repos/{owner}/{repo}/tags', {
+      owner: settings.github.owner,
+      repo: settings.github.repository,
+    });
+    return latestReleases.data[0].name;
+  },
 };

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -16,11 +16,12 @@ module.exports = {
     }
   },
 
-   async deploy(releaseTag) {
+   async deploy(environment, releaseTag) {
     const scriptFileName = `deploy.sh`;
     try {
+      const sanitizedEnvironment = _sanitizedArgument(environment);
       const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
-      await _runScriptWithArgument(scriptFileName, sanitizedReleaseTag);
+      await _runScriptWithArgument(scriptFileName, sanitizedEnvironment, sanitizedReleaseTag);
     } catch (err) {
       console.error(err);
     }
@@ -63,6 +64,6 @@ async function _runScriptWithArgument (scriptFileName, ...arguments) {
   console.log(`stdout: ${stdout}`);
   console.error(`stderr: ${stderr}`);
 }
-function _sanitizedArgument(releaseTag) {
-  return releaseTag? releaseTag.trim().toLowerCase(): null;
+function _sanitizedArgument(param) {
+  return param? param.trim().toLowerCase(): null;
 }

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -6,6 +6,11 @@ const RELEASE_PIX_SCRIPT = `release-pix-repo.sh`;
 
 module.exports = {
 
+  environments: {
+    recette: 'recette',
+    production: 'production'
+  },
+
   async publish(releaseType) {
     const scriptFileName = `publish.sh`;
     try {
@@ -30,7 +35,7 @@ module.exports = {
   async releaseAndDeployPixSite(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);
-      const arguments = ['pix-site', releaseType];
+      const arguments = ['1024pix', 'pix-site', releaseType];
       await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...arguments);
     } catch (err) {
       console.error(err);
@@ -40,7 +45,7 @@ module.exports = {
   async releaseAndDeployPixPro(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);
-      const arguments = ['pix-pro', releaseType];
+      const arguments = ['1024pix', 'pix-pro', releaseType];
       await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...arguments);
     } catch (err) {
       console.error(err);
@@ -50,7 +55,7 @@ module.exports = {
   async releaseAndDeployPixBotTest(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);
-      const arguments = ['pix-bot-release-test', releaseType];
+      const arguments = ['1024pix', 'pix-bot-release-test', releaseType];
       await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...arguments);
     } catch (err) {
       console.error(err);

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -1,10 +1,17 @@
+const { Octokit } = require("@octokit/core");
 const openModalReleasePublicationConfirmation = require('./surfaces/modals/publish-release/release-publication-confirmation');
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
 const { deploy, publish } = require('../releases');
+const settings = require('../../config');
 
 async function _publishAndDeploy({ releaseType, environment }) {
   await publish(releaseType);
-  return deploy(environment, null);
+  const octokit = new Octokit({ auth: settings.github.token });
+  const latestReleaseTag = (await octokit.request('/repos/{owner}/{repo}/tags', {
+    owner: 'jbuget',
+    repo: 'pix'
+  })).data[0].name;
+  return deploy(environment, latestReleaseTag);
 }
 
 module.exports = {

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -2,9 +2,9 @@ const openModalReleasePublicationConfirmation = require('./surfaces/modals/publi
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
 const { deploy, publish } = require('../releases');
 
-async function _publishAndDeploy({ releaseTag, environment }) {
-  await publish(releaseTag);
-  return deploy(environment);
+async function _publishAndDeploy({ releaseType, environment }) {
+  await publish(releaseType);
+  return deploy(environment, null);
 }
 
 module.exports = {

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -2,6 +2,11 @@ const openModalReleasePublicationConfirmation = require('./surfaces/modals/publi
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
 const { deploy, publish } = require('../releases');
 
+async function _publishAndDeploy({ releaseTag, environment }) {
+  await publish(releaseTag);
+  return deploy(environment);
+}
+
 module.exports = {
 
   // Release publication
@@ -13,8 +18,7 @@ module.exports = {
 
   submitReleasePublicationConfirmation(payload) {
     const releaseType = payload.view.private_metadata;
-    publish(releaseType);
-    deploy('recette');
+    _publishAndDeploy({ releaseType, environment: 'recette' });
     return {
       "response_action": "clear"
     };

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -14,6 +14,7 @@ module.exports = {
   submitReleasePublicationConfirmation(payload) {
     const releaseType = payload.view.private_metadata;
     publish(releaseType);
+    deploy('recette');
     return {
       "response_action": "clear"
     };
@@ -28,7 +29,7 @@ module.exports = {
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
-    deploy(releaseTag);
+    deploy('production', releaseTag);
     return {
       "response_action": "clear"
     };

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -1,18 +1,7 @@
-const { Octokit } = require("@octokit/core");
 const openModalReleasePublicationConfirmation = require('./surfaces/modals/publish-release/release-publication-confirmation');
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
-const { deploy, publish } = require('../releases');
-const settings = require('../../config');
-
-async function _publishAndDeploy({ releaseType, environment }) {
-  await publish(releaseType);
-  const octokit = new Octokit({ auth: settings.github.token });
-  const latestReleaseTag = (await octokit.request('/repos/{owner}/{repo}/tags', {
-    owner: 'jbuget',
-    repo: 'pix'
-  })).data[0].name;
-  return deploy(environment, latestReleaseTag);
-}
+const { environments, deploy, publish } = require('../releases');
+const githubService = require('../github');
 
 module.exports = {
 
@@ -25,7 +14,14 @@ module.exports = {
 
   submitReleasePublicationConfirmation(payload) {
     const releaseType = payload.view.private_metadata;
-    _publishAndDeploy({ releaseType, environment: 'recette' });
+
+    async function _publishAndDeploy({ releaseType, environment }) {
+      await publish(releaseType);
+      const latestReleaseTag = await githubService.getLatestReleaseTag();
+      return deploy(environment, latestReleaseTag);
+    }
+
+    _publishAndDeploy({ releaseType, environment: environments.recette });
     return {
       "response_action": "clear"
     };
@@ -40,7 +36,7 @@ module.exports = {
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
-    deploy('production', releaseTag);
+    deploy(environments.production, releaseTag);
     return {
       "response_action": "clear"
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,6 +300,80 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-yPyQSmxIXLieEIRikk2w8AEtWkFdfG/LXcw1KvEtK3iP0ENZLW/WYQmdzOKqfSaLhooz4CJ9D+WY79C8ZliACw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
+      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
+      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
+      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sentry/cli": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.52.0.tgz",
@@ -357,6 +431,11 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "14.0.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.20.tgz",
+      "integrity": "sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A=="
     },
     "agent-base": {
       "version": "5.1.1",
@@ -422,6 +501,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -586,6 +670,18 @@
         "moment-timezone": "^0.5.x"
       }
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
     "crypto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
@@ -623,6 +719,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -639,6 +740,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "es-abstract": {
       "version": "1.17.5",
@@ -681,6 +790,20 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "fill-keys": {
       "version": "1.0.2",
@@ -761,6 +884,14 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.3",
@@ -917,6 +1048,11 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
+    "is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -925,6 +1061,11 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -944,8 +1085,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -997,6 +1137,11 @@
       "requires": {
         "chalk": "^2.4.2"
       }
+    },
+    "macos-release": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.0.tgz",
+      "integrity": "sha512-ko6deozZYiAkqa/0gmcsz+p4jSy3gY7/ZsCEokPaYd8k+6/aXGkiTgr61+Owup7Sf+xjqW8u2ElhoM9SEcEfuA=="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1109,6 +1254,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
     "nise": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
@@ -1142,6 +1292,14 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1181,10 +1339,23 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.2.2",
@@ -1221,6 +1392,11 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1266,6 +1442,15 @@
         "fill-keys": "^1.0.2",
         "module-not-found-error": "^1.0.1",
         "resolve": "^1.11.1"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "readdirp": {
@@ -1319,14 +1504,31 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
       "version": "9.0.1",
@@ -1411,6 +1613,11 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1446,11 +1653,18 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "universal-user-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -1468,6 +1682,14 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "windows-release": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
+      "requires": {
+        "execa": "^1.0.0"
       }
     },
     "wrap-ansi": {
@@ -1512,8 +1734,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "7.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,6 +1102,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "just-extend": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
@@ -1127,6 +1133,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "log-symbols": {
@@ -1270,6 +1282,35 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "nock": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.2.tgz",
+      "integrity": "sha512-Wm8H22iT3UKPDf138tmgJ0NRfCLd9f2LByki9T2mGHnB66pEqvJh3gV/up1ZufZF24n7/pDYyLGybdqOzF3JIw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "node-environment-flags": {
@@ -1428,6 +1469,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/1024pix/pix-bot#readme",
   "dependencies": {
     "@hapi/hapi": "^19.1.1",
+    "@octokit/core": "^3.1.0",
     "@sentry/cli": "^1.52.0",
     "axios": "^0.19.2",
     "crypto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
+    "nock": "^13.0.2",
     "sinon": "^9.0.1"
   }
 }

--- a/sample.env
+++ b/sample.env
@@ -8,6 +8,7 @@
 #
 # Sections (displayed in sorted in alphabtic order):
 #   - Release management
+#   - Deployment management
 #   - Review apps management
 #   - Security
 #   - Slack integration
@@ -55,14 +56,27 @@ GITHUB_USERNAME=__CHANGE_ME__
 # default: none
 GITHUB_PERSONAL_ACCESS_TOKEN=__CHANGE_ME__
 
-# Sentry API key used to finalize declared releases
+# =====================
+# DEPLOYMENT MANAGEMENT
+# =====================
+
+# GitHub organization's name (ex: 1024pix)
 #
-# If not present, the end of the release process will fail.
+# If not present, Pix applications (Admin, API, App, Certif, Orga) could not be deployed
 #
 # presence: required
 # type: String
 # default: none
-SENTRY_AUTH_TOKEN=__CHANGE_ME__
+GITHUB_OWNER=__CHANGE_ME__
+
+# GitHub mono-repository's name (ex: pix)
+#
+# If not present, Pix applications (Admin, API, App, Certif, Orga) could not be deployed
+#
+# presence: required
+# type: String
+# default: none
+GITHUB_REPOSITORY=__CHANGE_ME__
 
 # ======================
 # REVIEW APPS MANAGEMENT

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -29,3 +29,7 @@ function configure_git_user_information {
   echo "Set Git user information"
 }
 
+function get_package_version() {
+  node -p -e "require('./package.json').version"
+}
+

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,7 +16,7 @@ function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
   echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/1024pix/${REPOSITORY_NAME}.git" "${REPOSITORY_FOLDER}"
+  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${REPOSITORY_NAME}.git" "${REPOSITORY_FOLDER}"
   echo "Cloned repository ${REPOSITORY_NAME} to temporary directory"
 
   cd "${REPOSITORY_FOLDER}" || exit 1

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,8 +16,8 @@ function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
   echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${REPOSITORY_NAME}.git" "${REPOSITORY_FOLDER}"
-  echo "Cloned repository ${REPOSITORY_NAME} to temporary directory"
+  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}.git" "${REPOSITORY_FOLDER}"
+  echo "Cloned repository ${GITHUB_OWNER}/${GITHUB_REPOSITORY} to temporary directory"
 
   cd "${REPOSITORY_FOLDER}" || exit 1
   echo "Moved to repository folder"
@@ -32,4 +32,3 @@ function configure_git_user_information {
 function get_package_version() {
   node -p -e "require('./package.json').version"
 }
-

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euxo pipefail
-REPOSITORY_NAME=pix
+REPOSITORY_NAME=1024pix/pix
 
 source "$(dirname $0)"/common.sh
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,8 +5,8 @@ REPOSITORY_NAME=1024pix/pix
 
 source "$(dirname $0)"/common.sh
 
-RELEASE_TAG=$1
-ENVIRONMENT=$2
+ENVIRONMENT=$1
+RELEASE_TAG=${2:-$NEW_PACKAGE_VERSION}
 
 echo "Version number ${RELEASE_TAG}"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euxo pipefail
-REPOSITORY_NAME=1024pix/pix
+REPOSITORY_NAME=${REPOSITORY_NAME:-1024/pix}
 
 source "$(dirname $0)"/common.sh
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,45 +6,58 @@ REPOSITORY_NAME=1024pix/pix
 source "$(dirname $0)"/common.sh
 
 RELEASE_TAG=$1
+ENVIRONMENT=$2
 
 echo "Version number ${RELEASE_TAG}"
 
+function get_target_branch_name {
+  case ${ENVIRONMENT} in
+    recette)
+      TARGET_BRANCH=master
+      ;;
+    production)
+      TARGET_BRANCH=prod
+      ;;
+    *)
+      echo -e "${RED} Environment shall be 'recette' or 'production'${RESET_COLOR}\n" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "Get remote branch name: ${TARGET_BRANCH}"
+}
+
 function get_release_commit_hash {
-    local commit_hash
+  local commit_hash
 
-    commit_hash="$(git rev-parse --verify --quiet "${RELEASE_TAG}")"
+  commit_hash="$(git rev-parse --verify --quiet "${RELEASE_TAG}")"
 
-    if [ -z "${commit_hash}" ];
-    then
-        echo -e "${RED}Version ${RELEASE_TAG} does not exist!${RESET_COLOR}\n" >&2
-        exit 1
-    fi
+  if [ -z "${commit_hash}" ];
+  then
+      echo -e "${RED}Version ${RELEASE_TAG} does not exist!${RESET_COLOR}\n" >&2
+      exit 1
+  fi
 
-    echo "Fetched release commit hash"
+  echo "Fetched release commit hash"
 }
 
-function update_production_branch {
-    local annotated_version
-    local annotated_tag_hash
+function update_remote_branch {
+  local annotated_version
+  local annotated_tag_hash
 
-    annotated_version="${RELEASE_TAG}^{}"
-    annotated_tag_hash="$(git rev-parse --quiet "${annotated_version}")"
-    git push -f origin "$annotated_tag_hash":prod
+  annotated_version="${RELEASE_TAG}^{}"
+  annotated_tag_hash="$(git rev-parse --quiet "${annotated_version}")"
+  git push -f origin "$annotated_tag_hash":${TARGET_BRANCH}
 
-    echo "Pushed changes on branch origin/prod"
+  echo "Pushed release to branch origin/${TARGET_BRANCH}"
 }
 
-function finalize_release_on_sentry {
-    npx sentry-cli releases -o pix finalize "${RELEASE_TAG}"
-    echo "Finalized release on Sentry"
-}
+echo "Start deploying version ${RELEASE_TAG} to ${ENVIRONMENT}…"
 
-echo "Start deploying version ${RELEASE_TAG}…"
-
+get_target_branch_name
 clone_repository_and_move_inside
 configure_git_user_information
 get_release_commit_hash
-update_production_branch
-finalize_release_on_sentry
+update_remote_branch
 
 echo -e "Release deployment ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 set -euxo pipefail
-REPOSITORY_NAME=${REPOSITORY_NAME:-1024/pix}
+GITHUB_OWNER=${GITHUB_OWNER:-1024pix}
+GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-pix}
 
 source "$(dirname $0)"/common.sh
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,8 +5,10 @@ REPOSITORY_NAME=${REPOSITORY_NAME:-1024/pix}
 
 source "$(dirname $0)"/common.sh
 
+LAST_RELEASE_TAG="v$(get_package_version)"
+
 ENVIRONMENT=$1
-RELEASE_TAG=${2:-$NEW_PACKAGE_VERSION}
+RELEASE_TAG=${2:-$LAST_RELEASE_TAG}
 
 echo "Version number ${RELEASE_TAG}"
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,8 +3,7 @@
 set -euxo pipefail
 
 CWD_DIR=$(pwd)
-REPOSITORY_NAME=1024pix/pix
-
+REPOSITORY_NAME=${REPOSITORY_NAME:-1024/pix}
 echo "${CWD_DIR}"
 
 source "${CWD_DIR}/scripts/common.sh"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -102,6 +102,7 @@ function tag_release_commit() {
 function publish_release_on_sentry() {
   npx sentry-cli releases -o pix new -p pix-api "v${NEW_PACKAGE_VERSION}"
   npx sentry-cli releases -o pix set-commits --commit "${REPOSITORY_NAME}@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
+  npx sentry-cli releases -o pix finalize "${RELEASE_TAG}"
 
   echo "Published release on Sentry"
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -117,6 +117,6 @@ complete_change_log
 create_a_release_commit
 tag_release_commit
 push_commit_and_tag_to_remote_dev
-publish_release_on_sentry
+#publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,10 +10,6 @@ source "${CWD_DIR}/scripts/common.sh"
 
 NEW_VERSION_TYPE=$1
 
-function get_package_version() {
-  node -p -e "require('./package.json').version"
-}
-
 function ensure_no_uncommited_changes_are_present() {
   if [ -n "$(git status --porcelain)" ]; then
     echo -e "${RED}You have uncommitted changes!${RESET_COLOR} Please commit or stash your changes first.\n"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,8 @@
 set -euxo pipefail
 
 CWD_DIR=$(pwd)
-REPOSITORY_NAME=${REPOSITORY_NAME:-1024/pix}
+GITHUB_OWNER=${GITHUB_OWNER:-1024pix}
+GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-pix}
 echo "${CWD_DIR}"
 
 source "${CWD_DIR}/scripts/common.sh"
@@ -96,7 +97,7 @@ function tag_release_commit() {
 
 function publish_release_on_sentry() {
   npx sentry-cli releases -o pix new -p pix-api "v${NEW_PACKAGE_VERSION}"
-  npx sentry-cli releases -o pix set-commits --commit "${REPOSITORY_NAME}@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
+  npx sentry-cli releases -o pix set-commits --commit "${GITHUB_OWNER}/${GITHUB_REPOSITORY}@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
   npx sentry-cli releases -o pix finalize "${RELEASE_TAG}"
 
   echo "Published release on Sentry"
@@ -117,6 +118,6 @@ complete_change_log
 create_a_release_commit
 tag_release_commit
 push_commit_and_tag_to_remote_dev
-#publish_release_on_sentry
+publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -87,30 +87,16 @@ function create_a_release_commit() {
   echo "Created the release commit"
 }
 
-function push_commit_to_remote_dev() {
+function push_commit_and_tag_to_remote_dev() {
   git push origin dev
+  git push origin "v${NEW_PACKAGE_VERSION}"
 
   echo "Pushed release commit on branch origin/dev"
 }
 
-function checkout_master() {
-  git checkout master >>/dev/null 2>&1
-
-  echo "Checked out branch master"
-}
-
-function create_a_merge_commit_of_dev_into_master_and_tag_it() {
-  git merge dev --no-edit
+function tag_release_commit() {
   git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
-
-  echo "Merged changes from dev into master and created annotated tag"
-}
-
-function push_commit_and_tag_to_remote_master() {
-  git push origin master
-  git push origin "v${NEW_PACKAGE_VERSION}"
-
-  echo "Pushed changes on branch origin/master with tag"
+  echo "Created annotated tag"
 }
 
 function publish_release_on_sentry() {
@@ -124,7 +110,6 @@ echo -e "Preparing a new release.\n"
 
 echo "== Clone and move into Pix repository =="
 clone_repository_and_move_inside
-configure_git_user_information
 echo "== Validate context =="
 ensure_no_uncommited_changes_are_present
 ensure_new_version_is_either_minor_or_patch_or_major
@@ -134,12 +119,8 @@ fetch_and_rebase
 update_all_pix_modules_version
 complete_change_log
 create_a_release_commit
-push_commit_to_remote_dev
-echo "== Publish release =="
-checkout_master
-fetch_and_rebase
-create_a_merge_commit_of_dev_into_master_and_tag_it
-push_commit_and_tag_to_remote_master
+tag_release_commit
+push_commit_and_tag_to_remote_dev
 publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 CWD_DIR=$(pwd)
-REPOSITORY_NAME=pix
+REPOSITORY_NAME=1024pix/pix
 
 echo "${CWD_DIR}"
 
@@ -115,7 +115,7 @@ function push_commit_and_tag_to_remote_master() {
 
 function publish_release_on_sentry() {
   npx sentry-cli releases -o pix new -p pix-api "v${NEW_PACKAGE_VERSION}"
-  npx sentry-cli releases -o pix set-commits --commit "1024pix/pix@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
+  npx sentry-cli releases -o pix set-commits --commit "${REPOSITORY_NAME}@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
 
   echo "Published release on Sentry"
 }

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -4,10 +4,11 @@ set -euxo pipefail
 
 source "$(dirname $0)"/common.sh
 
-REPOSITORY_NAME=(${1})
-VERSION_TYPE=(${2-""})
+GITHUB_OWNER=(${1})
+GITHUB_REPOSITORY=(${2})
+VERSION_TYPE=(${3-""})
 
-echo "Version type ${VERSION_TYPE} for ${REPOSITORY_NAME}"
+echo "Version type ${VERSION_TYPE} for ${GITHUB_OWNER}/${GITHUB_REPOSITORY}"
 
 function install_required_packages {
   echo "Install packages"
@@ -27,4 +28,4 @@ configure_git_user_information
 install_required_packages
 create_and_deploy_release
 
-echo -e "Release deployment for ${REPOSITORY_NAME} ${GREEN}succeeded${RESET_COLOR}."
+echo -e "Release deployment for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} ${GREEN}succeeded${RESET_COLOR}."

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('mocha');
 const { expect } = require('chai');
-const sinon = require('sinon');
+const { sinon } = require('../test-helper');
 const axios = require('axios');
 const githubService = require('../../../lib/services/github');
 
@@ -9,7 +9,7 @@ describe('#getPullRequests', function() {
         { html_url: 'http://test1.fr', title: 'PR1'},
         { html_url: 'http://test2.fr', title: 'PR2'},
     ];
-    before(() => {
+    beforeEach(() => {
         sinon.stub(axios, 'get').resolves({ data: { items: items } });
     });
 

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -1,45 +1,65 @@
 const { describe, it } = require('mocha');
 const { expect } = require('chai');
-const { sinon } = require('../test-helper');
+const { sinon, nock } = require('../test-helper');
 const axios = require('axios');
 const githubService = require('../../../lib/services/github');
 
 describe('#getPullRequests', function() {
-    const items = [
-        { html_url: 'http://test1.fr', title: 'PR1'},
-        { html_url: 'http://test2.fr', title: 'PR2'},
-    ];
-    beforeEach(() => {
-        sinon.stub(axios, 'get').resolves({ data: { items: items } });
-    });
+  const items = [
+    { html_url: 'http://test1.fr', title: 'PR1' },
+    { html_url: 'http://test2.fr', title: 'PR2' },
+  ];
+  beforeEach(() => {
+    sinon.stub(axios, 'get').resolves({ data: { items: items } });
+  });
 
-    it('should return the response for slack', async function() {
-        // given
-        const expectedResponse = {
-            response_type: 'in_channel',
-            text: 'PRs à review pour team-certif',
-            attachments: [
-                {color: '#B7CEF5', pretext: '', fields: [{value: '<http://test1.fr|PR1>', short: false}]},
-                {color: '#B7CEF5', pretext: '', fields: [{value: '<http://test2.fr|PR2>', short: false}]}
-            ]
-        };
+  it('should return the response for slack', async function() {
+    // given
+    const expectedResponse = {
+      response_type: 'in_channel',
+      text: 'PRs à review pour team-certif',
+      attachments: [
+        { color: '#B7CEF5', pretext: '', fields: [{ value: '<http://test1.fr|PR1>', short: false }] },
+        { color: '#B7CEF5', pretext: '', fields: [{ value: '<http://test2.fr|PR2>', short: false }] }
+      ]
+    };
 
-        // when
-        const response = await githubService.getPullRequests('team-certif');
+    // when
+    const response = await githubService.getPullRequests('team-certif');
 
-        // then
-        expect(response).to.deep.equal(expectedResponse);
-    });
+    // then
+    expect(response).to.deep.equal(expectedResponse);
+  });
 
-    it('should call the Github API with the label without space', async function() {
-        // given
-        const expectedUrl = 'https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:Tech%20Review%20Needed';
+  it('should call the Github API with the label without space', async function() {
+    // given
+    const expectedUrl = 'https://api.github.com/search/issues?q=is:pr+is:open+archived:false+sort:updated-desc+user:1024pix+label:Tech%20Review%20Needed';
 
-        // when
-        const response = await githubService.getPullRequests('Tech Review Needed');
+    // when
+    const response = await githubService.getPullRequests('Tech Review Needed');
 
-        // then
-        sinon.assert.calledWith(axios.get, expectedUrl);
-    });
+    // then
+    sinon.assert.calledWith(axios.get, expectedUrl);
+  });
 
 });
+
+describe('#getLatestReleaseTag', () => {
+
+  it('should call GitHub "Tags" API', async () => {
+    // given
+    const scope = nock('https://api.github.com')
+      .get('/repos/github-owner/github-repository/tags')
+      .reply(200, [
+        { "name": "v2.171.0", },
+        { "name": "v2.170.0", },
+      ]);
+
+    // when
+    const response = await githubService.getLatestReleaseTag();
+
+    // then
+    expect(response).to.equal('v2.171.0');
+  })
+
+})

--- a/test/unit/services/google-sheet_test.js
+++ b/test/unit/services/google-sheet_test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('mocha');
 const { expect } = require('chai');
-const sinon = require('sinon');
+const { sinon } = require('../test-helper');
 const axios = require('axios');
 const googleSheet = require('../../../lib/services/google-sheet');
 

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -1,10 +1,15 @@
 const sinon = require('sinon');
+const nock = require('nock');
+
+beforeEach(() => {
+  nock.disableNetConnect();
+});
 
 afterEach(function () {
   sinon.restore();
 });
 
 module.exports = {
-  sinon
+  sinon,
+  nock,
 };
-

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -1,0 +1,10 @@
+const sinon = require('sinon');
+
+afterEach(function () {
+  sinon.restore();
+});
+
+module.exports = {
+  sinon
+};
+


### PR DESCRIPTION
## :unicorn: Problème
Le script de publication de la release contient à la fois la création **et** le déploiement.

## :robot: Solution
Pour uniformiser les tâches, le script de création et publication de la release ne déploie plus la release en recette. (fichier `publish.sh`).

La commande Slack permettant de faire la mise en recette appelle désormais le script de création de release puis le script de déploiement de la release créée sur l'environnement `Recette`.

Dans le cas de la publication d'une release, les 2 scripts étant décorrelés, il faut trouver un moyen de récupérer le LTR (Last Release Tag) généré après création de la release, pour pouvoir le passer à la procédure de déploiement sur recette. Pour se faire, nous utilisons l'API GitHub et son client Node.js officiel ([Octokit.js](https://github.com/octokit/core.js)). Pour tester, nous ajoutons et utilisons [Nock.js](https://github.com/nock/nock).

Par ailleurs, cette PR ajoute les variables d'environnement `GITHUB_OWNER` ("1024pix") et `GITHUB_REPOSITORY` ("pix").

## 💯 Test
Pour tester, il faut : 
- cloner le repo 1024pix/pix sur un compte GitHub valide disposant d'un _personal access token_
- configurer en local les 2 varenv `GITHUB_OWNER` et `GITHUB_REPOSITORY` dans le fichier `.env`
- lancer l'application derrière un [ngrok](https://ngrok.com/)
- définir, configurer (via le interactive endpoint pointant vers l'URL fournie par ngrok) et installer l'app bot sur le workspace de test pix-bot.slack.com (il faut être membre du Slack) avec les bons _shortcuts_
- ⚠️ penser à bien désactiver les features Sentry !!!
- enfin, exécuter les shortcuts "publish/MER" & "deploy/MEP"

