### PR TITLE
Affichage des statuts des app en intégration

### DIFF
--- a/config.js
+++ b/config.js
@@ -36,6 +36,10 @@ module.exports = (function() {
         token: process.env.SCALINGO_TOKEN_REVIEW_APPS,
         apiUrl: process.env.SCALINGO_API_URL_REVIEW_APPS || 'https://api.osc-fr1.scalingo.com',
       },
+      integration: {
+        token: process.env.SCALINGO_TOKEN_INTEGRATION,
+        apiUrl: process.env.SCALINGO_API_URL_INTEGRATION || 'https://api.osc-fr1.scalingo.com',
+      },
       recette: {
         token: process.env.SCALINGO_TOKEN_RECETTE,
         apiUrl: process.env.SCALINGO_API_URL_RECETTE,

--- a/run/services/slack/app-status-from-scalingo.js
+++ b/run/services/slack/app-status-from-scalingo.js
@@ -5,7 +5,7 @@ async function getAppStatusFromScalingo(appName) {
     return { text: 'Un nom d\'application est attendu en paramètre (ex: pix-app-production)' } ;
   }
 
-  const environment = appName.endsWith('recette') ? 'recette' : 'production';
+  const environment = _getEnvironmentFrom({ appName });
 
   try {
     const client = await ScalingoClient.getInstance(environment);
@@ -15,12 +15,13 @@ async function getAppStatusFromScalingo(appName) {
 
     const blocks = appInfos.map((appInfo) => {
       const appStatus = appInfo.isUp ? '💚' : '🛑';
+      const lastVersionDisplayed = environment === 'integration' ? '' : ` - ${appInfo.lastDeployedVersion}`;
       return {
         'type': 'section',
         'text': {
           'type': 'mrkdwn',
-          'text': `*${appInfo.name}* ${appStatus} - ${appInfo.lastDeployedVersion}\n${appInfo.lastDeployementAt}`,
-        }
+          'text': `*${appInfo.name}* ${appStatus}${lastVersionDisplayed}\n${appInfo.lastDeployementAt}`,
+        },
       };
     });
 
@@ -31,6 +32,15 @@ async function getAppStatusFromScalingo(appName) {
   } catch (error) {
     return { text: `Une erreur est survenue : "${error.message}"` } ;
   }
+}
+
+function _getEnvironmentFrom({ appName }) {
+  if (appName.endsWith('integration')) {
+    return 'integration';
+  } else if (appName.endsWith('recette')) {
+    return 'recette';
+  }
+  return 'production';
 }
 
 module.exports = { getAppStatusFromScalingo };

--- a/run/services/slack/app-status-from-scalingo.js
+++ b/run/services/slack/app-status-from-scalingo.js
@@ -13,22 +13,20 @@ async function getAppStatusFromScalingo(appName) {
       appName
     );
 
-    const text = appInfos.map((appInfo) => {
-      const appStatus = appInfo.isUp ? `*${appInfo.name}* is up 💚` : `*${appInfo.name}* is down 🛑`;
-      return `· ${appStatus} - ${appInfo.lastDeployedVersion} deployed at ${appInfo.lastDeployementAt}`;
+    const blocks = appInfos.map((appInfo) => {
+      const appStatus = appInfo.isUp ? '💚' : '🛑';
+      return {
+        'type': 'section',
+        'text': {
+          'type': 'mrkdwn',
+          'text': `*${appInfo.name}* ${appStatus} - ${appInfo.lastDeployedVersion}\n${appInfo.lastDeployementAt}`,
+        }
+      };
     });
 
     return {
       response_type: 'in_channel',
-      blocks: [
-        {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': text.join('\n'),
-          }
-        }
-      ]
+      blocks,
     };
   } catch (error) {
     return { text: `Une erreur est survenue : "${error.message}"` } ;

--- a/sample.env
+++ b/sample.env
@@ -326,3 +326,25 @@ SCALINGO_TOKEN_RECETTE=__CHANGE_ME__
 # type: String (URL)
 # default: "https://api.osc-fr1.scalingo.com"
 SCALINGO_API_URL_RECETTE=https://api.osc-fr1.scalingo.com
+
+# ======================
+# SCALINGO INTEGRATION
+# ======================
+
+# Scalingo user API token for integration environment.
+#
+# If not present, app-status for integration environment will failed
+#
+# presence: optional
+# type: String
+# default: none
+SCALINGO_TOKEN_INTEGRATION=__CHANGE_ME__
+
+# Scalingo API endpoint
+#
+# If not present, app-status for integration environment will failed
+#
+# presence: optional
+# type: String (URL)
+# default: "https://api.osc-fr1.scalingo.com"
+SCALINGO_API_URL_INTEGRATION=https://api.osc-fr1.scalingo.com

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -64,6 +64,39 @@ describe('#getAppStatusFromScalingo', () => {
     expect(response.blocks).is.not.empty;
   });
 
+  it('returns an integration app status for slack', async () => {
+    // given
+    const getAppInfo = sinon.stub().resolves([{
+      name: 'pix-app-integration',
+      url: 'https://app.recette.pix.fr',
+      isUp: true,
+      lastDeployementAt: '2021-03-24T08:37:18.611Z',
+      lastDeployedBy: 'Bob',
+      lastDeployedVersion: 'v1.0.0',
+    }]);
+    sinon.stub(ScalingoClient, 'getInstance').withArgs('integration').resolves({ getAppInfo });
+
+    // when
+    const response = await getAppStatusFromScalingo('pix-app-integration');
+
+    // then
+    expect(response.blocks).is.not.empty;
+    expect(response).to.deep.equal(
+      {
+        'response_type': 'in_channel',
+        'blocks': [
+          {
+            'type': 'section',
+            'text': {
+              'type': 'mrkdwn',
+              'text': '*pix-app-integration* 💚\n2021-03-24T08:37:18.611Z',
+            }
+          }
+        ]
+      }
+    );
+  });
+
   it('returns status for all production apps for slack', async () => {
     // given
     const getAppInfo = sinon.stub().resolves([

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -38,7 +38,7 @@ describe('#getAppStatusFromScalingo', () => {
           'type': 'section',
           'text': {
             'type': 'mrkdwn',
-            'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z',
+            'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
           }
         }
       ]
@@ -98,7 +98,13 @@ describe('#getAppStatusFromScalingo', () => {
             'type': 'section',
             'text': {
               'type': 'mrkdwn',
-              'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z\n· *pix-api-production* is up 💚 - v1.1.0 deployed at 2021-03-25T08:37:18.611Z',
+              'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
+            }
+          }, {
+            'type': 'section',
+            'text': {
+              'type': 'mrkdwn',
+              'text': '*pix-api-production* 💚 - v1.1.0\n2021-03-25T08:37:18.611Z',
             }
           }
         ]
@@ -122,7 +128,7 @@ describe('#getAppStatusFromScalingo', () => {
     const response = await getAppStatusFromScalingo('pix-app-recette');
 
     // then
-    expect(response.blocks[0].text.text).equals('· *pix-app-recette* is down 🛑 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z');
+    expect(response.blocks[0].text.text).equals('*pix-app-recette* 🛑 - v1.0.0\n2021-03-24T08:37:18.611Z');
   });
 
   it('returns an error response if an error occured', async () => {
@@ -161,7 +167,7 @@ describe('#getAppStatusFromScalingo', () => {
           'type': 'section',
           'text': {
             'type': 'mrkdwn',
-            'text': '· *pix-app-production* is up 💚 - v1.0.0 deployed at 2021-03-24T08:37:18.611Z'
+            'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z'
           }
         },
       ]


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de lister le status des applications en intégration

## :robot: Solution
Ajouter la possibilité de lister le status des applications en intégration via la commande `/app-status integration`

## :rainbow: Remarques
Nouvelles variables d'environnement:
- SCALINGO_TOKEN_INTEGRATION
- SCALINGO_API_URL_INTEGRATION

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._