### PR TITLE
Mise à jour de la documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Services provided by Pix Bot:
 - deploy a specific release into production via secured API
 - deploy a specific release into production via a Slack command or shortcut
 
+Pix Bot is deployed into two apps:
+- Pix Bot Build: contains the commands for the development tools
+- Pix Bot Run: contains the commands related to the releases
+
 ## Getting started
+
+### Run locally
 
 *1/* Get the sources
 
@@ -45,6 +51,25 @@ Command to run the `publish` script:
 ```sh
 GITHUB_OWNER=#github_owner# GITHUB_REPOSITORY=#github_repository# GITHUB_USERNAME=#github_username# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# scripts/publish.sh (path|minor|major)
 ```
+
+### Test the endpoint on Slack
+
+If you want to test your new endpoint before deploying it, 
+you will need to run your server locally and make it visible (with ngrok for example).
+
+Ensure you have the access rights to Pix Bot Build and Pix Bot Run on Slack, 
+then go to [https://api.slack.com/apps](https://api.slack.com/apps).
+Click on the Bot you want to create the new endpoint (Pix Bot Build or Pix Bot Run), 
+then in "Slash commands" tab, click "Create new command".
+In the popup, register ${ngrok url}/slack/commands/my-slack-command.
+
+## Deploy
+
+Pix Bot has a Slack command that allow to release itself:
+```
+/deploy-pix-bot [patch|minor|major]
+```
+This command will create a tag, a release commit and deploy the applications Pix Bot Build and Pix Bot Run.
 
 ## License
 


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de se plonger dans Pix Bot, entre le split de Pix Bot et le déploiment de Pix Bot désormais fait depuis Slack.

## :robot: Solution
Documenter:
- le split de Pix Bot
- comment tester fonctionnellement un nouvel endpoint appelé depuis Slack
- le déploiement Pix Bot depuis Slack