### PR TITLE
[TECH] Mise à jour des dépendances scalingo-review-app-manager et scalingo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2143,12 +2143,29 @@
       }
     },
     "scalingo-review-app-manager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.0.tgz",
-      "integrity": "sha512-yNgeJ3b4cI3Ywm4sNjAUlLNHToiJFNNRL1Gx+v3OQqjzKb0Oi2QM4N74oz3WL0xzTmJfsKPadBjBqL5dcW0DWw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.1.tgz",
+      "integrity": "sha512-1+05PBuzc03zrkjePXPlMs4l/SE8Wdxr8YuXGNo4mdGt5Q1ioqUlQoWv8P8ijJfTFmInQ/0vi3vjRXd0o/pIHw==",
       "requires": {
         "cron": "^1.8.2",
-        "scalingo": "^0.1.1"
+        "scalingo": "^0.3.1"
+      },
+      "dependencies": {
+        "scalingo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.3.1.tgz",
+          "integrity": "sha512-I9M/5lT04O1TAIIv5B498e+IN9ACE2XeH1RzBGhUK2lXPb2Ds2HdbYTefDuDncwwSHhnkQJ/c6wZF+pj/nL5RQ==",
+          "requires": {
+            "axios": "^0.21.1",
+            "isomorphic-ws": "4.x",
+            "ws": "^7.4.3"
+          }
+        },
+        "ws": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+        }
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,31 +2115,13 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "scalingo": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.1.1.tgz",
-      "integrity": "sha512-IIDvRKwS6uVAOdgyS5a3RWOTMTFMTo2vCVWX3OxcfHvYXgZ/51c2byEletnZ/39d7IRz7ze+BciY9m98RMLanQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.3.1.tgz",
+      "integrity": "sha512-I9M/5lT04O1TAIIv5B498e+IN9ACE2XeH1RzBGhUK2lXPb2Ds2HdbYTefDuDncwwSHhnkQJ/c6wZF+pj/nL5RQ==",
       "requires": {
-        "axios": "0.19.x",
+        "axios": "^0.21.1",
         "isomorphic-ws": "4.x",
-        "ws": "7.x"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        }
+        "ws": "^7.4.3"
       }
     },
     "scalingo-review-app-manager": {
@@ -2551,9 +2533,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "y18n": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.19",
     "moment": "^2.27.0",
     "proxyquire": "^2.1.3",
-    "scalingo": "^0.1.1",
+    "scalingo": "^0.3.1",
     "scalingo-review-app-manager": "^1.0.1",
     "sib-api-v3-sdk": "^8.0.1",
     "tsscmp": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "moment": "^2.27.0",
     "proxyquire": "^2.1.3",
     "scalingo": "^0.1.1",
-    "scalingo-review-app-manager": "^1.0.0",
+    "scalingo-review-app-manager": "^1.0.1",
     "sib-api-v3-sdk": "^8.0.1",
     "tsscmp": "^1.0.6"
   },


### PR DESCRIPTION
## :unicorn: Problème
La dépendance scalingo-review-app-manager, dans sa version 1.0.0, présentait une vulnérabilité dans la dépendances axios portée par la dépendance scalingo. De fait, nous avons publié une nouvelle version du package scalingo-review-app-manager, la 1.0.1, qui met à jour les paquets nécessaires afin de résoudre la vulnérabilité.
Aussi, PixBot utilise directement la dépendance scalingo, laquelle nous avons également monté la version.

## :robot: Solution
Mettre à jour scalingo-review-app-manager de 1.0.0 vers 1.0.1
Mettre à jour scalingo de 0.1.1 vers 0.3.1

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._