### PR TITLE
[TECH] Ajout d'un message d'information sur slack pour les déploiement de Pix-UI 

### DIFF
--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -2,6 +2,7 @@ const { releaseAndDeployPixBotTest } = require('../releases');
 const releasesService = require('../releases');
 const githubServices = require('../github');
 const axios = require('axios');
+const postSlackMessage = require('../../services/slack/surfaces/messages/post-message');
 
 const PIX_SITE_REPO_NAME = 'pix-site';
 const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
@@ -57,6 +58,7 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
     sendResponse(responseUrl, getErrorMessage(releaseTagAfterRelease, repoName));
   } else {
     sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
+    postSlackMessage(`[PIX-UI] App deployed (${releaseTagAfterRelease})`);
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Quand on lance un déploiement de Pix-UI sur slack via la commande `/publish-pix-ui [patch|minor|major]` Pix bot nous donne 2 retours mais via des messages privés (voir image ci-dessous). Et donc non visible de tous.
<img width="941" alt="image" src="https://user-images.githubusercontent.com/38167520/99282808-7ae26580-2834-11eb-8f21-2dd6d076c69c.png">
<img width="941" alt="image" src="https://user-images.githubusercontent.com/38167520/99282832-833aa080-2834-11eb-9c52-64d0a9e97fe6.png">

Cela peut devenir embêtant si on ne sait pas qui déploie une nouvelle version ni quand.

## :robot: Solution
Rajouter un message d'information sur slack visible pour tous, après un déploiement de pix-ui.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._