### PR TITLE
[BUGFIX] Correction du script de publication d'une nouvelle release.

### DIFF
--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -79,7 +79,7 @@ module.exports = {
   async getCommitAtURL(commitUrl) {
     const { request } = new Octokit({ auth: settings.github.token });
     const { data } = await request(commitUrl);
-    return data;
+    return data.commit;
   },
 
   async getMergedPullRequestsSortedByDescendingDate(owner, repo) {

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -116,7 +116,7 @@ describe('#getCommitAtURL', () => {
     const response = await githubService.getCommitAtURL('https://commit-url.github.com');
 
     // then
-    expect(response).to.deep.equal({ commit: 'some data' });
+    expect(response).to.deep.equal('some data');
 
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Suite au merge de la PR #30 la procédure de release pour les applications Pix (Pix API, Pix App, etc.) ne fonctionne plus.

## :robot: Solution

Le problème venait d'un mauvais mapping de la réponse d'une requête à l'API GitHub via Octokit.

## :rainbow: Remarques

## :100: Pour tester

