### PR TITLE
[TECH] Création de la release de `pix-app` sur Sentry.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -79,6 +79,7 @@ function create_a_release_commit() {
 
 function publish_release_on_sentry() {
   npx sentry-cli releases -o pix new -p pix-api "v${NEW_PACKAGE_VERSION}"
+  npx sentry-cli releases -o pix new -p pix-app "v${NEW_PACKAGE_VERSION}"
   npx sentry-cli releases -o pix set-commits --commit "${GITHUB_OWNER}/${GITHUB_REPOSITORY}@v${NEW_PACKAGE_VERSION}" "v${NEW_PACKAGE_VERSION}"
   npx sentry-cli releases -o pix finalize "v${NEW_PACKAGE_VERSION}"
 


### PR DESCRIPTION
## :unicorn: Problème
La PR [https://github.com/1024pix/pix/pull/2038]() ajoute l'envoie des exceptions de `pix-app` vers Sentry.
Actuellement, la publication d'une release de pix ne créée pas de release Sentry pour `pix-app` et il est donc impossible d'utiliser Sentry pour détecter les commits introduisant de nouvelles exceptions.

## :robot: Solution
Ajout de la création de la release Sentry de `pix-app` lors de la création de la release de pix.

## :rainbow: Remarques
RAS

## :100: Pour tester
Après la publication d'une release, vérifier que les exceptions dans Sentry sur `pix-app` sont bien classées dans une release et que les commits associés sont disponibles.