### PR TITLE
[TECH] Montrer de manière publique les erreurs potentielles lors des releases de Pix-UI

### DIFF
--- a/lib/services/slack/commands.js
+++ b/lib/services/slack/commands.js
@@ -65,10 +65,10 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
   await releasesService.deployPixUI();
 
   if (releaseTagBeforeRelease === releaseTagAfterRelease) {
-    sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
+    postSlackMessage(getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
     sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
-    postSlackMessage(`[PIX-UI] App deployed (${releaseTagAfterRelease})`);
+    postSlackMessage(`[PIX-UI] App deployed in new version : (${releaseTagAfterRelease})`);
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui s'il y a un soucis avec une release de Pix-UI un message **_privé_** est remonté à la personne ayant lancé le script dans Slack.

Seule la personne ayant lancé le script pourra voir ce message là. Or, pour rendre le débug et la maintenabilité plus simple ce message ci devrait être publique.

## :robot: Solution
Faire afficher publiquement le message d'erreur s'il y en a un.

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS