### PR TITLE
[FEATURE] Display Pull-request labels on slack message

### DIFF
--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -33,20 +33,20 @@ async function getDataFromGithub(label) {
 }
 
 function createResponseForSlack(pullRequests, label) {
+  const attachments = pullRequests.map((prs) => ({
+    color: color[label],
+    pretext: '',
+    fields: [
+      { value: `<${prs.html_url}|${prs.title}>`, short: false },
+    ],
+  }));
+
   const resp = {
     response_type: 'in_channel',
     text: 'PRs à review pour ' + label,
-    attachments: []
+    attachments
   };
-  pullRequests.forEach((prs) => {
-    resp.attachments.push({
-      color: color[label],
-      pretext: '',
-      fields: [
-        { value: `<${prs.html_url}|${prs.title}>`, short: false },
-      ],
-    });
-  });
+
   return resp;
 }
 

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -32,22 +32,31 @@ async function getDataFromGithub(label) {
     });
 }
 
-function createResponseForSlack(pullRequests, label) {
-  const attachments = pullRequests.map((prs) => ({
-    color: color[label],
-    pretext: '',
-    fields: [
-      { value: `<${prs.html_url}|${prs.title}>`, short: false },
-    ],
-  }));
+function getEmojis(pullRequests) {
+  const labelsEmojis = pullRequests.labels.map(label => {
+    const match = label.name.match(/^:[A-z,_,-]*:/);
+    return match ? match[0] : '';
+  });
+  return labelsEmojis.filter(Boolean).join(' ');
+}
 
-  const resp = {
+function createResponseForSlack(pullRequests, label) {
+  const attachments = pullRequests.map((pullRequests) => {
+    const emojis = getEmojis(pullRequests);
+    return {
+      color: color[label],
+      pretext: '',
+      fields:[ {value: `${emojis}<${pullRequests.html_url}|${pullRequests.title}>`, short: false},],
+    };
+  }).sort().reverse();
+
+  const response = {
     response_type: 'in_channel',
     text: 'PRs à review pour ' + label,
     attachments
   };
 
-  return resp;
+  return response;
 }
 
 async function getLastCommitUrl({ branchName, tagName }) {

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -6,8 +6,8 @@ const githubService = require('../../../lib/services/github');
 
 describe('#getPullRequests', function() {
   const items = [
-    { html_url: 'http://test1.fr', title: 'PR1' },
-    { html_url: 'http://test2.fr', title: 'PR2' },
+    { html_url: 'http://test1.fr', title: 'PR1', labels: [ { name: 'team certif'} ]},
+    { html_url: 'http://test2.fr', title: 'PR2', labels: [ { name: ':construction: toto'}, { name: ':idea: team certif'}] },
   ];
   beforeEach(() => {
     sinon.stub(axios, 'get').resolves({ data: { items: items } });
@@ -19,8 +19,8 @@ describe('#getPullRequests', function() {
       response_type: 'in_channel',
       text: 'PRs à review pour team-certif',
       attachments: [
-        { color: '#B7CEF5', pretext: '', fields: [{ value: '<http://test1.fr|PR1>', short: false }] },
-        { color: '#B7CEF5', pretext: '', fields: [{ value: '<http://test2.fr|PR2>', short: false }] }
+        { color: '#B7CEF5', pretext: '', fields: [{ value: ':construction: :idea:<http://test2.fr|PR2>', short: false }] },
+        { color: '#B7CEF5', pretext: '', fields: [{ value: '<http://test1.fr|PR1>', short: false }] }
       ]
     };
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on récupère les PR ouvertes d'une équipe, on a pas d'information sur son statut

## :robot: Solution
Pour ne pas faire trop long, on récupère l'emoji lié au label:
🚧  => en cours de développement
👀   => review needed
🚀 => ready to merge

## :rainbow: Remarques
On pourrait ajouter un paramètre pour filtrer par type/label de PR

## :100: Pour tester
sur slack, lancer `/pr-pix team-certif` et voir le les icônes s'afficher

> 
> 👀 [TECH] Enlever les actions synchrones qui bloquent nodejs
> 🚧  [TECH] Renommer les routes api/jury en api/admin
> 🚀 [TECH] Ajout d'un script permettant de visualiser une certif VS le profil de positionnement