### PR TITLE
[BUGFIX] Fix typo dans le nom du channel Slack

### DIFF
--- a/lib/services/slack/surfaces/messages/post-message.js
+++ b/lib/services/slack/surfaces/messages/post-message.js
@@ -10,7 +10,7 @@ module.exports = (message) => {
       'authorization': `Bearer ${config.slack.botToken}`
     },
     data: {
-      'channel': '#tech-release',
+      'channel': '#tech-releases',
       'text': message,
     }
   };


### PR DESCRIPTION
## :unicorn: Problème
Il y a une typo dans le nom du channel Slack.

## :robot: Solution
Fix typo dans le nom du channel Slack
