### PR TITLE
[TECH] Supprimer un endpoint inutilisé

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -20,15 +20,6 @@ module.exports = {
     };
   },
 
-  createAndDeployPixBotTestRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixBotTestRelease(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX bot test (repo vide)')
-    };
-  },
-
   createAndDeployPixUIRelease(request) {
     const payload = request.pre.payload;
     commandsFromRun.createAndDeployPixUI(payload);

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -14,12 +14,6 @@ const slackConfig = {
 module.exports = [
   {
     method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-bot-test-release',
-    handler: slackbotController.createAndDeployPixBotTestRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
     path: '/slack/commands/create-and-deploy-pix-lcms-release',
     handler: slackbotController.createAndDeployPixLCMSRelease,
     config: slackConfig

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -12,7 +12,6 @@ const PIX_SITE_REPO_NAME = 'pix-site';
 const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
 const PIX_DATAWAREHOUSE_REPO_NAME = 'pix-db-replication';
 const PIX_DATAWAREHOUSE_APPS_NAME = ['pix-datawarehouse', 'pix-datawarehouse-ex'];
-const PIX_BOT_REPO_TEST = 'pix-bot-release-test';
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,
@@ -78,13 +77,13 @@ async function publishAndDeployPixBot(repoName, releaseType, responseUrl) {
   }
   await releasesService.publishPixRepo(repoName, releaseType);
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
-  
+
   const recette = await ScalingoClient.getInstance('recette');
   await recette.deployFromArchive('pix-bot-build', releaseTag, repoName, { withEnvSuffix: false });
 
   const production = await ScalingoClient.getInstance('production');
   await production.deployFromArchive('pix-bot-run', releaseTag, repoName);
-  
+
   sendResponse(responseUrl, `Pix Bot deployed (${releaseTag})`);
 }
 
@@ -97,7 +96,7 @@ module.exports = {
   async createAndDeployPixUI(payload) {
     await publishAndDeployPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
   },
-  
+
   async createAndDeployPixSiteRelease(payload) {
     await publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APPS, payload.text, payload.response_url);
   },
@@ -108,10 +107,6 @@ module.exports = {
 
   async createAndDeployPixBotRelease(payload) {
     await publishAndDeployPixBot(PIX_BOT_REPO_NAME, payload.text, payload.response_url);
-  },
-
-  async createAndDeployPixBotTestRelease(payload) {
-    await publishAndDeployRelease(PIX_BOT_REPO_TEST, [PIX_BOT_REPO_TEST], payload.text, payload.response_url);
   },
 
 };


### PR DESCRIPTION
## :unicorn: Problème
Le endpoint `/slack/commands/create-and-deploy-pix-bot-test-release` est un endpoint de test qui n'est plus utilisé.

## :robot: Solution
Supprimer cet endpoint.