### PR TITLE
[FEATURE] Ajout du déploiement de l'API LCMS.

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -47,6 +47,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixLCMSRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixLCMS(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX LCMS')
+    };
+  },
+
   interactiveEndpoint(request) {
     const payload = request.pre.payload;
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -38,6 +38,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-lcms-release',
+    handler: slackbotController.createAndDeployPixLCMSRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
     config: slackConfig

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,8 +11,8 @@ const server = Hapi.server({
 });
 
 const routesDir = path.join(__dirname, 'routes');
-require('fs').readdirSync(routesDir).forEach((file) => {
-  server.route(require(path.join(routesDir, file)));
-});
+require('fs').readdirSync(routesDir)
+  .filter((file) => path.extname(file) === '.js')
+  .forEach((file) => server.route(require(path.join(routesDir, file))));
 
 module.exports = server;

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -50,10 +50,10 @@ function createResponseForSlack(pullRequests, label) {
   return resp;
 }
 
-async function getLatestRelease(repo) {
+async function getLatestRelease(repoOwner, repo) {
   const octokit = new Octokit({ auth: settings.github.token });
   const latestReleases = await octokit.repos.listTags({
-    owner: settings.github.owner,
+    owner: repoOwner,
     repo,
   });
   return latestReleases.data[0];
@@ -67,12 +67,12 @@ module.exports = {
   },
 
   async getLatestReleaseTag(repo = settings.github.repository) {
-    const latestReleaseTag = await getLatestRelease(repo);
+    const latestReleaseTag = await getLatestRelease(settings.github.owner, repo);
     return latestReleaseTag.name;
   },
 
-  async getLatestReleaseTagUrl(repo = settings.github.repository) {
-    const latestReleaseTag = await getLatestRelease(repo);
+  async getLatestReleaseTagUrl(repoOwner, repo = settings.github.repository) {
+    const latestReleaseTag = await getLatestRelease(repoOwner, repo);
     return latestReleaseTag.commit.url;
   },
 

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -1,4 +1,4 @@
-const { Octokit } = require('@octokit/core');
+const { Octokit } = require('@octokit/rest');
 const axios = require('axios');
 const settings = require('../config');
 
@@ -50,6 +50,15 @@ function createResponseForSlack(pullRequests, label) {
   return resp;
 }
 
+async function getLatestRelease(repo) {
+  const octokit = new Octokit({ auth: settings.github.token });
+  const latestReleases = await octokit.repos.listTags({
+    owner: settings.github.owner,
+    repo,
+  });
+  return latestReleases.data[0];
+}
+
 module.exports = {
 
   async getPullRequests(label) {
@@ -58,11 +67,31 @@ module.exports = {
   },
 
   async getLatestReleaseTag(repo = settings.github.repository) {
-    const octokit = new Octokit({ auth: settings.github.token });
-    const latestReleases = await octokit.request('/repos/{owner}/{repo}/tags', {
-      owner: settings.github.owner,
-      repo,
-    });
-    return latestReleases.data[0].name;
+    const latestReleaseTag = await getLatestRelease(repo);
+    return latestReleaseTag.name;
   },
+
+  async getLatestReleaseTagUrl(repo = settings.github.repository) {
+    const latestReleaseTag = await getLatestRelease(repo);
+    return latestReleaseTag.commit.url;
+  },
+
+  async getCommitAtURL(commitUrl) {
+    const octokit = new Octokit({ auth: settings.github.token });
+    const { data } = await octokit.request(commitUrl);
+    return data;
+  },
+
+  async getMergedPullRequestsSortedByDescendingDate(owner, repo) {
+    const octokit = new Octokit({ auth: settings.github.token });
+    const { data } = await octokit.pulls.list({
+      owner,
+      repo,
+      state: 'closed',
+      sort: 'updated',
+      direction: 'desc'
+    });
+    return data;
+  }
+
 };

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -51,8 +51,8 @@ function createResponseForSlack(pullRequests, label) {
 }
 
 async function getLatestRelease(repoOwner, repo) {
-  const octokit = new Octokit({ auth: settings.github.token });
-  const latestReleases = await octokit.repos.listTags({
+  const { repos } = new Octokit({ auth: settings.github.token });
+  const latestReleases = await repos.listTags({
     owner: repoOwner,
     repo,
   });
@@ -77,14 +77,14 @@ module.exports = {
   },
 
   async getCommitAtURL(commitUrl) {
-    const octokit = new Octokit({ auth: settings.github.token });
-    const { data } = await octokit.request(commitUrl);
+    const { request } = new Octokit({ auth: settings.github.token });
+    const { data } = await request(commitUrl);
     return data;
   },
 
   async getMergedPullRequestsSortedByDescendingDate(owner, repo) {
-    const octokit = new Octokit({ auth: settings.github.token });
-    const { data } = await octokit.pulls.list({
+    const { pulls } = new Octokit({ auth: settings.github.token });
+    const { data } = await pulls.list({
       owner,
       repo,
       state: 'closed',

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -48,7 +48,7 @@ module.exports = {
     }
   },
 
-  async deployPixSite(repoName, appName, releaseTag) {
+  async deployPixRepo(repoName, appName, releaseTag) {
     const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
     const sanitizedRepoName = _sanitizedArgument(repoName);
     const sanitizedAppName = _sanitizedArgument(appName);

--- a/lib/services/scalingo-client.js
+++ b/lib/services/scalingo-client.js
@@ -29,7 +29,7 @@ class ScalingoClient {
         {
           deployment: {
             git_ref: releaseTag,
-            source_url: `https://github.com/${config.github.owner}/${repository}/archive/${releaseTag}.tar.gz`
+            source_url: `https://${config.github.token}@github.com/${config.github.owner}/${repository}/archive/${releaseTag}.tar.gz`
           }
         });
     } catch (e) {

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -8,6 +8,8 @@ const PIX_SITE_REPO_NAME = 'pix-site';
 const PIX_PRO_APP_NAME = 'pix-pro';
 const PIX_PRO_REPO_NAME = 'pix-site-pro';
 const PIX_UI_REPO_NAME = 'pix-ui';
+const PIX_LCMS_REPO_NAME = 'pix-editor';
+const PIX_LCMS_APP_NAME = 'pix-lcms-api';
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,
@@ -38,7 +40,7 @@ async function publishAndDeployRelease(repoName, appName, releaseType, responseU
   }
   await releasesService.publishPixRepo(repoName, releaseType);
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
-  await releasesService.deployPixSite(repoName, appName, releaseTag);
+  await releasesService.deployPixRepo(repoName, appName, releaseTag);
 
   sendResponse(responseUrl, getSuccessMessage(releaseTag, appName));
 }
@@ -71,6 +73,10 @@ module.exports = {
 
   async createAndDeployPixUI(payload) {
     await publishAndDeployPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
+  },
+
+  async createAndDeployPixLCMS(payload) {
+    await publishAndDeployRelease(PIX_LCMS_REPO_NAME, PIX_LCMS_APP_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixBotTestRelease(payload) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,6 +367,48 @@
         "universal-user-agent": "^6.0.0"
       }
     },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.2.tgz",
+      "integrity": "sha512-PjHbMhKryxClCrmfvRpGaKCTxUcHIf2zirWRV9SMGf0EmxD/rFew/abSqbMiLl9uQgRZvqtTyCRMGMlUv1ZsBg==",
+      "requires": {
+        "@octokit/types": "^5.3.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+          "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.4.tgz",
+      "integrity": "sha512-Y2tVpSa7HjV3DGIQrQOJcReJ2JtcN9FaGr9jDa332Flro923/h3/Iu9e7Y4GilnzfLclHEh5iCQoCkHm7tWOcg==",
+      "requires": {
+        "@octokit/types": "^5.4.1",
+        "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+          "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
     "@octokit/request": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.6.tgz",
@@ -390,6 +432,17 @@
         "@octokit/types": "^5.0.1",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.5.tgz",
+      "integrity": "sha512-SPKI24tQXrr1XsnaIjv2x0rl4M5eF1+hj8+vMe3d/exZ7NnL5sTe1BuFyCyJyrc+j1HkXankvgGN9zT0rwBwtg==",
+      "requires": {
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "4.1.4"
       }
     },
     "@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@hapi/hapi": "^19.1.1",
     "@octokit/core": "^3.1.1",
+    "@octokit/rest": "18.0.5",
     "@sentry/cli": "^1.55.0",
     "axios": "^0.19.2",
     "crypto": "^1.0.1",

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -8,7 +8,7 @@ const CHANGELOG_FILE = 'CHANGELOG.md';
 const CHANGELOG_HEADER_LINES = 2;
 
 async function getLastMEPDate(repoOwner, repoName) {
-  const latestTagUrl = await github.getLatestReleaseTagUrl(repoName);
+  const latestTagUrl = await github.getLatestReleaseTagUrl(repoOwner, repoName);
 
   const commit = await github.getCommitAtURL(latestTagUrl);
   return commit.committer.date;

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -11,20 +11,24 @@ VERSION_TYPE=(${3-""})
 
 echo "Version type ${VERSION_TYPE} for ${GITHUB_OWNER}/${GITHUB_REPOSITORY}"
 
+function executeCommandRecursivelyInPackageJsonDir {
+  find . -name package.json -type f ! -path '*/node_modules/*' -execdir ${1} \;
+}
+
 function install_required_packages {
   echo "Install packages"
-  find . -name package.json -type f ! -path '*/node_modules/*' -execdir npm ci --dev --no-optional \;
+  executeCommandRecursivelyInPackageJsonDir "npm ci --dev --no-optional"
 }
 
 function create_release {
   npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
-  find . -name package.json -type f ! -path '*/node_modules/*' -execdir npm version ${npm_arg} --no-git-tag-version \;
+  executeCommandRecursivelyInPackageJsonDir "npm version ${npm_arg} --no-git-tag-version"
   NEW_PACKAGE_VERSION=$(get_package_version)
 }
 
-function create_a_release_commit() {
+function create_a_release_commit {
   git add  --update CHANGELOG.md
-  find . -name package.json -type f ! -path '*/node_modules/*' -execdir git add --update package*.json \;
+  executeCommandRecursivelyInPackageJsonDir "git add --update package*.json"
 
   git commit --message "[RELEASE] A ${VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."
 

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -13,18 +13,18 @@ echo "Version type ${VERSION_TYPE} for ${GITHUB_OWNER}/${GITHUB_REPOSITORY}"
 
 function install_required_packages {
   echo "Install packages"
-  npm ci --dev --no-optional
+  find . -name package.json -type f ! -path '*/node_modules/*' -execdir npm ci --dev --no-optional \;
 }
 
 function create_release {
   npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
-  npm version ${npm_arg} --no-git-tag-version
+  find . -name package.json -type f ! -path '*/node_modules/*' -execdir npm version ${npm_arg} --no-git-tag-version \;
   NEW_PACKAGE_VERSION=$(get_package_version)
 }
 
 function create_a_release_commit() {
   git add  --update CHANGELOG.md
-  git add  --update package*.json
+  find . -name package.json -type f ! -path '*/node_modules/*' -execdir git add --update package*.json \;
 
   git commit --message "[RELEASE] A ${VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."
 

--- a/test/get-pull-requests-to-release-in-prod_test.js
+++ b/test/get-pull-requests-to-release-in-prod_test.js
@@ -110,7 +110,7 @@ describe('Unit | Script | GET Pull Request to release in Prod', () => {
 
     beforeEach(() => {
       sinon.stub(github, 'getLatestReleaseTagUrl')
-        .withArgs(repoName)
+        .withArgs(repoOwner, repoName)
         .resolves(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`);
 
       sinon.stub(github, 'getCommitAtURL')

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -79,3 +79,45 @@ describe('#getLatestReleaseTag', () => {
   });
 
 });
+
+
+describe('#getMergedPullRequestsSortedByDescendingDate', () => {
+
+  it('should call GitHub "Pulls" API', async () => {
+    // given
+    const pullRequests = [
+      { merged_at: '2020-09-02T12:26:47Z' },
+      { merged_at: '2020-09-01T12:26:47Z' }
+    ];
+    nock('https://api.github.com')
+      .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc')
+      .reply(200, pullRequests);
+
+    // when
+    const response = await githubService.getMergedPullRequestsSortedByDescendingDate('github-owner', 'github-repository');
+
+    // then
+    expect(response).to.deep.equal(pullRequests);
+  });
+
+});
+
+describe('#getCommitAtURL', () => {
+
+  it('should call Github "Request" API', async () => {
+    // given
+    nock('https://commit-url.github.com')
+      .get('/')
+      .reply(200, {
+        commit: 'some data'
+      });
+
+    // when
+    const response = await githubService.getCommitAtURL('https://commit-url.github.com');
+
+    // then
+    expect(response).to.deep.equal({ commit: 'some data' });
+
+  });
+});
+

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -37,7 +37,7 @@ describe('releases', function() {
     });
   });
 
-  describe('#deployPixSite', async function() {
+  describe('#deployPixRepo', async function() {
     it('should deploy the pix site pro', async function() {
       // given
       const scalingoClient = new ScalingoClient(null, 'production');
@@ -45,7 +45,7 @@ describe('releases', function() {
       scalingoClient.deployFromArchive.withArgs('app-name', 'v1.0.0', 'pix-site-pro').resolves('OK');
       sinon.stub(ScalingoClient, 'getInstance').resolves(scalingoClient);
       // when
-      const response = await releasesService.deployPixSite('Pix-Site-Pro', 'app-name', 'V1.0.0 ');
+      const response = await releasesService.deployPixRepo('Pix-Site-Pro', 'app-name', 'V1.0.0 ');
       // then
       expect(response).to.equal('OK');
     });

--- a/test/unit/services/scalingo-client_test.js
+++ b/test/unit/services/scalingo-client_test.js
@@ -1,5 +1,5 @@
 const { describe, it } = require('mocha');
-const sinon = require('sinon');
+const { sinon } = require('../test-helper');
 const scalingo = require('scalingo');
 
 const ScalingoClient = require('../../../lib/services/scalingo-client');
@@ -88,7 +88,7 @@ describe('Scalingo client', () => {
         {
           deployment: {
             git_ref: 'v1.0',
-            source_url: 'https://github.com/github-owner/github-repository/archive/v1.0.tar.gz'
+            source_url: 'https://github-personal-access-token@github.com/github-owner/github-repository/archive/v1.0.tar.gz'
           },
         }
       );
@@ -106,7 +106,7 @@ describe('Scalingo client', () => {
         {
           deployment: {
             git_ref: 'v1.0',
-            source_url: 'https://github.com/github-owner/given-repository/archive/v1.0.tar.gz'
+            source_url: 'https://github-personal-access-token@github.com/github-owner/given-repository/archive/v1.0.tar.gz'
           },
         }
       );

--- a/test/unit/services/slack/commands_test.js
+++ b/test/unit/services/slack/commands_test.js
@@ -1,7 +1,12 @@
 const { describe, it } = require('mocha');
 const axios = require('axios');
 const { sinon } = require('../../test-helper');
-const { createAndDeployPixSiteRelease, createAndDeployPixProRelease, createAndDeployPixUI } = require('../../../../lib/services/slack/commands');
+const {
+  createAndDeployPixSiteRelease,
+  createAndDeployPixProRelease,
+  createAndDeployPixUI,
+  createAndDeployPixLCMS
+} = require('../../../../lib/services/slack/commands');
 const releasesServices = require('../../../../lib/services/releases');
 const githubServices = require('../../../../lib/services/github');
 
@@ -10,7 +15,7 @@ describe('Services | Slack | Commands', () => {
     // given
     sinon.stub(axios, 'post');
     sinon.stub(releasesServices, 'publishPixRepo').resolves();
-    sinon.stub(releasesServices, 'deployPixSite').resolves();
+    sinon.stub(releasesServices, 'deployPixRepo').resolves();
     sinon.stub(releasesServices, 'deployPixUI').resolves();
     sinon.stub(githubServices, 'getLatestReleaseTag').resolves('v1.0.0');
   });
@@ -36,7 +41,7 @@ describe('Services | Slack | Commands', () => {
 
       it('should deploy the release', () => {
         // then
-        sinon.assert.calledWith(releasesServices.deployPixSite, 'pix-site', 'pix-site', 'v1.0.0');
+        sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-site', 'v1.0.0');
       });
     });
 
@@ -73,7 +78,7 @@ describe('Services | Slack | Commands', () => {
 
     it('should deploy the release', () => {
       // then
-      sinon.assert.calledWith(releasesServices.deployPixSite, 'pix-site-pro', 'pix-pro', 'v1.0.0');
+      sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site-pro', 'pix-pro', 'v1.0.0');
     });
   });
 
@@ -98,6 +103,30 @@ describe('Services | Slack | Commands', () => {
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixUI);
+    });
+  });
+
+  describe('#createAndDeployPixLCMS', () => {
+    beforeEach(async () => {
+      // given
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixLCMS(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-editor', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', () => {
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-editor');
+    });
+
+    it('should deploy the release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.deployPixRepo);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La nouvelle API LCMS (Learning Content Management System) ne peut être déployée automatiquement par qui que ce soit.
Seul un·e développeu·r·se peut le faire via le client Scalingo en local.

## :robot: Solution
Adapter le fonctionnement du déploiement des sites `pix.fr` et `pro.pix.fr` pour offrir une commande slack `/deploy-pix-lcms` qui crée la release et la déploie en production.

## :rainbow: Remarques
Il n'existe pas d'environnement de recette pour le moment pour cette application.

## :100: Pour tester
En local, appeler la route `POST /slack/commands/create-and-deploy-pix-lcms-release`.
Le body de la requête doit contenir les champs suivants : 

- "text": "patch | minor | major", 
- "response_url": "<url pour la réponse à slack, pour le test on peut mettre> https://httpbin.org/status/200"