### PR TITLE
[BUGFIX] Appel à /app-status avec un nom court

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -65,7 +65,7 @@ class ScalingoClient {
       };
     } catch (err) {
       if (err.status === 404) {
-        throw new Error(`Impossible to get info for ${appName}`);
+        throw new Error(`Impossible to get info for ${scalingoAppName}`);
       }
       throw err;
     }

--- a/run/services/slack/app-status-from-scalingo.js
+++ b/run/services/slack/app-status-from-scalingo.js
@@ -5,7 +5,7 @@ async function getAppStatusFromScalingo(appName) {
     return { text: 'Un nom d\'application est attendu en paramètre (ex: pix-app-production)' } ;
   }
 
-  const environment = appName.endsWith('production') ? 'production' : 'recette';
+  const environment = appName.endsWith('recette') ? 'recette' : 'production';
 
   try {
     const client = await ScalingoClient.getInstance(environment);

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -126,4 +126,66 @@ describe('#getAppStatusFromScalingo', () => {
     expect(response.text).equals('Une erreur est survenue : "message erreur"');
   });
 
+  it('returns a production app status when the appName is not the full app name', async () => {
+    // given
+    const getAppInfo = sinon.stub().resolves({
+      name: 'pix-app-production',
+      url: 'https://app.pix.fr',
+      isUp: true,
+      lastDeployementAt: '2021-03-24T08:37:18.611Z',
+      lastDeployedBy: 'Bob',
+      lastDeployedVersion: 'v1.0.0',
+    });
+    const scalingoClientSpy = sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
+
+    // when
+    const response = await getAppStatusFromScalingo('app');
+
+    // then
+    expect(scalingoClientSpy.called).to.equal(true);
+    expect(response).to.deep.equal({
+      'response_type': 'in_channel',
+      'blocks': [
+        {
+          'type': 'section',
+          'text': {
+            'type': 'mrkdwn',
+            'text': '*pix-app-production* is up 💚'
+          }
+        },
+        {
+          'type': 'context',
+          'elements': [
+            {
+              'type': 'mrkdwn',
+              'text': 'Version *v1.0.0*'
+            }
+          ]
+        },
+        {
+          'type': 'context',
+          'elements': [
+            {
+              'type': 'mrkdwn',
+              'text': 'Deployée par *Bob* à 2021-03-24T08:37:18.611Z.'
+            }
+          ]
+        },
+        {
+          'type': 'actions',
+          'elements': [
+            {
+              'type': 'button',
+              'text': {
+                'type': 'plain_text',
+                'text': 'Application'
+              },
+              'url': 'https://app.pix.fr'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Losque /app-status est appelé avec un nom court (ex: `/app-status app`), Slack ne parvient pas à retourner le status d'une application.

## :robot: Solution
Pour connaitre la région Scalingo à requêter, on se basait sur le suffixe du nom de l'application.
Par exemple, si le nom est `pix-app-production`, alors la région est celle de la prod.
Or, en renseignant seulement `app` comme nom d'application, on requêtait la région de recette.
La région par défaut à requêter à été changé pour la prod.
