### PR TITLE
[FEATURE] Deployer pix bot avec pix bot

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -37,6 +37,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixBotRelease(request) {
+    const payload = request.pre.payload;
+    commandsFromRun.createAndDeployPixBotRelease(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX Bot')
+    };
+  },
+
   createAndDeployPixLCMSRelease(request) {
     const payload = request.pre.payload;
     commandsFromRun.createAndDeployPixLCMS(payload);

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -38,6 +38,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-bot-release',
+    handler: slackbotController.createAndDeployPixBotRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
     handler: slackbotController.createAndDeployPixDatawarehouseRelease,
     config: slackConfig

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -1,6 +1,8 @@
 const scalingo = require('scalingo');
 const config = require('../../config');
 
+const DEFAULT_OPTS = { withEnvSuffix: true };
+
 class ScalingoClient {
   constructor(client, environment) {
     this.client = client;
@@ -13,7 +15,7 @@ class ScalingoClient {
     return new ScalingoClient(client, environment);
   }
 
-  async deployFromArchive(pixApp, releaseTag, repository = config.github.repository) {
+  async deployFromArchive(pixApp, releaseTag, repository = config.github.repository, options = DEFAULT_OPTS) {
     if (!pixApp) {
       throw new Error('No application to deploy.');
     }
@@ -21,7 +23,7 @@ class ScalingoClient {
       throw new Error('No release tag to deploy.');
     }
 
-    const scalingoApp = `${pixApp}-${this.environment}`;
+    const scalingoApp = options.withEnvSuffix ? `${pixApp}-${this.environment}` : pixApp;
 
     try {
       await this.client.apiClient().post(

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -1,9 +1,10 @@
 const releasesService = require('../../../common/services/releases');
+const ScalingoClient = require('../../../common/services/scalingo-client');
 const githubServices = require('../../../common/services/github');
 const axios = require('axios');
 const postSlackMessage = require('../../../common/services/slack/surfaces/messages/post-message');
 
-
+const PIX_BOT_REPO_NAME = 'pix-bot';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
 const PIX_LCMS_APP_NAME = 'pix-lcms';
 const PIX_UI_REPO_NAME = 'pix-ui';
@@ -72,6 +73,22 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
   }
 }
 
+async function publishAndDeployPixBot(repoName, releaseType, responseUrl) {
+  if (_isReleaseTypeInvalid(releaseType)) {
+    releaseType = 'minor';
+  }
+  await releasesService.publishPixRepo(repoName, releaseType);
+  const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+  
+  const recette = await ScalingoClient.getInstance('recette');
+  await recette.deployFromArchive('pix-bot-build', releaseTag, repoName, { withEnvSuffix: false });
+
+  const production = await ScalingoClient.getInstance('production');
+  await production.deployFromArchive('pix-bot-run', releaseTag, repoName);
+  
+  sendResponse(responseUrl, `Pix Bot deployed (${releaseTag})`);
+}
+
 module.exports = {
 
   async createAndDeployPixLCMS(payload) {
@@ -88,6 +105,10 @@ module.exports = {
 
   async createAndDeployPixDatawarehouse(payload) {
     await publishAndDeployRelease(PIX_DATAWAREHOUSE_REPO_NAME, PIX_DATAWAREHOUSE_APPS_NAME, payload.text, payload.response_url);
+  },
+
+  async createAndDeployPixBotRelease(payload) {
+    await publishAndDeployPixBot(PIX_BOT_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixBotTestRelease(payload) {

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -95,6 +95,14 @@ describe('Scalingo client', () => {
       expect(result).to.be.equal('Deployed pix-app-production v1.0');
     });
 
+    it('should deploy an application without the environment suffix', async () => {
+      // given
+      // when
+      const result = await scalingoClient.deployFromArchive('pix-app', 'v1.0', undefined, { withEnvSuffix: false });
+      // then
+      expect(result).to.be.equal('Deployed pix-app v1.0');
+    });
+
     it('should deploy an application for a given repository', async () => {
       // given
       // when

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -6,9 +6,11 @@ const {
   createAndDeployPixUI,
   createAndDeployPixSiteRelease,
   createAndDeployPixDatawarehouse,
+  createAndDeployPixBotRelease,
 } = require('../../../../../run/services/slack/commands');
 const releasesServices = require('../../../../../common/services/releases');
 const githubServices = require('../../../../../common/services/github');
+const ScalingoClient = require('../../../../../common/services/scalingo-client');
 
 describe('Services | Slack | Commands', () => {
   beforeEach(() => {
@@ -119,6 +121,38 @@ describe('Services | Slack | Commands', () => {
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixRepo);
+    });
+  });
+
+  describe('#createAndDeployPixBotRelease', () => {
+    let client;
+    beforeEach(async () => {
+      // given
+      client = { deployFromArchive: sinon.spy() };
+      sinon.stub(ScalingoClient, 'getInstance').resolves(client);
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixBotRelease(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-bot', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', () => {
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-bot');
+    });
+
+    it('should deploy the release for pix-bot-build', () => {
+      // then
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build');
+    });
+
+    it('should deploy the release for pix-bot-run', () => {
+      // then
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, le déploiement de `pix-bot-build` et `pix-bot-run` se fait manuellement.

## :robot: Solution

Pouvoir déployer `pix-bot-build` et `pix-bot-run` via pix-bot et une commande Slack `/deploy-pix-bot [release type]`.

Tâches à réaliser:
- [x] Ajouter un endpoint Slack sur `pix-bot` afin de créer une nouvelle release et déployer `pix-bot-build` et `pix-bot-run`

```
POST /slack/commands/create-and-deploy-pix-bot-release
```

- [x] Ajouter la configuration de la nouvelle commande Slack sur le Slack de Pix
