### PR TITLE
[BUGFIX] Correction de l'échec du déploiement de pix-site quand le type de release n'est pas spécifié.

### DIFF
--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -23,7 +23,14 @@ function getResponseText(release, appName) {
   return `Le script de déploiement de la release '${release}' pour ${appName} en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`;
 }
 
+function _isReleaseTypeInvalid(releaseType) {
+  return !['major', 'minor', 'patch'].includes(releaseType);
+}
+
 async function publishAndDeployRelease(repoName, appName, releaseType, responseUrl) {
+  if (_isReleaseTypeInvalid(releaseType)) {
+    releaseType = 'minor';
+  }
   await releasesService.publishPixSite(repoName, releaseType);
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.deployPixSite(repoName, appName, releaseTag);

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,7 +16,7 @@ function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
   echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}.git" "${REPOSITORY_FOLDER}"
+  git clone --depth 1 "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}.git" "${REPOSITORY_FOLDER}"
   echo "Cloned repository ${GITHUB_OWNER}/${GITHUB_REPOSITORY} to temporary directory"
 
   cd "${REPOSITORY_FOLDER}" || exit 1

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -28,14 +28,6 @@ describe('releases', function() {
   });
 
   describe('#publishPixSite', async function () {
-    it('should call the release pix site script with default', async function () {
-      //when
-      await releasesService.publishPixSite('pix-site');
-
-      // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh) github-owner pix-site $')));
-    });
-
     it('should call the release pix pro script with \'minor\'', async function () {
       //when
       await releasesService.publishPixSite('pix-site-pro', 'minor');

--- a/test/unit/services/slack/commands_test.js
+++ b/test/unit/services/slack/commands_test.js
@@ -15,27 +15,41 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployPixSiteRelease', () => {
-    beforeEach(async () => {
-      // given
-      const payload = { text: 'minor' };
-      // when
-      await createAndDeployPixSiteRelease(payload);
+    describe('when releaseType is set to minor', () => {
+      beforeEach(async () => {
+        // given
+        const payload = { text: 'minor' };
+        // when
+        await createAndDeployPixSiteRelease(payload);
+      });
+
+      it('should publish a new release', () => {
+        // then
+        sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site', 'minor');
+      });
+
+      it('should retrieve the last release tag from GitHub', () => {
+        // then
+        sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-site');
+      });
+
+      it('should deploy the release', () => {
+        // then
+        sinon.assert.calledWith(releasesServices.deployPixSite, 'pix-site', 'pix-site', 'v1.0.0');
+      });
     });
 
-    it('should publish a new release', () => {
-      // then
-      sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site', 'minor');
+    describe('when releaseType is not set to a valid value', () => {
+      it('should publish a new minor release', async () => {
+        // given
+        const payload = { text: '' };
+        // when
+        await createAndDeployPixSiteRelease(payload);
+        // then
+        sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site', 'minor');
+      });
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-site');
-    });
-
-    it('should deploy the release', () => {
-      // then
-      sinon.assert.calledWith(releasesServices.deployPixSite, 'pix-site', 'pix-site', 'v1.0.0');
-    });
   });
 
   describe('#createAndDeployPixProRelease', () => {


### PR DESCRIPTION
## :unicorn: Problème
Le déploiement de pix-site échoue si on ne spécifie pas le type de release dans la commande slack.

## :robot: Solution
Mettre le type de release à `minor` si celui-ci n'est pas défini par l'utilisateur.

## :rainbow: Remarques
On en a profité pour limiter le clone du repo git au dernier commit car on ne se sert pas de l'historique.

## :100: Pour tester
Faire un déploiement de pix-site depuis la commande `/deploy-pix-site` sans argument.