### PR TITLE
[BUGFIX] Corriger la récupération de la branche par défault des repos privés.

### DIFF
--- a/lib/services/github.js
+++ b/lib/services/github.js
@@ -101,11 +101,12 @@ async function getTags(repoOwner, repo) {
 }
 
 async function getDefaultBranch(owner, repo) {
-  const url = `https://api.github.com/repos/${owner}/${repo}`;
-  const { default_branch } = await axios.get(url)
-    .then(response => response.data)
-    .catch(error => console.log(error));
-  return default_branch;
+  const { repos } = new Octokit({ auth: settings.github.token });
+  const { data } = await repos.get({
+    owner,
+    repo,
+  });
+  return data.default_branch;
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-bot",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-bot",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Pix Bot application",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :unicorn: Problème
La PR #39 a ajouté la spécification de branche de base utilisée pour le CHANGELOG.
Malheureusement, la récupération de la branche par défaut est fait par un appel sans `credentials`, ce qui fonctionne pour la plupart des répos car ils sont publiques.
`pix-editor` en revanche est un repo privé et donc cet appel échoue et bloque la mise en production de l'application.

## :robot: Solution
Utiliser `Octokit`, le client node officiel de GitHub pour spécifier la clé d'API et ainsi pouvoir accéder aux données des repos privés.

## :rainbow: Remarques
Il faut privilégier l'utilisation d'Octokit plutôt que de faire des appels directement via `axios` ou autre paquet du même genre.

## :100: Pour tester
Lancer le script de computation du CHANGELOG sur pix-editor et vérifier que celui-ci se déroule sans erreur.