### PR TITLE
[TECH] Utiliser le déploiement manuel par archive proposé par Scalingo plutôt que le trigger GitHub

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -20,10 +20,4 @@ const init = async () => {
   console.log('Server running on %s', server.info.uri);
 };
 
-process.on('unhandledRejection', (err) => {
-
-  console.log(err);
-  process.exit(1);
-});
-
 init();

--- a/bin/www
+++ b/bin/www
@@ -2,12 +2,13 @@ require('dotenv').config();
 
 const ReviewAppManager = require('scalingo-review-app-manager').ReviewAppManager;
 
+const config = require('../lib/config');
 const server = require('../lib/server');
 
 const init = async () => {
 
-  const scalingoToken = process.env.SCALINGO_TOKEN;
-  const scalingoApiUrl = process.env.SCALINGO_API_URL;
+  const scalingoToken = config.scalingo.reviewApps.token;
+  const scalingoApiUrl = config.scalingo.reviewApps.apiUrl;
   const stopCronTime = process.env.STOP_CRON_TIME;
   const restartCronTime = process.env.RESTART_CRON_TIME;
   const timeZone = process.env.TIME_ZONE || 'Europe/Paris';

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,13 +3,20 @@ function _getNumber(numberAsString, defaultIntNumber) {
   return isNaN(number) ? defaultIntNumber : number;
 }
 
+function _getCommaSeparatedValues(valuesAsString) {
+    if (!valuesAsString) {
+        return undefined;
+    }
+    return valuesAsString.split(',').map(v => v.trim());
+}
+
 module.exports = (function() {
 
   const config = {
     port: _getNumber(process.env.PORT, 3000),
     environment: (process.env.NODE_ENV || 'development'),
 
-    pixApps: process.env.PIX_APPS_TO_DEPLOY,
+    pixApps: _getCommaSeparatedValues(process.env.PIX_APPS_TO_DEPLOY),
 
     scalingo: {
       token: process.env.SCALINGO_TOKEN,

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,6 +9,12 @@ module.exports = (function() {
     port: _getNumber(process.env.PORT, 3000),
     environment: (process.env.NODE_ENV || 'development'),
 
+    pixApps: process.env.PIX_APPS_TO_DEPLOY,
+
+    scalingo: {
+      token: process.env.SCALINGO_TOKEN,
+    },
+
     reviewApps: {
       scalingoApiUrl: process.env.SCALINGO_API_URL || 'https://api.osc-fr1.scalingo.com',
       scalingoToken: process.env.SCALINGO_TOKEN,
@@ -42,6 +48,10 @@ module.exports = (function() {
     config.github.token = 'github-personal-access-token';
     config.github.owner = 'github-owner';
     config.github.repository = 'github-repository';
+
+    config.scalingo.token = 'tk-us-scalingo-token';
+
+    config.pixApps = ['pix-app1', 'pix-app2', 'pix-app3'];
   }
 
   return config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,10 +4,10 @@ function _getNumber(numberAsString, defaultIntNumber) {
 }
 
 function _getCommaSeparatedValues(valuesAsString) {
-    if (!valuesAsString) {
-        return undefined;
-    }
-    return valuesAsString.split(',').map(v => v.trim());
+  if (!valuesAsString) {
+    return undefined;
+  }
+  return valuesAsString.split(',').map(v => v.trim());
 }
 
 module.exports = (function() {
@@ -19,6 +19,10 @@ module.exports = (function() {
     pixApps: _getCommaSeparatedValues(process.env.PIX_APPS_TO_DEPLOY),
 
     scalingo: {
+      reviewApps: {
+        token: process.env.SCALINGO_TOKEN_REVIEW_APPS,
+        apiUrl: process.env.SCALINGO_API_URL_REVIEW_APPS || 'https://api.osc-fr1.scalingo.com',
+      },
       recette: {
         token: process.env.SCALINGO_TOKEN_RECETTE,
         apiUrl: process.env.SCALINGO_API_URL_RECETTE,
@@ -27,11 +31,6 @@ module.exports = (function() {
         token: process.env.SCALINGO_TOKEN_PRODUCTION,
         apiUrl: process.env.SCALINGO_API_URL_PRODUCTION,
       }
-    },
-
-    reviewApps: {
-      scalingoApiUrl: process.env.SCALINGO_API_URL || 'https://api.osc-fr1.scalingo.com',
-      scalingoToken: process.env.SCALINGO_TOKEN,
     },
 
     openApi: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,9 +21,11 @@ module.exports = (function() {
     scalingo: {
       recette: {
         token: process.env.SCALINGO_TOKEN_RECETTE,
+        apiUrl: process.env.SCALINGO_API_URL_RECETTE,
       },
       production: {
         token: process.env.SCALINGO_TOKEN_PRODUCTION,
+        apiUrl: process.env.SCALINGO_API_URL_PRODUCTION,
       }
     },
 
@@ -62,7 +64,9 @@ module.exports = (function() {
     config.github.repository = 'github-repository';
 
     config.scalingo.recette.token = 'tk-us-scalingo-token-recette';
+    config.scalingo.recette.apiUrl = 'https://scalingo.recette';
     config.scalingo.production.token = 'tk-us-scalingo-token-production';
+    config.scalingo.production.apiUrl = 'https://scalingo.production';
 
     config.pixApps = ['pix-app1', 'pix-app2', 'pix-app3'];
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,7 +19,12 @@ module.exports = (function() {
     pixApps: _getCommaSeparatedValues(process.env.PIX_APPS_TO_DEPLOY),
 
     scalingo: {
-      token: process.env.SCALINGO_TOKEN,
+      recette: {
+        token: process.env.SCALINGO_TOKEN_RECETTE,
+      },
+      production: {
+        token: process.env.SCALINGO_TOKEN_PRODUCTION,
+      }
     },
 
     reviewApps: {
@@ -56,7 +61,8 @@ module.exports = (function() {
     config.github.owner = 'github-owner';
     config.github.repository = 'github-repository';
 
-    config.scalingo.token = 'tk-us-scalingo-token';
+    config.scalingo.recette.token = 'tk-us-scalingo-token-recette';
+    config.scalingo.production.token = 'tk-us-scalingo-token-production';
 
     config.pixApps = ['pix-app1', 'pix-app2', 'pix-app3'];
   }

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -1,5 +1,7 @@
 const process = require('process');
 const util = require('util');
+const config = require('../config');
+const ScalingoClient = require('./scalingo-client');
 const exec = util.promisify(require('child_process').exec);
 
 const RELEASE_PIX_SCRIPT = `release-pix-repo.sh`;
@@ -21,15 +23,17 @@ module.exports = {
     }
   },
 
-   async deploy(environment, releaseTag) {
-    const scriptFileName = `deploy.sh`;
-    try {
-      const sanitizedEnvironment = _sanitizedArgument(environment);
-      const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
-      await _runScriptWithArgument(scriptFileName, sanitizedEnvironment, sanitizedReleaseTag);
-    } catch (err) {
-      console.error(err);
-    }
+  async deploy(environment, releaseTag) {
+    const sanitizedEnvironment = _sanitizedArgument(environment);
+    const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
+
+    const client = await ScalingoClient.getInstance(sanitizedEnvironment);
+    
+    const results = await Promise.all(config.pixApps.map(pixApp => {
+      return client.deployFromArchive(pixApp, sanitizedReleaseTag);
+    }));
+
+    return results;
   },
 
   async releaseAndDeployPixSite(versionType) {

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -16,7 +16,7 @@ class ScalingoClient {
       apiUrl = 'https://api.osc-fr1.scalingo.com';
     }
 
-    const client = await scalingo.clientFromToken(config.scalingo.token, { apiUrl });
+    const client = await scalingo.clientFromToken(config.scalingo[environment].token, { apiUrl });
     return new ScalingoClient(client, environment);
   }
 

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -40,7 +40,8 @@ class ScalingoClient {
           }
         });
     } catch (e) {
-      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`, e);
+      console.error(e);
+      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`);
     }
     
     return `Deployed ${scalingoApp} ${releaseTag}`;

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -1,0 +1,51 @@
+const scalingo = require('scalingo');
+const config = require('../config');
+
+class ScalingoClient {
+  constructor(client, environment) {
+    this.client = client;
+    this.environment = environment;
+  }
+
+  static async getInstance(environment) {  
+    let apiUrl;
+    if (environment === 'production') {
+      apiUrl = 'https://api.osc-secnum-fr1.scalingo.com';
+    }
+    if (environment === 'recette') {
+      apiUrl = 'https://api.osc-fr1.scalingo.com';
+    }
+
+    const client = await scalingo.clientFromToken(config.scalingo.token, { apiUrl });
+    return new ScalingoClient(client, environment);
+  }
+
+  async deployFromArchive(pixApp, releaseTag) {
+    if (!pixApp) {
+      throw new Error('No application to deploy.');
+    }
+    if (!releaseTag) {
+      throw new Error('No release tag to deploy.');
+    }
+
+    const scalingoApp = `${pixApp}-${this.environment}`;
+
+    try {
+      await this.client.apiClient().post(
+        `/apps/${scalingoApp}/deployments`, 
+        {
+          deployment: {
+            git_ref: releaseTag,
+            source_url: `https://github.com/1024pix/pix/archive/${releaseTag}.tar.gz`
+          }
+        });
+    } catch (e) {
+      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`, e);
+    }
+    
+    return `Deployed ${scalingoApp} ${releaseTag}`;
+  }
+}
+
+
+module.exports = ScalingoClient;

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -36,7 +36,7 @@ class ScalingoClient {
         {
           deployment: {
             git_ref: releaseTag,
-            source_url: `https://github.com/1024pix/pix/archive/${releaseTag}.tar.gz`
+            source_url: `https://github.com/${config.github.owner}/${config.github.repository}/archive/${releaseTag}.tar.gz`
           }
         });
     } catch (e) {

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -8,15 +8,8 @@ class ScalingoClient {
   }
 
   static async getInstance(environment) {  
-    let apiUrl;
-    if (environment === 'production') {
-      apiUrl = 'https://api.osc-secnum-fr1.scalingo.com';
-    }
-    if (environment === 'recette') {
-      apiUrl = 'https://api.osc-fr1.scalingo.com';
-    }
-
-    const client = await scalingo.clientFromToken(config.scalingo[environment].token, { apiUrl });
+    const { token, apiUrl } = config.scalingo[environment];
+    const client = await scalingo.clientFromToken(token, { apiUrl });
     return new ScalingoClient(client, environment);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,9 +1784,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "proxyquire": "^2.1.3",
+    "scalingo": "^0.1.1",
     "scalingo-review-app-manager": "^1.0.0",
     "tsscmp": "^1.0.6"
   },

--- a/sample.env
+++ b/sample.env
@@ -127,23 +127,23 @@ SCALINGO_API_URL_PRODUCTION=https://api.osc-secnum-fr1.scalingo.com
 # REVIEW APPS MANAGEMENT
 # ======================
 
-# Scalingo API endpoint
+# Scalingo API endpoint for review apps
 #
 # If not present, application will not start (error during bootstrap).
 #
 # presence: required
 # type: String (URL)
 # default: "https://api.osc-fr1.scalingo.com"
-SCALINGO_API_URL=https://api.osc-fr1.scalingo.com
+SCALINGO_API_URL_REVIEW_APPS=https://api.osc-fr1.scalingo.com
 
-# Scalingo user API token.
+# Scalingo user API token for review apps.
 #
 # If not present, application will not start (error during bootstrap).
 #
 # presence: required
 # type: String
 # default: none
-SCALINGO_TOKEN=__CHANGE_ME__
+SCALINGO_TOKEN_REVIEW_APPS=__CHANGE_ME__
 
 # Date time at which Scalingo running review apps must be stopped.
 #

--- a/sample.env
+++ b/sample.env
@@ -100,6 +100,15 @@ SCALINGO_API_URL=https://api.osc-fr1.scalingo.com
 # default: none
 SCALINGO_TOKEN=__CHANGE_ME__
 
+# Pix applications to deploy
+#
+# If not present, application will not start
+#
+# presence: required
+# type: String (pix apps names, separated by ',')
+# default: none
+PIX_APPS_TO_DEPLOY=__CHANGE_ME__
+
 # Date time at which Scalingo running review apps must be stopped.
 #
 # presence: optionnal

--- a/sample.env
+++ b/sample.env
@@ -78,6 +78,33 @@ GITHUB_OWNER=__CHANGE_ME__
 # default: none
 GITHUB_REPOSITORY=__CHANGE_ME__
 
+# Pix applications to deploy
+#
+# If not present, application will not start
+#
+# presence: required
+# type: String (pix apps names, separated by ',')
+# default: none
+PIX_APPS_TO_DEPLOY=__CHANGE_ME__
+
+# Scalingo user API token for recette environment.
+#
+# If not present, deployment in recette environment will failed
+#
+# presence: required
+# type: String
+# default: none
+SCALINGO_TOKEN_RECETTE=__CHANGE_ME__
+
+# Scalingo user API token for production environment.
+#
+# If not present, deployment in production environment will failed
+#
+# presence: required
+# type: String
+# default: none
+SCALINGO_TOKEN_PRODUCTION=__CHANGE_ME__
+
 # ======================
 # REVIEW APPS MANAGEMENT
 # ======================
@@ -99,15 +126,6 @@ SCALINGO_API_URL=https://api.osc-fr1.scalingo.com
 # type: String
 # default: none
 SCALINGO_TOKEN=__CHANGE_ME__
-
-# Pix applications to deploy
-#
-# If not present, application will not start
-#
-# presence: required
-# type: String (pix apps names, separated by ',')
-# default: none
-PIX_APPS_TO_DEPLOY=__CHANGE_ME__
 
 # Date time at which Scalingo running review apps must be stopped.
 #

--- a/sample.env
+++ b/sample.env
@@ -96,6 +96,15 @@ PIX_APPS_TO_DEPLOY=__CHANGE_ME__
 # default: none
 SCALINGO_TOKEN_RECETTE=__CHANGE_ME__
 
+# Scalingo API endpoint
+#
+# If not present, deployment in recette environment will failed
+#
+# presence: required
+# type: String (URL)
+# default: "https://api.osc-fr1.scalingo.com"
+SCALINGO_API_URL_RECETTE=https://api.osc-fr1.scalingo.com
+
 # Scalingo user API token for production environment.
 #
 # If not present, deployment in production environment will failed
@@ -104,6 +113,15 @@ SCALINGO_TOKEN_RECETTE=__CHANGE_ME__
 # type: String
 # default: none
 SCALINGO_TOKEN_PRODUCTION=__CHANGE_ME__
+
+# Scalingo API endpoint
+#
+# If not present, deployment in production environment will failed
+#
+# presence: required
+# type: String (URL)
+# default: "https://api.osc-secnum-fr1.scalingo.com"
+SCALINGO_API_URL_PRODUCTION=https://api.osc-secnum-fr1.scalingo.com
 
 # ======================
 # REVIEW APPS MANAGEMENT

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -118,6 +118,6 @@ complete_change_log
 create_a_release_commit
 tag_release_commit
 push_commit_and_tag_to_remote_dev
-#publish_release_on_sentry
+publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -118,6 +118,6 @@ complete_change_log
 create_a_release_commit
 tag_release_commit
 push_commit_and_tag_to_remote_dev
-publish_release_on_sentry
+#publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -1,14 +1,17 @@
 const { describe, it } = require('mocha');
 const sinon = require('sinon');
 const proxyquire =  require('proxyquire');
+const { expect } = require('chai');
+const releasesService = require('../../../lib/services/releases');
+const ScalingoClient = require('../../../lib/services/scalingo-client');
 
 describe('releases', function() {
     let exec;
-    let releaseService;
+    let releasesService;
 
     before(() => {
         exec = sinon.stub().callsFake(async () => Promise.resolve({stdout: '', stderr: ''}));
-        releaseService = proxyquire('../../../lib/services/releases', {
+        releasesService = proxyquire('../../../lib/services/releases', {
             'child_process': {exec},
             util: {promisify: fn => fn}
         });
@@ -17,56 +20,78 @@ describe('releases', function() {
     describe('#publish', async function () {
         it('should call the publish script', async function () {
             //when
-            await releaseService.publish('minor');
+            await releasesService.publish('minor');
 
             // then
             sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/publish.sh minor)")));
         });
     });
 
-    describe('#deploy', async function () {
-        it('should call the deploy script', async function () {
-            //when
-            await releaseService.deploy('minor');
-
-            // then
-            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/deploy.sh minor)")));
-        });
-    });
-
     describe('#createAndDeployPixSite', async function () {
         it('should call the release pix site script with default', async function () {
             //when
-            await releaseService.releaseAndDeployPixSite();
+            await releasesService.releaseAndDeployPixSite();
 
             // then
-            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh pix-site)")));
+            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh 1024pix pix-site)")));
         });
 
         it('should call the release pix site script with \'minor\'', async function () {
             //when
-            await releaseService.releaseAndDeployPixSite('minor');
+            await releasesService.releaseAndDeployPixSite('minor');
 
             // then
-            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh pix-site minor)")));
+            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh 1024pix pix-site minor)")));
         });
     });
 
     describe('#createAndDeployPro', async function () {
         it('should call the release pix pro script with default', async function () {
             //when
-            await releaseService.releaseAndDeployPixPro();
+            await releasesService.releaseAndDeployPixPro();
 
             // then
-            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh pix-pro)")));
+            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh 1024pix pix-pro)")));
         });
 
         it('should call the release pix pro script with \'minor\'', async function () {
             //when
-            await releaseService.releaseAndDeployPixPro('minor');
+            await releasesService.releaseAndDeployPixPro('minor');
 
             // then
-            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh pix-pro minor)")));
+            sinon.assert.calledWith(exec, sinon.match(new RegExp(".*(\/scripts\/release-pix-repo.sh 1024pix pix-pro minor)")));
         });
     });
 });
+
+describe('#deploy', async function () {
+    it('should trigger deployments of managed applications', async () => {
+      // given
+      const scalingoClient = new ScalingoClient(null, 'production');
+      scalingoClient.deployFromArchive = sinon.stub();
+      scalingoClient.deployFromArchive.resolves('OK');
+      sinon.stub(ScalingoClient, 'getInstance').resolves(scalingoClient);
+      // when
+      const response = await releasesService.deploy('production', 'v1.0');
+      // then
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app1', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app2', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app3', 'v1.0');
+      expect(response).to.deep.equal(['OK', 'OK', 'OK']);
+    });
+  
+    it('should trigger deployments of managed applications', async () => {
+      // given
+      const scalingoClient = new ScalingoClient(null, 'production');
+      scalingoClient.deployFromArchive = sinon.stub();
+      scalingoClient.deployFromArchive.rejects(new Error('KO'));
+      sinon.stub(ScalingoClient, 'getInstance').resolves(scalingoClient);
+      // when
+      try {
+        await releasesService.deploy('production', 'v1.0');
+        expect.fail('Should throw an error when an application deployment fails')
+      } catch (e) {
+        expect(e.message).to.equal('KO')
+      }
+    });
+  });

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -2,7 +2,7 @@ const { describe, it } = require('mocha');
 const sinon = require('sinon');
 const proxyquire =  require('proxyquire');
 
-describe('release', function() {
+describe('releases', function() {
     let exec;
     let releaseService;
 

--- a/test/unit/services/scalingo-client_test.js
+++ b/test/unit/services/scalingo-client_test.js
@@ -11,7 +11,7 @@ describe('Scalingo client', () => {
     it('should return the Scalingo client instance for recette', async () => {
       // given
       sinon.stub(scalingo, 'clientFromToken')
-        .withArgs('tk-us-scalingo-token-recette', { apiUrl: 'https://api.osc-fr1.scalingo.com'})
+        .withArgs('tk-us-scalingo-token-recette', { apiUrl: 'https://scalingo.recette' })
         .resolves({ apiClient: () => {} });
       // when
       const scalingoClient = await ScalingoClient.getInstance('recette');
@@ -19,11 +19,11 @@ describe('Scalingo client', () => {
       expect(scalingoClient).to.be.an.instanceof(ScalingoClient);
       expect(scalingoClient.client).to.exist;
     });
-  
+
     it('should return the Scalingo client instance for production', async () => {
       // given
       sinon.stub(scalingo, 'clientFromToken')
-        .withArgs('tk-us-scalingo-token-production', { apiUrl: 'https://api.osc-secnum-fr1.scalingo.com'})
+        .withArgs('tk-us-scalingo-token-production', { apiUrl: 'https://scalingo.production' })
         .resolves({ apiClient: () => {} });
       // when
       const scalingoClient = await ScalingoClient.getInstance('production');
@@ -31,7 +31,7 @@ describe('Scalingo client', () => {
       expect(scalingoClient).to.be.an.instanceof(ScalingoClient);
       expect(scalingoClient.client).to.exist;
     });
-  
+
     it('should throw an error when scalingo authentication failed', async () => {
       // given
       sinon.stub(scalingo, 'clientFromToken').rejects(new Error('Invalid credentials'));
@@ -43,14 +43,14 @@ describe('Scalingo client', () => {
       } catch (e) {
         expect(e.message).to.equal('Invalid credentials');
         expect(scalingoClient).to.be.undefined;
-      } 
+      }
     });
   });
 
   describe('#ScalingoClient.deployFromArchive', () => {
     let apiClientPost;
     let scalingoClient;
-  
+
     beforeEach(async () => {
       apiClientPost = sinon.stub();
       sinon.stub(scalingo, 'clientFromToken')
@@ -58,7 +58,7 @@ describe('Scalingo client', () => {
 
       scalingoClient = await ScalingoClient.getInstance('production');
     });
-  
+
     it('should not deploy without app given', async () => {
       try {
         await scalingoClient.deployFromArchive(null, 'v1.0');
@@ -76,7 +76,7 @@ describe('Scalingo client', () => {
         expect(e.message).to.equal('No release tag to deploy.');
       }
     });
-  
+
     it('should deploy an application for a given tag', async () => {
       // given
       // when
@@ -84,8 +84,8 @@ describe('Scalingo client', () => {
       // then
       sinon.assert.calledWithExactly(
         apiClientPost,
-        '/apps/pix-app-production/deployments', 
-        { 
+        '/apps/pix-app-production/deployments',
+        {
           deployment: {
             git_ref: 'v1.0',
             source_url: `https://github.com/github-owner/github-repository/archive/v1.0.tar.gz`
@@ -97,6 +97,7 @@ describe('Scalingo client', () => {
 
     it('should failed when application does not exists', async () => {
       // given
+      sinon.stub(console, 'error');
       apiClientPost.rejects(new Error());
       // when
       try {

--- a/test/unit/services/scalingo-client_test.js
+++ b/test/unit/services/scalingo-client_test.js
@@ -11,7 +11,7 @@ describe('Scalingo client', () => {
     it('should return the Scalingo client instance for recette', async () => {
       // given
       sinon.stub(scalingo, 'clientFromToken')
-        .withArgs('tk-us-scalingo-token', { apiUrl: 'https://api.osc-fr1.scalingo.com'})
+        .withArgs('tk-us-scalingo-token-recette', { apiUrl: 'https://api.osc-fr1.scalingo.com'})
         .resolves({ apiClient: () => {} });
       // when
       const scalingoClient = await ScalingoClient.getInstance('recette');
@@ -23,7 +23,7 @@ describe('Scalingo client', () => {
     it('should return the Scalingo client instance for production', async () => {
       // given
       sinon.stub(scalingo, 'clientFromToken')
-        .withArgs('tk-us-scalingo-token', { apiUrl: 'https://api.osc-secnum-fr1.scalingo.com'})
+        .withArgs('tk-us-scalingo-token-production', { apiUrl: 'https://api.osc-secnum-fr1.scalingo.com'})
         .resolves({ apiClient: () => {} });
       // when
       const scalingoClient = await ScalingoClient.getInstance('production');

--- a/test/unit/services/scalingo-client_test.js
+++ b/test/unit/services/scalingo-client_test.js
@@ -1,0 +1,110 @@
+const { describe, it } = require('mocha');
+const sinon = require('sinon');
+const scalingo = require('scalingo');
+
+const ScalingoClient = require('../../../lib/services/scalingo-client');
+const { expect } = require('chai');
+
+describe('Scalingo client', () => {
+  describe('#ScalingoClient.getInstance', () => {
+
+    it('should return the Scalingo client instance for recette', async () => {
+      // given
+      sinon.stub(scalingo, 'clientFromToken')
+        .withArgs('tk-us-scalingo-token', { apiUrl: 'https://api.osc-fr1.scalingo.com'})
+        .resolves({ apiClient: () => {} });
+      // when
+      const scalingoClient = await ScalingoClient.getInstance('recette');
+      // then
+      expect(scalingoClient).to.be.an.instanceof(ScalingoClient);
+      expect(scalingoClient.client).to.exist;
+    });
+  
+    it('should return the Scalingo client instance for production', async () => {
+      // given
+      sinon.stub(scalingo, 'clientFromToken')
+        .withArgs('tk-us-scalingo-token', { apiUrl: 'https://api.osc-secnum-fr1.scalingo.com'})
+        .resolves({ apiClient: () => {} });
+      // when
+      const scalingoClient = await ScalingoClient.getInstance('production');
+      // then
+      expect(scalingoClient).to.be.an.instanceof(ScalingoClient);
+      expect(scalingoClient.client).to.exist;
+    });
+  
+    it('should throw an error when scalingo authentication failed', async () => {
+      // given
+      sinon.stub(scalingo, 'clientFromToken').rejects(new Error('Invalid credentials'));
+      // when
+      let scalingoClient;
+      try {
+        scalingoClient = await ScalingoClient.getInstance('production');
+        expect.fail('should raise an error when credentials are invalid');
+      } catch (e) {
+        expect(e.message).to.equal('Invalid credentials');
+        expect(scalingoClient).to.be.undefined;
+      } 
+    });
+  });
+
+  describe('#ScalingoClient.deployFromArchive', () => {
+    let apiClientPost;
+    let scalingoClient;
+  
+    beforeEach(async () => {
+      apiClientPost = sinon.stub();
+      sinon.stub(scalingo, 'clientFromToken')
+        .resolves({ apiClient: () => ({ post: apiClientPost }) });
+
+      scalingoClient = await ScalingoClient.getInstance('production');
+    });
+  
+    it('should not deploy without app given', async () => {
+      try {
+        await scalingoClient.deployFromArchive(null, 'v1.0');
+        expect.fail('Should throw an error when no application given');
+      } catch (e) {
+        expect(e.message).to.equal('No application to deploy.');
+      }
+    });
+
+    it('should not deploy without a release tag given', async () => {
+      try {
+        await scalingoClient.deployFromArchive('pix-app', null);
+        expect.fail('Should throw an error when no release tag given');
+      } catch (e) {
+        expect(e.message).to.equal('No release tag to deploy.');
+      }
+    });
+  
+    it('should deploy an application for a given tag', async () => {
+      // given
+      // when
+      const result = await scalingoClient.deployFromArchive('pix-app', 'v1.0');
+      // then
+      sinon.assert.calledWithExactly(
+        apiClientPost,
+        '/apps/pix-app-production/deployments', 
+        { 
+          deployment: {
+            git_ref: 'v1.0',
+            source_url: `https://github.com/1024pix/pix/archive/v1.0.tar.gz`
+          },
+        }
+      );
+      expect(result).to.be.equal('Deployed pix-app-production v1.0');
+    });
+
+    it('should failed when application does not exists', async () => {
+      // given
+      apiClientPost.rejects(new Error());
+      // when
+      try {
+        await scalingoClient.deployFromArchive('unknown-app', 'v1.0');
+        expect.fail('Should throw an error when application doesnt exists');
+      } catch (e) {
+        expect(e.message).to.equal('Impossible to deploy unknown-app-production v1.0');
+      }
+    });
+  });
+});

--- a/test/unit/services/scalingo-client_test.js
+++ b/test/unit/services/scalingo-client_test.js
@@ -88,7 +88,7 @@ describe('Scalingo client', () => {
         { 
           deployment: {
             git_ref: 'v1.0',
-            source_url: `https://github.com/1024pix/pix/archive/v1.0.tar.gz`
+            source_url: `https://github.com/github-owner/github-repository/archive/v1.0.tar.gz`
           },
         }
       );


### PR DESCRIPTION
## Contexte

Pour rappel, les applications Pix API, Admin, App, Certif & Orga sont hébergées par Scalingo (PaaS) / 3DS Outscale (IaaS). 

Le déploiement d’une nouvelle version de la plateforme et de chaque application se fait via l’application Pix Bot (déclenchée depuis une commande Slack), laquelle exécute un script Shell, qui se termine par un push (du commit du tag livré) sur la branche prod du repository 1024pix/pix.

Ce mécanisme est fonctionnel depuis des mois.

Cependant, le fait de lier aussi fortement GitHub (hébergeur de code source) et Scalingo (hébergeur de l’applicatif) nous paraît risqué à terme, car trop rigide ou trop fragile, à tout le moins pour les applications de production.

Nous pensons qu’il serait préférable et plus pérenne de dissocier GitHub de Scalingo en production.

Par ailleurs : 
- Scalingo impose un délai de 10s avant de déclencher un déploiement depuis un changement sur GitHub, pour une histoire de checks GitHub dont ile ne peuvent pas détecter l'état.
- le mécanisme actuel perd 30s à récupérer - `git checkout` - les sources pour les manipuler et déployer le tag
- comme on éxécute un script Shell depuis un sous-process Node, il est extrêmememnt dur de déboguer (en local) en cas de problème
- sans compter que les logs générées par le script arrivent dans un ordre totalement asynchrone et dans un format qui rend la lecture / exploitation très compliquée
- enfin, le mécanisme repose sur 2 fonctionnalités haut-niveau de Scalingo (trigger) et GitHub (webhook) ; il nous paraît plus robuste de s'appuyer directement sous les macanismes sous-jacents

## Solution

Pour commencer, GitHub permet très simplement, via une requête GET, de récupérer des archives de code. 

Par exemple il est possible de récupérer le code de la v2.160.0 directement via https://github.com/1024pix/pix/archive/v2.160.0.tar.gz.

De son côté, Scalingo expose une API, via une requête POST, qui permet de déployer manuellement n’importe quel code ou archive sur n’importe quelle application.

```
curl -H "Accept: application/json" -H "Content-Type: application/json" \
     -H "Authorization: Bearer $BEARER_TOKEN" \
     -X POST https://$SCALINGO_API_URL/v1/apps/example-app/deployments -d \
     '{
       "deployment": {
         "git_ref": "master",
         "source_url": "https://github.com/Scalingo/sample-go-martini/archive/master.tar.gz"
       }
     }'
```

Cette PR se propose d’améliorer (simplfier + accélérer + renforcer) la procédure de déploiement de code déclenchée et gérée au sein l’application Pix Bot en remplaçant le script shell scripts/deploy.sh par un appel à l’API Scalingo directement dans le code Node.js du service services/releases.js.


## Remarque

Cette PR modifie 6 variables d'environnement : 

- SCALINGO_API_URL_REVIEW_APPS : renommage de SCALINGO_API_URL
- SCALINGO_TOKEN_REVIEW_APPS : renommage de SCALINGO_TOKEN_URL
- SCALINGO_API_URL_RECETTE
- SCALINGO_TOKEN_RECETTE
- SCALINGO_API_URL_PRODUCTION
- SCALINGO_TOKEN_PRODUCTION

Bien penser à les définir dans l'application Pix Bot sur Scalingo et mettre à jour les fichiers `.env` locaux des gens.