### PR TITLE
Suppression du nom de la branche dans le script de release

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,11 +33,11 @@ function get_package_version() {
   node -p -e "require('./package.json').version"
 }
 
-function push_commit_and_tag_to_remote_dev() {
-  git push origin dev
+function push_commit_and_tag_to_remote() {
+  git push origin
   git push origin "v${NEW_PACKAGE_VERSION}"
 
-  echo "Pushed release commit on branch origin/dev"
+  echo "Pushed release commit on branch origin"
 }
 
 function complete_change_log() {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -99,7 +99,7 @@ complete_change_log
 configure_git_user_information
 create_a_release_commit
 tag_release_commit
-push_commit_and_tag_to_remote_dev
+push_commit_and_tag_to_remote
 publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -44,6 +44,6 @@ create_release
 complete_change_log
 create_a_release_commit
 tag_release_commit
-push_commit_and_tag_to_remote_dev
+push_commit_and_tag_to_remote
 
 echo -e "Release publication for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} ${GREEN}succeeded${RESET_COLOR} (${VERSION_TYPE})."


### PR DESCRIPTION
## :unicorn: Problème

Le script de release est lié à la branche dev au moment du push de tag.

## :robot: Solution

Faire en sorte de ne plus être lié à la branche dev dans le script..
