### PR TITLE
[FEATURE] Deployer pix-site et pix-pro désormais dans le même repo (PIX-1266)

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -16,7 +16,7 @@ module.exports = {
     commands.createAndDeployPixSiteRelease(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX site')
+      'text': _getDeployStartedMessage(payload.text, 'PIX site and pro')
     };
   },
 

--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -20,15 +20,6 @@ module.exports = {
     };
   },
 
-  createAndDeployPixProRelease(request) {
-    const payload = request.pre.payload;
-    commands.createAndDeployPixProRelease(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX pro')
-    };
-  },
-
   createAndDeployPixBotTestRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixBotTestRelease(payload);

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -20,12 +20,6 @@ module.exports = [
   },
   {
     method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-pro-release',
-    handler: slackbotController.createAndDeployPixProRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
     path: '/slack/commands/create-and-deploy-pix-bot-test-release',
     handler: slackbotController.createAndDeployPixBotTestRelease,
     config: slackConfig

--- a/lib/services/releases.js
+++ b/lib/services/releases.js
@@ -62,16 +62,6 @@ module.exports = {
     await _runScriptWithArgument(DEPLOY_PIX_UI_SCRIPT, ...args);
   },
 
-  async releaseAndDeployPixPro(versionType) {
-    try {
-      const releaseType = _sanitizedArgument(versionType);
-      const args = [config.github.owner, 'pix-pro', releaseType];
-      await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
-    } catch (err) {
-      console.error(err);
-    }
-  },
-
   async releaseAndDeployPixBotTest(versionType) {
     try {
       const releaseType = _sanitizedArgument(versionType);

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -5,8 +5,6 @@ const axios = require('axios');
 
 const PIX_SITE_APP_NAME = 'pix-site';
 const PIX_SITE_REPO_NAME = 'pix-site';
-const PIX_PRO_APP_NAME = 'pix-pro';
-const PIX_PRO_REPO_NAME = 'pix-site-pro';
 const PIX_UI_REPO_NAME = 'pix-ui';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
 const PIX_LCMS_APP_NAME = 'pix-lcms-api';
@@ -65,10 +63,6 @@ module.exports = {
 
   async createAndDeployPixSiteRelease(payload) {
     await publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APP_NAME, payload.text, payload.response_url);
-  },
-
-  async createAndDeployPixProRelease(payload) {
-    await publishAndDeployRelease(PIX_PRO_REPO_NAME, PIX_PRO_APP_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixUI(payload) {

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -3,8 +3,8 @@ const releasesService = require('../releases');
 const githubServices = require('../github');
 const axios = require('axios');
 
-const PIX_SITE_APP_NAME = 'pix-site';
 const PIX_SITE_REPO_NAME = 'pix-site';
+const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
 const PIX_UI_REPO_NAME = 'pix-ui';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
 const PIX_LCMS_APP_NAME = 'pix-lcms-api';
@@ -32,15 +32,16 @@ function _isReleaseTypeInvalid(releaseType) {
   return !['major', 'minor', 'patch'].includes(releaseType);
 }
 
-async function publishAndDeployRelease(repoName, appName, releaseType, responseUrl) {
+async function publishAndDeployRelease(repoName, appNamesList = [], releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
   await releasesService.publishPixRepo(repoName, releaseType);
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
-  await releasesService.deployPixRepo(repoName, appName, releaseTag);
 
-  sendResponse(responseUrl, getSuccessMessage(releaseTag, appName));
+  await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag)));
+
+  sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
 }
 
 async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
@@ -62,7 +63,7 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
 module.exports = {
 
   async createAndDeployPixSiteRelease(payload) {
-    await publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APP_NAME, payload.text, payload.response_url);
+    await publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APPS, payload.text, payload.response_url);
   },
 
   async createAndDeployPixUI(payload) {
@@ -70,7 +71,7 @@ module.exports = {
   },
 
   async createAndDeployPixLCMS(payload) {
-    await publishAndDeployRelease(PIX_LCMS_REPO_NAME, PIX_LCMS_APP_NAME, payload.text, payload.response_url);
+    await publishAndDeployRelease(PIX_LCMS_REPO_NAME, [PIX_LCMS_APP_NAME], payload.text, payload.response_url);
   },
 
   async createAndDeployPixBotTestRelease(payload) {

--- a/test/unit/services/releases_test.js
+++ b/test/unit/services/releases_test.js
@@ -28,44 +28,26 @@ describe('releases', function() {
   });
 
   describe('#publishPixRepo', async function () {
-    it('should call the release pix pro script with \'minor\'', async function () {
+    it('should call the release pix script with \'minor\'', async function () {
       //when
-      await releasesService.publishPixRepo('pix-site-pro', 'minor');
+      await releasesService.publishPixRepo('pix-site', 'minor');
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh) github-owner pix-site-pro minor$')));
+      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh) github-owner pix-site minor$')));
     });
   });
 
   describe('#deployPixRepo', async function() {
-    it('should deploy the pix site pro', async function() {
+    it('should deploy the pix site', async function() {
       // given
       const scalingoClient = new ScalingoClient(null, 'production');
       scalingoClient.deployFromArchive = sinon.stub();
-      scalingoClient.deployFromArchive.withArgs('app-name', 'v1.0.0', 'pix-site-pro').resolves('OK');
+      scalingoClient.deployFromArchive.withArgs('app-name', 'v1.0.0', 'pix-site').resolves('OK');
       sinon.stub(ScalingoClient, 'getInstance').resolves(scalingoClient);
       // when
-      const response = await releasesService.deployPixRepo('Pix-Site-Pro', 'app-name', 'V1.0.0 ');
+      const response = await releasesService.deployPixRepo('Pix-Site', 'app-name', 'V1.0.0 ');
       // then
       expect(response).to.equal('OK');
-    });
-  });
-
-  describe('#createAndDeployPro', async function () {
-    it('should call the release pix pro script with default', async function () {
-      //when
-      await releasesService.releaseAndDeployPixPro();
-
-      // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh github-owner pix-pro)')));
-    });
-
-    it('should call the release pix pro script with \'minor\'', async function () {
-      //when
-      await releasesService.releaseAndDeployPixPro('minor');
-
-      // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh github-owner pix-pro minor)')));
     });
   });
 });

--- a/test/unit/services/slack/commands_test.js
+++ b/test/unit/services/slack/commands_test.js
@@ -58,30 +58,6 @@ describe('Services | Slack | Commands', () => {
 
   });
 
-  describe('#createAndDeployPixProRelease', () => {
-    beforeEach(async () => {
-      // given
-      const payload = { text: 'minor' };
-      // when
-      await createAndDeployPixProRelease(payload);
-    });
-
-    it('should publish a new release', () => {
-      // then
-      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site-pro', 'minor');
-    });
-
-    it('should retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-site-pro');
-    });
-
-    it('should deploy the release', () => {
-      // then
-      sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site-pro', 'pix-pro', 'v1.0.0');
-    });
-  });
-
   describe('#createAndDeployPixUI', () => {
     beforeEach(async () => {
       // given

--- a/test/unit/services/slack/commands_test.js
+++ b/test/unit/services/slack/commands_test.js
@@ -3,7 +3,6 @@ const axios = require('axios');
 const { sinon } = require('../../test-helper');
 const {
   createAndDeployPixSiteRelease,
-  createAndDeployPixProRelease,
   createAndDeployPixUI,
   createAndDeployPixLCMS
 } = require('../../../../lib/services/slack/commands');
@@ -39,9 +38,10 @@ describe('Services | Slack | Commands', () => {
         sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-site');
       });
 
-      it('should deploy the release', () => {
+      it('should deploy the release for pix-site and pix-pro', () => {
         // then
         sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-site', 'v1.0.0');
+        sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-pro', 'v1.0.0');
       });
     });
 


### PR DESCRIPTION
**⚠️ Cette PR devra être mergée quand la migration pix-pro dans pix-site sera complètement terminée ⚠️** 

## :unicorn: Problème

Suite à la migration de pix-pro dans pix-site le processus de déploiement en production n'est plus le même. Avant cette migration pix-site et pix-pro étaient dans des repositories différents avec chacun sa commande slack dédiée pour être déployé.

Voici une schématisation du processus de déploiement actuel:
![image](https://user-images.githubusercontent.com/516360/94147036-0cf17180-fe75-11ea-8564-4dea80693221.png)

## :robot: Solution

Comme pix-site et pix-pro sont désormais sur le même repository, il n'y aura qu'une seule commande qui réalisera le déploiement des 2 sites. Et les 2 sites partageront le même tag déployé sur 2 instances (une pour pix-site et une pour pix-pro)

![image](https://user-images.githubusercontent.com/516360/94147076-1b3f8d80-fe75-11ea-8b73-4d80f0dd56fb.png)


## :rainbow: Remarques

- Il faudra supprimer la commande `/deploy-pix-pro` de Slack
- Cette PR devra être mergée quand la migration pix-pro dans pix-site sera terminée et ISO

## :100: Pour tester

RAF: Tests à réaliser sur le slack pix-bot-test