### PR TITLE
[BUGFIX] Correction du nom de l'application PIX LCMS.

### DIFF
--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -9,7 +9,7 @@ const PIX_PRO_APP_NAME = 'pix-pro';
 const PIX_PRO_REPO_NAME = 'pix-site-pro';
 const PIX_UI_REPO_NAME = 'pix-ui';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
-const PIX_LCMS_APP_NAME = 'pix-lcms-api';
+const PIX_LCMS_APP_NAME = 'pix-lcms';
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,


### PR DESCRIPTION
## :unicorn: Problème
L'application `pix-lcms-api-production` a été renommée en `pix-lcms-production` (sur Scalingo) car elle héberge à la fois l'api et le front (Pix Editor).
Comme le nom n'a pas été modifié dans pix bot, il n'est plus possible de déployer PIX LCMS.

## :robot: Solution
Modifier le nom de l'application utilisée par le bot pour déployer sur Scalingo.

## :rainbow: Remarques
RAS

## :100: Pour tester
Merger, déployer PIX LCMS depuis Slack, prier.