### PR TITLE
[TECH] Informe l'utilisateur de la commande que celle ci à échoué

### DIFF
--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -27,7 +27,11 @@ function getSuccessMessage(release, appName) {
   return `Le script de déploiement de la release '${release}' pour ${appName} en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`;
 }
 
-function getErrorMessage(release, appName) {
+function getErrorAppMessage(appName) {
+  return `Erreur lors du déploiement de ${appName} en production.`;
+}
+
+function getErrorReleaseMessage(release, appName) {
   return `Erreur lors du déploiement de la release '${release}' pour ${appName} en production.`;
 }
 
@@ -36,15 +40,19 @@ function _isReleaseTypeInvalid(releaseType) {
 }
 
 async function publishAndDeployRelease(repoName, appNamesList = [], releaseType, responseUrl) {
-  if (_isReleaseTypeInvalid(releaseType)) {
-    releaseType = 'minor';
+  try {
+    if (_isReleaseTypeInvalid(releaseType)) {
+      releaseType = 'minor';
+    }
+    await releasesService.publishPixRepo(repoName, releaseType);
+    const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+
+    await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag)));
+
+    sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
+  } catch (e) {
+    sendResponse(responseUrl, getErrorAppMessage(appNamesList.join(', ')));
   }
-  await releasesService.publishPixRepo(repoName, releaseType);
-  const releaseTag = await githubServices.getLatestReleaseTag(repoName);
-
-  await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag)));
-
-  sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
 }
 
 async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
@@ -57,7 +65,7 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
   await releasesService.deployPixUI();
 
   if (releaseTagBeforeRelease === releaseTagAfterRelease) {
-    sendResponse(responseUrl, getErrorMessage(releaseTagAfterRelease, repoName));
+    sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
     sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
     postSlackMessage(`[PIX-UI] App deployed (${releaseTagAfterRelease})`);

--- a/test/unit/lib/services/slack/commands_test.js
+++ b/test/unit/lib/services/slack/commands_test.js
@@ -24,7 +24,7 @@ describe('Services | Slack | Commands', () => {
     describe('when releaseType is set to minor', () => {
       beforeEach(async () => {
         // given
-        const payload = { text: 'minor' };
+        const payload = { text: 'minor', response_url: 'http://example.net/callback' };
         // when
         await createAndDeployPixSiteRelease(payload);
       });
@@ -44,6 +44,10 @@ describe('Services | Slack | Commands', () => {
         sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-site', 'v1.0.0');
         sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-pro', 'v1.0.0');
       });
+
+      it('should inform the user of the progress', () => {
+        sinon.assert.calledWith(axios.post, 'http://example.net/callback', { text: 'Le script de déploiement de la release \'v1.0.0\' pour pix-site, pix-pro en production s\'est déroulé avec succès. En attente de l\'installation des applications sur Scalingo…' });
+      });
     });
 
     describe('when releaseType is not set to a valid value', () => {
@@ -57,6 +61,17 @@ describe('Services | Slack | Commands', () => {
       });
     });
 
+    describe('when something fails', () => {
+      it('should inform the user', async () => {
+        // given
+        const payload = { response_url: 'http://example.net/callback' };
+        releasesServices.publishPixRepo.rejects();
+        // when
+        await createAndDeployPixSiteRelease(payload);
+        // then
+        sinon.assert.calledWith(axios.post, 'http://example.net/callback', { text: 'Erreur lors du déploiement de pix-site, pix-pro en production.' });
+      });
+    });
   });
 
   describe('#createAndDeployPixUI', () => {


### PR DESCRIPTION
## :unicorn: Problème
Si pour une raison quelconque la release fail, nous n'avons aucun retour de la part de pix-bot coté slack.

## :robot: Solution
Envoyer un message à l'utilisateur pour l'informer que la release a échoué.

## :rainbow: Remarques

_Néant_

## :100: Pour tester
:open_mouth: Impossible, aucune erreur ne s'est jamais produite.
