### PR TITLE
Spécifier la base branch pour générer le CHANGELOG (PIX-1417).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IDE
+**/.idea
+!.idea/runConfigurations/*.xml
+*.iml

--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -100,6 +100,14 @@ async function getTags(repoOwner, repo) {
   return data;
 }
 
+async function getDefaultBranch(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}`;
+  const { default_branch } = await axios.get(url)
+    .then(response => response.data)
+    .catch(error => console.log(error));
+  return default_branch;
+}
+
 module.exports = {
 
   async getPullRequests(label) {
@@ -124,10 +132,12 @@ module.exports = {
   },
 
   async getMergedPullRequestsSortedByDescendingDate(owner, repo) {
+    const defaultBranch = await getDefaultBranch(owner, repo);
     const { pulls } = new Octokit({ auth: settings.github.token });
     const { data } = await pulls.list({
       owner,
       repo,
+      base: defaultBranch,
       state: 'closed',
       sort: 'updated',
       direction: 'desc'

--- a/test/unit/services/github_test.js
+++ b/test/unit/services/github_test.js
@@ -90,7 +90,10 @@ describe('#getMergedPullRequestsSortedByDescendingDate', () => {
       { merged_at: '2020-09-01T12:26:47Z' }
     ];
     nock('https://api.github.com')
-      .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc')
+      .get('/repos/github-owner/github-repository')
+      .reply(200, { default_branch: 'dev' });
+    nock('https://api.github.com')
+      .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc&base=dev')
       .reply(200, pullRequests);
 
     // when


### PR DESCRIPTION
## :unicorn: Problème
Lorsque des branches filles sont mergées dans une branche mère, mais que celle-ci n'est pas la branche de base, leur merge apparaît quand même dans le changelog.
Exemple :
Une branche US1-part1 et une branche US1-part2 sont revue techniquement et mergées dans la branche mère US1. La branche mère n'est pas encore mergée dans la branch dev (branche de référence), et toujours soumise à revue fonctionnelle. Le merge de ces 2 branches filles apparaissent dans le changelog de la version, alors même que la fonctionnalité n'est pas incluse.

## :robot: Solution
Spécifier la base branche pour récupérer les PR mergées.

## :rainbow: Remarques
NA

## :100: Pour tester
?