### PR TITLE
[TECH] Ajout de vérification CI avant MER/MEP

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -66,9 +66,8 @@ module.exports = {
     switch (interactionType) {
     case 'shortcut':
       if (payload.callback_id === 'publish-release') {
-        if(!github.isBuildStatusOK(releaseBranch)) {
-          postSlackMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
-          return null;
+        if(!github.isBuildStatusOK({ branchName: releaseBranch })) {
+          return this._interruptRelease();
         }
         shortcuts.openViewPublishReleaseTypeSelection(payload);
       }
@@ -105,6 +104,13 @@ module.exports = {
 
   async getAccessibilityTip() {
     return googleSheet.getA11YTip();
-  }
+  },
+
+  _interruptRelease() {
+    postSlackMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
+    return {
+      'response_action': 'clear'
+    };
+  },
 
 };

--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -3,7 +3,7 @@ const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
 const github = require('../services/github');
 const googleSheet = require('../services/google-sheet');
-
+const postSlackMessage = require('../services/slack/surfaces/messages/post-message');
 
 function _getDeployStartedMessage(release, appName) {
   return `Commande de déploiement de la release "${release}" pour ${appName} en production bien reçue.`;
@@ -61,9 +61,15 @@ module.exports = {
 
     const interactionType = payload.type;
 
+    const releaseBranch = 'dev';
+
     switch (interactionType) {
     case 'shortcut':
       if (payload.callback_id === 'publish-release') {
+        if(!github.isBuildStatusOK(releaseBranch)) {
+          postSlackMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
+          return null;
+        }
         shortcuts.openViewPublishReleaseTypeSelection(payload);
       }
       if (payload.callback_id === 'deploy-release') {

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -50,6 +50,13 @@ function createResponseForSlack(pullRequests, label) {
   return resp;
 }
 
+async function getLastCommitUrl({ branchName, tagName }) {
+  if (branchName) {
+    return await getBranchLastCommitUrl(branchName);
+  }
+  return getTagCommitUrl(tagName);
+}
+
 async function getBranchLastCommitUrl(branch) {
   const owner = settings.github.owner;
   const repo = settings.github.repository;
@@ -62,13 +69,26 @@ async function getBranchLastCommitUrl(branch) {
   return data.commit.url;
 }
 
+async function getTagCommitUrl(tagName) {
+  const owner = settings.github.owner;
+  const repo = settings.github.repository;
+  const tags = await getTags(owner, repo);
+  const tag = tags.find((tag) => tag.name === tagName);
+  return tag.commit.url;
+}
+
 async function getLatestRelease(repoOwner, repo) {
+  const tags = await getTags(repoOwner, repo);
+  return tags[0];
+}
+
+async function getTags(repoOwner, repo) {
   const { repos } = new Octokit({ auth: settings.github.token });
-  const latestReleases = await repos.listTags({
+  const { data } = await repos.listTags({
     owner: repoOwner,
     repo,
   });
-  return latestReleases.data[0];
+  return data;
 }
 
 module.exports = {
@@ -106,17 +126,14 @@ module.exports = {
     return data;
   },
 
-  async isBuildStatusOK(branchName) {
+  async isBuildStatusOK({ branchName, tagName }) {
     const githubCICheckName = 'build-test-and-deploy';
-    const commitUrl = await getBranchLastCommitUrl(branchName);
+    const commitUrl = await getLastCommitUrl({ branchName, tagName });
     const commitStatusUrl = commitUrl + '/check-runs';
     const octokit = new Octokit({ auth: settings.github.token });
     const { data } = await octokit.request(commitStatusUrl);
     const runs = data.check_runs;
-    const ciRuns = runs
-      .filter((run) => {
-        return run.name === githubCICheckName;
-      });
+    const ciRuns = runs.filter((run) => run.name === githubCICheckName);
     const buildStatusOk = ciRuns.every((run) => run.status === 'completed' && run.conclusion === 'success');
     return ciRuns.length > 0 && buildStatusOk;
   }

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -50,6 +50,18 @@ function createResponseForSlack(pullRequests, label) {
   return resp;
 }
 
+async function getBranchLastCommitUrl(branch) {
+  const owner = settings.github.owner;
+  const repo = settings.github.repository;
+  const octokit = new Octokit({ auth: settings.github.token });
+  const { data } = await octokit.repos.getBranch({
+    owner,
+    repo,
+    branch,
+  });
+  return data.commit.url;
+}
+
 async function getLatestRelease(repoOwner, repo) {
   const { repos } = new Octokit({ auth: settings.github.token });
   const latestReleases = await repos.listTags({
@@ -92,6 +104,21 @@ module.exports = {
       direction: 'desc'
     });
     return data;
+  },
+
+  async isBuildStatusOK(branchName) {
+    const githubCICheckName = 'build-test-and-deploy';
+    const commitUrl = await getBranchLastCommitUrl(branchName);
+    const commitStatusUrl = commitUrl + '/check-runs';
+    const octokit = new Octokit({ auth: settings.github.token });
+    const { data } = await octokit.request(commitStatusUrl);
+    const runs = data.check_runs;
+    const ciRuns = runs
+      .filter((run) => {
+        return run.name === githubCICheckName;
+      });
+    const buildStatusOk = ciRuns.every((run) => run.status === 'completed' && run.conclusion === 'success');
+    return ciRuns.length > 0 && buildStatusOk;
   }
 
 };

--- a/lib/services/slack/surfaces/messages/post-message.js
+++ b/lib/services/slack/surfaces/messages/post-message.js
@@ -1,0 +1,18 @@
+const axios = require('axios');
+const config = require('../../../../config');
+
+module.exports = (message) => {
+  const options = {
+    method: 'POST',
+    url: 'https://slack.com/api/chat.postMessage',
+    headers: {
+      'content-type': 'application/json',
+      'authorization': `Bearer ${config.slack.botToken}`
+    },
+    data: {
+      'channel': '#tech-release',
+      'text': message,
+    }
+  };
+  return axios(options);
+};

--- a/lib/services/slack/view-submissions.js
+++ b/lib/services/slack/view-submissions.js
@@ -1,5 +1,6 @@
 const openModalReleasePublicationConfirmation = require('./surfaces/modals/publish-release/release-publication-confirmation');
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
+const postSlackMessage = require('./surfaces/messages/post-message');
 const { environments, deploy, publish } = require('../releases');
 const githubService = require('../github');
 
@@ -36,7 +37,12 @@ module.exports = {
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
-    deploy(environments.production, releaseTag);
+    if(!githubService.isBuildStatusOK({ tagName: releaseTag.trim().toLowerCase() })) {
+      postSlackMessage('MEP bloquée. Etat de l‘environnement de recette à vérifier.');
+    }
+    else {
+      deploy(environments.production, releaseTag);
+    }
     return {
       'response_action': 'clear'
     };

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -121,3 +121,30 @@ describe('#getCommitAtURL', () => {
   });
 });
 
+describe('#isBuildStatusOK', () => {
+
+  it('should call Github "Request" API', async () => {
+    // given
+    const branchName = 'branch-name';
+    nock('https://api.github.com')
+      .get(`/repos/github-owner/github-repository/branches/${branchName}`)
+      .reply(200, {
+        commit: {
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/commitSHA1'
+        }
+      });
+    nock('https://api.github.com')
+      .get('/repos/github-owner/github-repository/commits/commitSHA1/check-runs')
+      .reply(200, {
+        'check_runs': [{ name: 'build-test-and-deploy', status: 'completed', conclusion: 'success' }]
+      });
+
+    // when
+    const response = await githubService.isBuildStatusOK(branchName);
+
+    // then
+    expect(response).to.equal(true);
+
+  });
+});
+


### PR DESCRIPTION
## :unicorn: Problème
Aucune vérification n'est faite sur l'environnement applicatif précédent avant une MER ou MEP.
Cette PR répond en partie à l'issue https://github.com/1024pix/pix-bot/issues/15

## :robot: Solution
Avant une MER, vérifier que la CI en intégration soit OK, sinon envoyer un message slack sur le channel tech-release.
Avant une MEP, vérifier que la CI en recette soit OK, sinon envoyer un message slack sur le channel tech-release.

## :rainbow: Remarques
API d'envoi de message d'erreur testé fonctionnellement.

## :100: Pour tester
Le channel #tmp-channel-test-pix-bot existe, si vous souhaitez checkout la branche. Dans ce cas, il faut penser à changer le nom du channel Slack dans le fichier `post-message.js`.