### PR TITLE
[BUGFIX] Corrige la création du fichier `CHANGELOG.md` s'il n'existe pas.

### DIFF
--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -62,6 +62,7 @@ async function main() {
       currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
     } catch(error) {
       console.log('Changelog file does not exist. It will be created.');
+      currentChangeLog = [`# ${repoName} Changelog\n`, '\n'];
     }
 
     currentChangeLog.splice(CHANGELOG_HEADER_LINES, 0, ...newChangeLogLines);

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -27,7 +27,7 @@ function create_release {
 }
 
 function create_a_release_commit {
-  git add  --update CHANGELOG.md
+  git add CHANGELOG.md
   executeCommandRecursivelyInPackageJsonDir "git add --update package*.json"
 
   git commit --message "[RELEASE] A ${VERSION_TYPE} is being released to ${NEW_PACKAGE_VERSION}."


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création d'une release, on essaie de mettre à jour le `CHANGELOG.md`.
S'il n'existe pas, on l'initialiser avec une chaine vide.
Cela ne fonctionne pas car le script s'attend à avoir un fichier contenant a minima l'entete (2 lignes).
En échouant cette mise à jour, cela met également en échec le processus de release.

## :robot: Solution
Initialisation du fichier `CHANGELOG.md` avec l'entete si le fichier n'existe pas.

## :rainbow: Remarques
Il faut enlever l'option `--update` du `git add` pour ce fichier sinon il n'ajoute pas de nouveau fichier.

## :100: Pour tester
Lancer le script `get-pull-requests-to-release-in-prod` sur un repo ne contenant pas de CHANGELOG.
Vérifier que le CHANGELOG a bien été créé.