### PR TITLE
[FEATURE] Ajout du déploiement automatique des sites statiques lors de la modification/création d'une page sur le CMS (Prismic).

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -61,8 +61,11 @@ module.exports = (function() {
 
     thirdServicesUsageReport: {
       schedule: process.env.THIRD_SERVICES_USAGE_REPORT_SCHEDULE,
-    }
+    },
 
+    prismic: {
+      secret: process.env.PRISMIC_SECRET,
+    },
   };
 
   if (process.env.NODE_ENV === 'test') {
@@ -78,6 +81,8 @@ module.exports = (function() {
     config.scalingo.production.apiUrl = 'https://scalingo.production';
 
     config.pixApps = ['pix-app1', 'pix-app2', 'pix-app3'];
+
+    config.prismic.secret = 'prismic-secret';
   }
 
   return config;

--- a/lib/controllers/deploy-sites.js
+++ b/lib/controllers/deploy-sites.js
@@ -1,0 +1,24 @@
+const githubServices = require('../services/github');
+const releasesService = require('../services/releases');
+const config = require('../config');
+const Boom = require('@hapi/boom');
+
+const PIX_SITE_REPO_NAME = 'pix-site';
+const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
+
+module.exports = {
+
+  async deploySites(request) {
+    const payload = request.payload;
+    if (payload.secret !== config.prismic.secret) {
+      throw Boom.unauthorized('Secret is missing or is incorrect');
+    }
+
+    const releaseTag = await githubServices.getLatestReleaseTag(PIX_SITE_REPO_NAME);
+    await Promise.all(PIX_SITE_APPS.map((appName) => releasesService.deployPixRepo(PIX_SITE_REPO_NAME, appName, releaseTag)));
+
+    return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
+  },
+
+};
+

--- a/lib/routes/deploy-sites.js
+++ b/lib/routes/deploy-sites.js
@@ -1,0 +1,10 @@
+const deploySitesController = require('../controllers/deploy-sites');
+
+module.exports = [
+  {
+    method: 'POST',
+    path: '/deploy-sites',
+    handler: deploySitesController.deploySites,
+  }
+];
+

--- a/sample.env
+++ b/sample.env
@@ -6,7 +6,7 @@
 #   2. edit the `.env` file with working values
 #   3. uncomment the lines to activate or configure associated features
 #
-# Sections (displayed in sorted in alphabtic order):
+# Sections (displayed in sorted alphabetic order):
 #   - Release management
 #   - Deployment management
 #   - Review apps management
@@ -122,6 +122,16 @@ SCALINGO_TOKEN_PRODUCTION=__CHANGE_ME__
 # type: String (URL)
 # default: "https://api.osc-secnum-fr1.scalingo.com"
 SCALINGO_API_URL_PRODUCTION=https://api.osc-secnum-fr1.scalingo.com
+
+
+# Prismic webhook secret
+#
+# If not present, deployments triggered by Prismic webhook will failed
+#
+# presence: required
+# type: String
+# default: none
+PRISMIC_SECRET=__CHANGE_ME__
 
 # ======================
 # REVIEW APPS MANAGEMENT


### PR DESCRIPTION
## :unicorn: Problème
Les sites pix.fr et pro.pix.fr migrent vers une architecture statique.
Ils ne feront donc plus d'appels au CMS pour récupérer les pages, cela rend donc obligatoire de reconstruire les sites pour publier de nouvelles pages.

## :robot: Solution
Prismic offre la possibilité de configurer un webhook lors de la modification / création d'une page.
En pratique, cela revient à configurer une url qui est appelée lors de ces événements. Prismic permet également d'ajouter un secret dans le corps de la requête pour authentifier l'appel.
On crée donc une route `POST /build-sites` qui récupère le nom de la dernière version en production et demande à Scalingo de la redéployer.

## :rainbow: Remarques
RAS

## :100: Pour tester
A définir