### PR TITLE
Pouvoir saisir des noms d'app raccourci sur la commande app-status

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -73,8 +73,14 @@ class ScalingoClient {
 }
 
 async function _isUrlReachable(url) {
+
+  let pingUrl = url;
+  if (url.includes('api')) {
+    pingUrl = url + '/api';
+  }
+
   try {
-    await axios.get(url, {
+    await axios.get(pingUrl, {
       timeout: 2500,
     });
     return true;

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -44,9 +44,15 @@ class ScalingoClient {
   }
 
   async getAppInfo(appName) {
+
+    let scalingoAppName = appName;
+    if (!appName.match(/^pix-[a-z0-9-]*$/g)) {
+      scalingoAppName = `pix-${appName}-production`;
+    }
+
     try {
-      const { name, url, last_deployment_id } = await this.client.Apps.find(appName);
-      const { created_at, git_ref, pusher } = await this.client.Deployments.find(appName, last_deployment_id);
+      const { name, url, last_deployment_id } = await this.client.Apps.find(scalingoAppName);
+      const { created_at, git_ref, pusher } = await this.client.Deployments.find(scalingoAppName, last_deployment_id);
       const isUp = await _isUrlReachable(url);
 
       return {


### PR DESCRIPTION
## :unicorn: Problème
Il peut être lourd de devoir saisir le nom entier de l'application lors de l'appel à la commande Slack `/app-status`

## :robot: Solution
Permettre à la commande Slack de comprendre les noms raccourcis des applications.  
Dans ce cas, ce sera automatiquement l'application de prod qui sera visée.

Ex:
- avant il fallait saisir `/app-status pix-app-production`
- maintenant il est aussi possible de saisir `/app-status app`: cette commande retournera le status de l'application pix-app-production

## :rainbow: Remarques
On a aussi porfité de cette PR pour corriger un problème sur la commande.  
Sur la PR #65 qui permet de remonter sur Slack le status d'un application Scalingo, on remarque que le status de l'api est toujours DOWN parce que l'on ping `https://app.{environement}.pix.fr` et non pas `https://app.{environement}.pix.fr/api`.
Fix: lorsque l'application demandée est l'api, suffixer l'url de ping par `/api`
