### PR TITLE
[FEATURE] Obtenir le statut de toutes les apps plutôt qu'une seule

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -43,11 +43,24 @@ class ScalingoClient {
     return `Deployed ${scalingoApp} ${releaseTag}`;
   }
 
-  async getAppInfo(appName) {
+  async getAppInfo(target) {
+    if (['production', 'integration', 'recette'].includes(target)) {
+      return await this._getAllAppsInfo(target);
+    }
 
+    return [await this._getSingleAppInfo(target)];
+  }
+
+  async _getAllAppsInfo(environement) {
+    const apps = ['api', 'app', 'orga', 'certif', 'admin'];
+    const promises = apps.map(appName => this._getSingleAppInfo(appName, environement));
+    return Promise.all(promises);
+  }
+
+  async _getSingleAppInfo(appName, environment = 'production') {
     let scalingoAppName = appName;
     if (!appName.match(/^pix-[a-z0-9-]*$/g)) {
-      scalingoAppName = `pix-${appName}-production`;
+      scalingoAppName = `pix-${appName}-${environment}`;
     }
 
     try {

--- a/run/services/slack/app-status-from-scalingo.js
+++ b/run/services/slack/app-status-from-scalingo.js
@@ -9,54 +9,26 @@ async function getAppStatusFromScalingo(appName) {
 
   try {
     const client = await ScalingoClient.getInstance(environment);
-    const { name, url, isUp, lastDeployementAt, lastDeployedBy, lastDeployedVersion } = await client.getAppInfo(
+    const appInfos = await client.getAppInfo(
       appName
     );
 
-    const appStatus = isUp ? `*${name}* is up 💚` : `*${name}* is down 🛑`;
+    const text = appInfos.map((appInfo) => {
+      const appStatus = appInfo.isUp ? `*${appInfo.name}* is up 💚` : `*${appInfo.name}* is down 🛑`;
+      return `· ${appStatus} - ${appInfo.lastDeployedVersion} deployed at ${appInfo.lastDeployementAt}`;
+    });
 
     return {
       response_type: 'in_channel',
       blocks: [
         {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: appStatus,
-          },
-        },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: `Version *${lastDeployedVersion}*`,
-            },
-          ],
-        },
-        {
-          type: 'context',
-          elements: [
-            {
-              type: 'mrkdwn',
-              text: `Deployée par *${lastDeployedBy}* à ${lastDeployementAt}.`,
-            },
-          ],
-        },
-        {
-          type: 'actions',
-          elements: [
-            {
-              type: 'button',
-              text: {
-                type: 'plain_text',
-                text: 'Application',
-              },
-              url: url,
-            },
-          ],
-        },
-      ],
+          'type': 'section',
+          'text': {
+            'type': 'mrkdwn',
+            'text': text.join('\n'),
+          }
+        }
+      ]
     };
   } catch (error) {
     return { text: `Une erreur est survenue : "${error.message}"` } ;

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -168,11 +168,12 @@ describe('Scalingo client', () => {
 
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-app-production');
+      const appInfos = await scalingoClient.getAppInfo('pix-app-production');
 
       // then
-      expect(info.name).to.equal('pix-app-production');
-      expect(info.url).to.equal('https://app.pix.fr');
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].name).to.equal('pix-app-production');
+      expect(appInfos[0].url).to.equal('https://app.pix.fr');
     });
 
     it('should return last deployment info', async () => {
@@ -188,12 +189,13 @@ describe('Scalingo client', () => {
       });
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-app-production');
+      const appInfos = await scalingoClient.getAppInfo('pix-app-production');
 
       // then
-      expect(info.lastDeployementAt).to.equal('2021-03-23T11:02:20.955Z');
-      expect(info.lastDeployedBy).to.equal('Bob');
-      expect(info.lastDeployedVersion).to.equal('v1.1.1');
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].lastDeployementAt).to.equal('2021-03-23T11:02:20.955Z');
+      expect(appInfos[0].lastDeployedBy).to.equal('Bob');
+      expect(appInfos[0].lastDeployedVersion).to.equal('v1.1.1');
     });
 
     it('should return application status when UP', async () => {
@@ -206,10 +208,11 @@ describe('Scalingo client', () => {
       axiosGet.withArgs('https://app.pix.fr').resolves();
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-app-production');
+      const appInfos = await scalingoClient.getAppInfo('pix-app-production');
 
       // then
-      expect(info.isUp).to.equal(true);
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].isUp).to.equal(true);
     });
 
     it('should return application status when DOWN', async () => {
@@ -222,10 +225,11 @@ describe('Scalingo client', () => {
       axiosGet.withArgs('https://app.pix.fr').rejects();
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-app-production');
+      const appInfos = await scalingoClient.getAppInfo('pix-app-production');
 
       // then
-      expect(info.isUp).to.equal(false);
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].isUp).to.equal(false);
     });
 
     it('should return production info by default with short name', async () => {
@@ -240,11 +244,12 @@ describe('Scalingo client', () => {
       clientDeploymentsFind.withArgs('pix-app-production', 'deployment-id-1').resolves({ pusher: {} });
 
       // when
-      const info = await scalingoClient.getAppInfo('app');
+      const appInfos = await scalingoClient.getAppInfo('app');
 
       // then
-      expect(info.name).to.equal('pix-app-production');
-      expect(info.url).to.equal('https://app.pix.fr');
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].name).to.equal('pix-app-production');
+      expect(appInfos[0].url).to.equal('https://app.pix.fr');
     });
 
     it('should return correct app with full name', async () => {
@@ -259,11 +264,11 @@ describe('Scalingo client', () => {
       clientDeploymentsFind.withArgs('pix-app-recette', 'deployment-id-1').resolves({ pusher: {} });
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-app-recette');
+      const appInfos = await scalingoClient.getAppInfo('pix-app-recette');
 
       // then
-      expect(info.name).to.equal('pix-app-recette');
-      expect(info.url).to.equal('https://app.recette.pix.fr');
+      expect(appInfos[0].name).to.equal('pix-app-recette');
+      expect(appInfos[0].url).to.equal('https://app.recette.pix.fr');
     });
 
     it('should suffix api url with /api', async () => {
@@ -276,11 +281,62 @@ describe('Scalingo client', () => {
       const axiosSpy = axiosGet.withArgs('https://api.pix.fr/api').resolves();
 
       // when
-      const info = await scalingoClient.getAppInfo('pix-api-production');
+      const appInfos = await scalingoClient.getAppInfo('pix-api-production');
 
       // then
-      expect(info.isUp).to.equal(true);
+      expect(appInfos.length).to.equal(1);
+      expect(appInfos[0].isUp).to.equal(true);
       expect(axiosSpy.called).to.equal(true);
+    });
+
+    it('should return all production app info', async () => {
+      // given
+      clientAppsFind.withArgs('pix-api-production').resolves({
+        url: 'https://api.pix.fr',
+        last_deployment_id: 'deployment-id-1',
+      });
+      clientAppsFind.withArgs('pix-app-production').resolves({
+        url: 'https://app.pix.fr',
+        last_deployment_id: 'deployment-id-2',
+      });
+      clientAppsFind.withArgs('pix-orga-production').resolves({
+        url: 'https://orga.pix.fr',
+        last_deployment_id: 'deployment-id-3',
+      });
+      clientAppsFind.withArgs('pix-certif-production').resolves({
+        url: 'https://certif.pix.fr',
+        last_deployment_id: 'deployment-id-4',
+      });
+      clientAppsFind.withArgs('pix-admin-production').resolves({
+        url: 'https://admin.pix.fr',
+        last_deployment_id: 'deployment-id-5',
+      });
+      clientDeploymentsFind.withArgs('pix-api-production', 'deployment-id-1').resolves({ pusher: {} });
+      clientDeploymentsFind.withArgs('pix-app-production', 'deployment-id-2').resolves({ pusher: {} });
+      clientDeploymentsFind.withArgs('pix-orga-production', 'deployment-id-3').resolves({ pusher: {} });
+      clientDeploymentsFind.withArgs('pix-certif-production', 'deployment-id-4').resolves({ pusher: {} });
+      clientDeploymentsFind.withArgs('pix-admin-production', 'deployment-id-5').resolves({ pusher: {} });
+      const apiPing = axiosGet.withArgs('https://api.pix.fr/api').resolves();
+      const appPing = axiosGet.withArgs('https://app.pix.fr').resolves();
+      const orgaPing = axiosGet.withArgs('https://orga.pix.fr').resolves();
+      const adminPing = axiosGet.withArgs('https://admin.pix.fr').resolves();
+      const certifPing = axiosGet.withArgs('https://certif.pix.fr').resolves();
+
+      // when
+      const appInfos = await scalingoClient.getAppInfo('production');
+
+      // then
+      expect(appInfos.length).to.equal(5);
+      expect(appInfos[0].isUp).to.equal(true);
+      expect(appInfos[1].isUp).to.equal(true);
+      expect(appInfos[2].isUp).to.equal(true);
+      expect(appInfos[3].isUp).to.equal(true);
+      expect(appInfos[4].isUp).to.equal(true);
+      expect(apiPing.called).to.equal(true);
+      expect(appPing.called).to.equal(true);
+      expect(orgaPing.called).to.equal(true);
+      expect(adminPing.called).to.equal(true);
+      expect(certifPing.called).to.equal(true);
     });
 
     it('should throw an error if app does not exist', async () => {

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -128,14 +128,14 @@ describe('#getAppStatusFromScalingo', () => {
 
   it('returns a production app status when the appName is not the full app name', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves({
+    const getAppInfo = sinon.stub().resolves([{
       name: 'pix-app-production',
       url: 'https://app.pix.fr',
       isUp: true,
       lastDeployementAt: '2021-03-24T08:37:18.611Z',
       lastDeployedBy: 'Bob',
       lastDeployedVersion: 'v1.0.0',
-    });
+    }]);
     const scalingoClientSpy = sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
 
     // when

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -17,14 +17,14 @@ describe('#getAppStatusFromScalingo', () => {
 
   it('returns a production app status for slack', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves({
+    const getAppInfo = sinon.stub().resolves([{
       name: 'pix-app-production',
       url: 'https://app.pix.fr',
       isUp: true,
       lastDeployementAt: '2021-03-24T08:37:18.611Z',
       lastDeployedBy: 'Bob',
       lastDeployedVersion: 'v1.0.0',
-    });
+    }]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
 
     // when
@@ -38,39 +38,8 @@ describe('#getAppStatusFromScalingo', () => {
           'type': 'section',
           'text': {
             'type': 'mrkdwn',
-            'text': '*pix-app-production* is up 💚'
+            'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z',
           }
-        },
-        {
-          'type': 'context',
-          'elements': [
-            {
-              'type': 'mrkdwn',
-              'text': 'Version *v1.0.0*'
-            }
-          ]
-        },
-        {
-          'type': 'context',
-          'elements': [
-            {
-              'type': 'mrkdwn',
-              'text': 'Deployée par *Bob* à 2021-03-24T08:37:18.611Z.'
-            }
-          ]
-        },
-        {
-          'type': 'actions',
-          'elements': [
-            {
-              'type': 'button',
-              'text': {
-                'type': 'plain_text',
-                'text': 'Application'
-              },
-              'url': 'https://app.pix.fr'
-            }
-          ]
         }
       ]
     });
@@ -78,14 +47,14 @@ describe('#getAppStatusFromScalingo', () => {
 
   it('returns a recette app status for slack', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves({
+    const getAppInfo = sinon.stub().resolves([{
       name: 'pix-app-recette',
       url: 'https://app.recette.pix.fr',
       isUp: true,
       lastDeployementAt: '2021-03-24T08:37:18.611Z',
       lastDeployedBy: 'Bob',
       lastDeployedVersion: 'v1.0.0',
-    });
+    }]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('recette').resolves({ getAppInfo });
 
     // when
@@ -95,23 +64,65 @@ describe('#getAppStatusFromScalingo', () => {
     expect(response.blocks).is.not.empty;
   });
 
+  it('returns status for all production apps for slack', async () => {
+    // given
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-production',
+        url: 'https://app.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+      {
+        name: 'pix-api-production',
+        url: 'https://api.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-25T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.1.0',
+      }
+    ]);
+    sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
+
+    // when
+    const response = await getAppStatusFromScalingo('production');
+
+    // then
+    expect(response).to.deep.equal(
+      {
+        'response_type': 'in_channel',
+        'blocks': [
+          {
+            'type': 'section',
+            'text': {
+              'type': 'mrkdwn',
+              'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z\n· *pix-api-production* is up 💚 - v1.1.0 deployed at 2021-03-25T08:37:18.611Z',
+            }
+          }
+        ]
+      }
+    );
+  });
+
   it('returns a different status message when app is down', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves({
+    const getAppInfo = sinon.stub().resolves([{
       name: 'pix-app-recette',
       url: 'https://app.recette.pix.fr',
       isUp: false,
       lastDeployementAt: '2021-03-24T08:37:18.611Z',
       lastDeployedBy: 'Bob',
       lastDeployedVersion: 'v1.0.0',
-    });
+    }]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('recette').resolves({ getAppInfo });
 
     // when
     const response = await getAppStatusFromScalingo('pix-app-recette');
 
     // then
-    expect(response.blocks[0].text.text).equals('*pix-app-recette* is down 🛑');
+    expect(response.blocks[0].text.text).equals('· *pix-app-recette* is down 🛑 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z');
   });
 
   it('returns an error response if an error occured', async () => {
@@ -150,40 +161,9 @@ describe('#getAppStatusFromScalingo', () => {
           'type': 'section',
           'text': {
             'type': 'mrkdwn',
-            'text': '*pix-app-production* is up 💚'
+            'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z'
           }
         },
-        {
-          'type': 'context',
-          'elements': [
-            {
-              'type': 'mrkdwn',
-              'text': 'Version *v1.0.0*'
-            }
-          ]
-        },
-        {
-          'type': 'context',
-          'elements': [
-            {
-              'type': 'mrkdwn',
-              'text': 'Deployée par *Bob* à 2021-03-24T08:37:18.611Z.'
-            }
-          ]
-        },
-        {
-          'type': 'actions',
-          'elements': [
-            {
-              'type': 'button',
-              'text': {
-                'type': 'plain_text',
-                'text': 'Application'
-              },
-              'url': 'https://app.pix.fr'
-            }
-          ]
-        }
       ]
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, la commande `/app-status` prend en paramètre le nom d'une app et ne retourne que le statut de celle-ci. Nous voudrions pouvoir obtenir le statut de toutes les apps avec une seule commande.

## :robot: Solution

Ajouter la possibilité de passer l'environnement comme paramètre à la commande `/app-status` pour obtenir le statut des apps de cet environnement.

## :rainbow: Remarques

Nous avons choisi de retourner le statut des apps Scalingo qui nous paraissaient le plus importantes : api, app, orga, certif, admin. Il est toujours possible d'obtenir manuellement le statut des autres (ex: `/app-status pix-site-production`).