### PR TITLE
[TECH] Ajout d'une action Slack pour déployer pix-ui

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -38,6 +38,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixUIRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixUI(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX UI')
+    };
+  },
+
   interactiveEndpoint(request) {
     const payload = request.pre.payload;
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -32,6 +32,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-ui-release',
+    handler: slackbotController.createAndDeployPixUIRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
     config: slackConfig

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -3,7 +3,7 @@ const slackbotController = require('../controllers/slack');
 
 const slackConfig = {
   payload: {
-    allow: 'application/x-www-form-urlencoded',
+    allow: ['application/json', 'application/x-www-form-urlencoded'],
     parse: false
   },
   pre: [

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -58,14 +58,14 @@ module.exports = {
   },
 
   async deployPixUI() {
-    const args = ['1024pix', 'pix-ui'];
+    const args = [config.github.owner, 'pix-ui'];
     await _runScriptWithArgument(DEPLOY_PIX_UI_SCRIPT, ...args);
   },
 
   async releaseAndDeployPixPro(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);
-      const args = ['1024pix', 'pix-pro', releaseType];
+      const args = [config.github.owner, 'pix-pro', releaseType];
       await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
     } catch (err) {
       console.error(err);
@@ -75,7 +75,7 @@ module.exports = {
   async releaseAndDeployPixBotTest(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);
-      const args = ['1024pix', 'pix-bot-release-test', releaseType];
+      const args = [config.github.owner, 'pix-bot-release-test', releaseType];
       await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
     } catch (err) {
       console.error(err);

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -5,6 +5,7 @@ const ScalingoClient = require('./scalingo-client');
 const exec = util.promisify(require('child_process').exec);
 
 const RELEASE_PIX_SCRIPT = 'release-pix-repo.sh';
+const DEPLOY_PIX_UI_SCRIPT = 'deploy-pix-ui.sh';
 
 module.exports = {
 
@@ -36,7 +37,7 @@ module.exports = {
     return results;
   },
 
-  async publishPixSite(repoName, releaseType) {
+  async publishPixRepo(repoName, releaseType) {
     try {
       const sanitizedReleaseType = _sanitizedArgument(releaseType);
       const sanitizedRepoName = _sanitizedArgument(repoName);
@@ -54,6 +55,11 @@ module.exports = {
 
     const client = await ScalingoClient.getInstance('production');
     return client.deployFromArchive(sanitizedAppName, sanitizedReleaseTag, sanitizedRepoName);
+  },
+
+  async deployPixUI() {
+    const args = ['1024pix', 'pix-ui'];
+    await _runScriptWithArgument(DEPLOY_PIX_UI_SCRIPT, ...args);
   },
 
   async releaseAndDeployPixPro(versionType) {
@@ -83,6 +89,7 @@ async function _runScriptWithArgument (scriptFileName, ...args) {
   console.log(`stdout: ${stdout}`);
   console.error(`stderr: ${stderr}`);
 }
+
 function _sanitizedArgument(param) {
   return param? param.trim().toLowerCase(): null;
 }

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -7,6 +7,7 @@ const PIX_SITE_APP_NAME = 'pix-site';
 const PIX_SITE_REPO_NAME = 'pix-site';
 const PIX_PRO_APP_NAME = 'pix-pro';
 const PIX_PRO_REPO_NAME = 'pix-site-pro';
+const PIX_UI_REPO_NAME = 'pix-ui';
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,
@@ -19,8 +20,12 @@ function sendResponse(responseUrl, text) {
   );
 }
 
-function getResponseText(release, appName) {
+function getSuccessMessage(release, appName) {
   return `Le script de déploiement de la release '${release}' pour ${appName} en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`;
+}
+
+function getErrorMessage(release, appName) {
+  return `Erreur lors du déploiement de la release '${release}' pour ${appName} en production.`;
 }
 
 function _isReleaseTypeInvalid(releaseType) {
@@ -31,11 +36,27 @@ async function publishAndDeployRelease(repoName, appName, releaseType, responseU
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
-  await releasesService.publishPixSite(repoName, releaseType);
+  await releasesService.publishPixRepo(repoName, releaseType);
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.deployPixSite(repoName, appName, releaseTag);
 
-  sendResponse(responseUrl, getResponseText(releaseTag, appName));
+  sendResponse(responseUrl, getSuccessMessage(releaseTag, appName));
+}
+
+async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
+  if (_isReleaseTypeInvalid(releaseType)) {
+    releaseType = 'minor';
+  }
+  const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
+  await releasesService.publishPixRepo(repoName, releaseType);
+  const releaseTagAfterRelease = await githubServices.getLatestReleaseTag(repoName);
+  await releasesService.deployPixUI();
+
+  if (releaseTagBeforeRelease === releaseTagAfterRelease) {
+    sendResponse(responseUrl, getErrorMessage(releaseTagAfterRelease, repoName));
+  } else {
+    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
+  }
 }
 
 module.exports = {
@@ -48,9 +69,13 @@ module.exports = {
     await publishAndDeployRelease(PIX_PRO_REPO_NAME, PIX_PRO_APP_NAME, payload.text, payload.response_url);
   },
 
+  async createAndDeployPixUI(payload) {
+    await publishAndDeployPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
+  },
+
   async createAndDeployPixBotTestRelease(payload) {
     await releaseAndDeployPixBotTest(payload.text);
     const release = payload.text || 'defaut';
-    sendResponse(payload, getResponseText(release, 'PIX TEST (repo de test)'));
+    sendResponse(payload, getSuccessMessage(release, 'PIX TEST (repo de test)'));
   }
 };

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -40,3 +40,13 @@ function push_commit_and_tag_to_remote_dev() {
   echo "Pushed release commit on branch origin/dev"
 }
 
+function complete_change_log() {
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
+
+  echo "Updated CHANGELOG.md"
+}
+
+function tag_release_commit() {
+  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
+  echo "Created annotated tag"
+}

--- a/scripts/deploy-pix-ui.sh
+++ b/scripts/deploy-pix-ui.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CWD_DIR=$(pwd)
+GITHUB_OWNER=(${1})
+GITHUB_REPOSITORY=(${2})
+
+source "${CWD_DIR}/scripts/common.sh"
+
+function deploy_storybook_to_ghpages() {
+  npm install
+  npm run deploy-storybook
+  echo "Deploying storybook on https://1024pix.github.io/pix-ui/"
+}
+
+echo "== Clone and move into Pix repository =="
+clone_repository_and_move_inside
+
+echo "== Deploy Storybook to Github Pages =="
+deploy_storybook_to_ghpages
+
+echo -e "Release publication for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} ${GREEN}succeeded${RESET_COLOR} (${VERSION_TYPE})."

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -7,20 +7,16 @@ const fs = require('fs');
 const CHANGELOG_FILE = 'CHANGELOG.md';
 const CHANGELOG_HEADER_LINES = 2;
 
-function buildRequestObject() {
-  return 'https://api.github.com/repos/1024pix/pix/pulls?state=closed&sort=updated&direction=desc';
-}
-
-function getTheLastCommitOnMaster() {
-  return 'https://api.github.com/repos/1024pix/pix/commits/master';
+function buildRequestObject(repoOwner, repoName) {
+  return `https://api.github.com/repos/${repoOwner}/${repoName}/pulls?state=closed&sort=updated&direction=desc'`
 }
 
 function getTheCommitDate(RawDataCommit) {
   return RawDataCommit.commit.committer.date;
 }
 
-async function getLastMEPDate() {
-  const tags = await axios.get('https://api.github.com/repos/1024pix/pix/tags');
+async function getLastMEPDate(repoOwner, repoName) {
+  const tags = await axios.get(`https://api.github.com/repos/${repoOwner}/${repoName}/tags`);
   const commitUrl = tags.data[0].commit.url;
 
   const commit = await axios.get(commitUrl);
@@ -51,11 +47,13 @@ function getHeadOfChangelog(tagVersion) {
 
 async function main() {
   const tagVersion = process.argv[2];
+  const repoOwner = process.argv[3];
+  const repoName = process.argv[4];
 
   try {
-    const dateOfLastMEP = await getLastMEPDate();
+    const dateOfLastMEP = await getLastMEPDate(repoOwner, repoName);
 
-    const { data: pullRequests } = await axios(buildRequestObject());
+    const { data: pullRequests } = await axios(buildRequestObject(repoOwner, repoName));
 
     const newChangeLogLines = [];
 
@@ -66,7 +64,14 @@ async function main() {
     newChangeLogLines.push(...orderedPR.map(displayPullRequest));
     newChangeLogLines.push('');
 
-    const currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
+
+    let currentChangeLog = '';
+
+    try {
+      currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
+    } catch(error) {
+      console.log('Changelog file does not exist. It will be created.');
+    }
 
     currentChangeLog.splice(CHANGELOG_HEADER_LINES, 0, ...newChangeLogLines);
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -60,7 +60,7 @@ function update_all_pix_modules_version() {
 }
 
 function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}"
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -59,12 +59,6 @@ function update_all_pix_modules_version() {
   echo "Bumped versions in package files"
 }
 
-function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
-
-  echo "Updated CHANGELOG.md"
-}
-
 # Update when adding a new app
 function create_a_release_commit() {
   git add  --update \
@@ -81,11 +75,6 @@ function create_a_release_commit() {
   git commit --message "[RELEASE] A ${NEW_VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."
 
   echo "Created the release commit"
-}
-
-function tag_release_commit() {
-  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
-  echo "Created annotated tag"
 }
 
 function publish_release_on_sentry() {

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -4,6 +4,7 @@ set -euxo pipefail
 
 source "$(dirname $0)"/common.sh
 
+CWD_DIR=$(pwd)
 GITHUB_OWNER=(${1})
 GITHUB_REPOSITORY=(${2})
 VERSION_TYPE=(${3-""})
@@ -15,10 +16,30 @@ function install_required_packages {
   npm ci --dev --no-optional
 }
 
+function complete_change_log() {
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
+
+  echo "Updated CHANGELOG.md"
+}
+
 function create_release {
-  npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg=":$VERSION_TYPE"
-  npm run release${npm_arg}
+  npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
+  npm version ${npm_arg} --no-git-tag-version
   NEW_PACKAGE_VERSION=$(get_package_version)
+}
+
+function create_a_release_commit() {
+  git add  --update CHANGELOG.md
+  git add  --update package*.json
+
+  git commit --message "[RELEASE] A ${VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."
+
+  echo "Created the release commit"
+}
+
+function tag_release_commit() {
+  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
+  echo "Created annotated tag"
 }
 
 echo "Start deploying version ${VERSION_TYPE}…"
@@ -27,6 +48,9 @@ clone_repository_and_move_inside
 configure_git_user_information
 install_required_packages
 create_release
+complete_change_log
+create_a_release_commit
+tag_release_commit
 push_commit_and_tag_to_remote_dev
 
 echo -e "Release publication for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} ${GREEN}succeeded${RESET_COLOR} (${VERSION_TYPE})."

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -16,12 +16,6 @@ function install_required_packages {
   npm ci --dev --no-optional
 }
 
-function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
-
-  echo "Updated CHANGELOG.md"
-}
-
 function create_release {
   npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
   npm version ${npm_arg} --no-git-tag-version
@@ -35,11 +29,6 @@ function create_a_release_commit() {
   git commit --message "[RELEASE] A ${VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."
 
   echo "Created the release commit"
-}
-
-function tag_release_commit() {
-  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
-  echo "Created annotated tag"
 }
 
 echo "Start deploying version ${VERSION_TYPE}…"

--- a/test/get-pull-requests-to-release-in-prod_test.js
+++ b/test/get-pull-requests-to-release-in-prod_test.js
@@ -136,26 +136,29 @@ describe('Unit | Script | GET Pull Request to release in Prod', () => {
   });
 
   describe('getLastMEPDate', () => {
+    const repoOwner = '1024pix';
+    const repoName = 'pix';
+
     beforeEach(() => {
       const axiosStub = sinon.stub(axios, 'get');
-      
-      axiosStub.withArgs('https://api.github.com/repos/1024pix/pix/tags')
+
+      axiosStub.withArgs(`https://api.github.com/repos/${repoOwner}/${repoName}/tags`)
         .resolves({ 
           data: [
             {
               'name': 'v2.173.0',
-              'zipball_url': 'https://api.github.com/repos/1024pix/pix/zipball/v2.173.0',
-              'tarball_url': 'https://api.github.com/repos/1024pix/pix/tarball/v2.173.0',
+              'zipball_url': `https://api.github.com/repos/${repoOwner}/${repoName}/zipball/v2.173.0`,
+              'tarball_url': `https://api.github.com/repos/${repoOwner}/${repoName}/tarball/v2.173.0`,
               'commit': {
                 'sha': '4c3ad3d377c37023e835ad674578cf06fcb4de7a',
-                'url': 'https://api.github.com/repos/1024pix/pix/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a'
+                'url': `https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`
               },
               'node_id': 'MDM6UmVmMTI2ODUyMzMxOnJlZnMvdGFncy92Mi4xNzMuMA=='
             },
           ]
         });
       
-      axiosStub.withArgs('https://api.github.com/repos/1024pix/pix/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a')
+      axiosStub.withArgs(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`)
         .resolves({ 
           data: {
             'commit': {
@@ -168,11 +171,12 @@ describe('Unit | Script | GET Pull Request to release in Prod', () => {
           }
         });
     });
+    
     it('should return the date of the last MEP commit', async () => {
       // given
       const expectedDate = '2019-01-18T15:29:51Z';
       // when
-      const date = await getLastMEPDate();
+      const date = await getLastMEPDate(repoOwner, repoName);
       // then
       expect(date).to.be.equal(expectedDate);
     });

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -57,7 +57,7 @@ describe('releases', function() {
       await releasesService.releaseAndDeployPixPro();
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh 1024pix pix-pro)')));
+      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh github-owner pix-pro)')));
     });
 
     it('should call the release pix pro script with \'minor\'', async function () {
@@ -65,7 +65,7 @@ describe('releases', function() {
       await releasesService.releaseAndDeployPixPro('minor');
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh 1024pix pix-pro minor)')));
+      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh github-owner pix-pro minor)')));
     });
   });
 });

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -27,10 +27,10 @@ describe('releases', function() {
     });
   });
 
-  describe('#publishPixSite', async function () {
+  describe('#publishPixRepo', async function () {
     it('should call the release pix pro script with \'minor\'', async function () {
       //when
-      await releasesService.publishPixSite('pix-site-pro', 'minor');
+      await releasesService.publishPixRepo('pix-site-pro', 'minor');
 
       // then
       sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh) github-owner pix-site-pro minor$')));
@@ -99,5 +99,26 @@ describe('#deploy', async function () {
     } catch (e) {
       expect(e.message).to.equal('KO');
     }
+  });
+
+  describe('#deployPixUI', async function () {
+    let exec, releasesService;
+
+    before(() => {
+      exec = sinon.stub().callsFake(async () => Promise.resolve({stdout: '', stderr: ''}));
+      releasesService = proxyquire('../../../lib/services/releases', {
+        'child_process': {exec},
+        util: {promisify: fn => fn}
+      });
+    });
+
+    it('should call the deploy Pix-UI script with default', async function () {
+      //when
+      await releasesService.deployPixUI('pix-ui');
+
+      // then
+      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/deploy-pix-ui.sh)')));
+    });
+
   });
 });

--- a/test/unit/services/slack/commands_test.js
+++ b/test/unit/services/slack/commands_test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require('mocha');
 const axios = require('axios');
 const { sinon } = require('../../test-helper');
-const { createAndDeployPixSiteRelease, createAndDeployPixProRelease } = require('../../../../lib/services/slack/commands');
+const { createAndDeployPixSiteRelease, createAndDeployPixProRelease, createAndDeployPixUI } = require('../../../../lib/services/slack/commands');
 const releasesServices = require('../../../../lib/services/releases');
 const githubServices = require('../../../../lib/services/github');
 
@@ -9,8 +9,9 @@ describe('Services | Slack | Commands', () => {
   beforeEach(() => {
     // given
     sinon.stub(axios, 'post');
-    sinon.stub(releasesServices, 'publishPixSite').resolves();
+    sinon.stub(releasesServices, 'publishPixRepo').resolves();
     sinon.stub(releasesServices, 'deployPixSite').resolves();
+    sinon.stub(releasesServices, 'deployPixUI').resolves();
     sinon.stub(githubServices, 'getLatestReleaseTag').resolves('v1.0.0');
   });
 
@@ -25,7 +26,7 @@ describe('Services | Slack | Commands', () => {
 
       it('should publish a new release', () => {
         // then
-        sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site', 'minor');
+        sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site', 'minor');
       });
 
       it('should retrieve the last release tag from GitHub', () => {
@@ -46,7 +47,7 @@ describe('Services | Slack | Commands', () => {
         // when
         await createAndDeployPixSiteRelease(payload);
         // then
-        sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site', 'minor');
+        sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site', 'minor');
       });
     });
 
@@ -62,7 +63,7 @@ describe('Services | Slack | Commands', () => {
 
     it('should publish a new release', () => {
       // then
-      sinon.assert.calledWith(releasesServices.publishPixSite, 'pix-site-pro', 'minor');
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site-pro', 'minor');
     });
 
     it('should retrieve the last release tag from GitHub', () => {
@@ -73,6 +74,30 @@ describe('Services | Slack | Commands', () => {
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixSite, 'pix-site-pro', 'pix-pro', 'v1.0.0');
+    });
+  });
+
+  describe('#createAndDeployPixUI', () => {
+    beforeEach(async () => {
+      // given
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixUI(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-ui', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', () => {
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-ui');
+    });
+
+    it('should deploy the release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.deployPixUI);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les déploiements de nouvelles versions d'applis se font via Slack.
Il y manque le déploiement de pix-ui.

## :robot: Solution
- Créer le script de déploiement de pix-ui `deploy-pix-ui.sh`
- Créer la commande Slack qui appelera ce script

## :rainbow: Remarques
- Réutilisation du script de release de pix-site `release-pix-repo.sh` + ajout de l'écriture de changelog dans ce script

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._