### PR TITLE
[Feature] Ajout d'une commande /deploy-pix-datawarehouse.

### DIFF
--- a/lib/controllers/slack.js
+++ b/lib/controllers/slack.js
@@ -47,6 +47,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixDatawarehouseRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixDatawarehouse(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX Datawarehouse')
+    };
+  },
+
   interactiveEndpoint(request) {
     const payload = request.pre.payload;
 

--- a/lib/routes/slack.js
+++ b/lib/routes/slack.js
@@ -50,6 +50,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
+    handler: slackbotController.createAndDeployPixDatawarehouseRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/commands/pull-requests',
     handler: slackbotController.getPullRequests,
     config: slackConfig

--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -9,6 +9,8 @@ const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
 const PIX_UI_REPO_NAME = 'pix-ui';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
 const PIX_LCMS_APP_NAME = 'pix-lcms';
+const PIX_DATAWAREHOUSE_REPO_NAME = 'pix-db-replication';
+const PIX_DATAWAREHOUSE_APPS_NAME = ['pix-datawarehouse', 'pix-datawarehouse-ex'];
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,
@@ -74,6 +76,10 @@ module.exports = {
 
   async createAndDeployPixLCMS(payload) {
     await publishAndDeployRelease(PIX_LCMS_REPO_NAME, [PIX_LCMS_APP_NAME], payload.text, payload.response_url);
+  },
+
+  async createAndDeployPixDatawarehouse(payload) {
+    await publishAndDeployRelease(PIX_DATAWAREHOUSE_REPO_NAME, PIX_DATAWAREHOUSE_APPS_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixBotTestRelease(payload) {

--- a/test/unit/lib/services/slack/commands_test.js
+++ b/test/unit/lib/services/slack/commands_test.js
@@ -4,7 +4,8 @@ const { sinon } = require('../../../test-helper');
 const {
   createAndDeployPixSiteRelease,
   createAndDeployPixUI,
-  createAndDeployPixLCMS
+  createAndDeployPixLCMS,
+  createAndDeployPixDatawarehouse,
 } = require('../../../../../lib/services/slack/commands');
 const releasesServices = require('../../../../../lib/services/releases');
 const githubServices = require('../../../../../lib/services/github');
@@ -98,6 +99,30 @@ describe('Services | Slack | Commands', () => {
     it('should retrieve the last release tag from GitHub', () => {
       // then
       sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-editor');
+    });
+
+    it('should deploy the release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.deployPixRepo);
+    });
+  });
+
+  describe('#createAndDeployPixDatawarehouse', () => {
+    beforeEach(async () => {
+      // given
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixDatawarehouse(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-replication', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', () => {
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-db-replication');
     });
 
     it('should deploy the release', () => {


### PR DESCRIPTION
## :unicorn: Problème
Les applications `pix-datawarehouse-production` et `pix-datawarehouse-ex-production` ne sont plus déployées automatiquement depuis GitHub.
Aucune release n'est faite actuellement, aussi il est compliqué de déployer des mises à jour.

## :robot: Solution
On tire profit de `pix-bot` en ajoutant une commande `/deploy-pix-datawarehouse` qui permet de générer le CHANGELOG, créer la release (tag Git) et de publier les applications sur Scalingo.

## :rainbow: Remarques
RAS

## :100: Pour tester
A définir