### PR TITLE
[TECH] Pusher le commit de version en même temps que le tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy:major": "npm version major && npm run deploy:tag",
     "deploy:minor": "npm version minor && npm run deploy:tag",
     "deploy:patch": "npm version patch && npm run deploy:tag",
-    "deploy:tag": "git push --tags",
+    "deploy:tag": "git push --tags && git push",
     "start": "node bin/www",
     "test": "NODE_ENV=test mocha --recursive --exit test",
     "lint": "eslint common/* run/* build/* bin/* test/*"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le script de déploiement de version n'envoie que le tag mais pas le commit associé.

## :robot: Solution
Envoyer le commit associé au tag. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._