### PR TITLE
Ajout d'une configuration circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+jobs:
+  build-and-test:
+    docker:
+      - image: circleci/node:12.14.0-browsers
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+workflows:
+  build_and_test:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui il n'y a aucune vérification automatique des tests et du lint du code de PixBot.

## :robot: Solution
Ajouter circle ci dans le workflow de pix bot.

## :rainbow: Remarques
RAS

## :100: Pour tester
Constater que circle CI tourne pour PixBot : https://app.circleci.com/pipelines/github/1024pix/pix-bot/1/workflows/6e6baa5e-65af-4889-992c-a1bf79a77ee9