### PR TITLE
[BUGFIX] Ajouter le pattern des fichiers à invalider dans le cache.

### DIFF
--- a/lib/services/cdn.js
+++ b/lib/services/cdn.js
@@ -37,6 +37,7 @@ async function invalidateCdnCache(application) {
   const urlForInvalidate = `${CDN_URL}/cache/invalidations`;
 
   await axios.post(urlForInvalidate, {
+    patterns: [ '.' ]
   }, {
     headers: {
       'X-Api-Key': config.baleen.pat,

--- a/test/integration/lib/services/cdn_test.js
+++ b/test/integration/lib/services/cdn_test.js
@@ -28,7 +28,7 @@ function _stubInvalidationCachePost(namespaceKey) {
       'Cookie': `baleen-namespace=${namespaceKey}`
     }
   })
-    .post('/cache/invalidations')
+    .post('/cache/invalidations', { patterns: ['.']})
     .reply(200);
 }
 


### PR DESCRIPTION
## :unicorn: Problème
La requête faite pour invalider le cache tombe en erreur car il manque le pattern des fichiers à invalider.

## :robot: Solution
Ajouter le pattern 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._