### PR TITLE
Redéployer une application via Slack

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -4,6 +4,7 @@ const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
 const github = require('../services/github');
 const postSlackMessage = require('../services/slack/surfaces/messages/post-message');
+const sendSlackBlockMessage = require('../services/slack/surfaces/messages/block-message');
 
 function _getDeployStartedMessage(release, appName) {
   return `Commande de déploiement de la release "${release}" pour ${appName} en production bien reçue.`;
@@ -59,6 +60,18 @@ module.exports = {
   getAppStatus(request) {
     const appName= request.pre.payload.text;
     return getAppStatusFromScalingo(appName);
+  },
+
+  async deployLastVersion(request) {
+    const appName = request.pre.payload.text;
+
+    try {
+      await commandsFromRun.getAndDeployLastVersion({ appName });
+    } catch(e) {
+      return sendSlackBlockMessage(e.message);
+    }
+
+    return sendSlackBlockMessage(`Re-déploiement de ${appName} déclenché`);
   },
 
   interactiveEndpoint(request) {

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -50,8 +50,14 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/deploy-last-version',
+    handler: slackbotController.deployLastVersion,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
     config: slackConfig
-  }
+  },
 ];

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -13,12 +13,12 @@ module.exports = {
     production: 'production'
   },
 
-  async deployPixRepo(repoName, appName, releaseTag) {
+  async deployPixRepo(repoName, appName, releaseTag, environment) {
     const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
     const sanitizedRepoName = _sanitizedArgument(repoName);
     const sanitizedAppName = _sanitizedArgument(appName);
+    const client = await ScalingoClient.getInstance(environment);
 
-    const client = await ScalingoClient.getInstance('production');
     return client.deployFromArchive(sanitizedAppName, sanitizedReleaseTag, sanitizedRepoName);
   },
 

--- a/common/services/slack/surfaces/messages/block-message.js
+++ b/common/services/slack/surfaces/messages/block-message.js
@@ -1,0 +1,12 @@
+module.exports = (message) => {
+  return {
+    response_type: 'in_channel',
+    blocks: [{
+      'type': 'section',
+      'text': {
+        'type': 'mrkdwn',
+        'text': message,
+      },
+    }],
+  };
+};

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -15,7 +15,8 @@ module.exports = {
     }
 
     const releaseTag = await githubServices.getLatestReleaseTag(PIX_SITE_REPO_NAME);
-    await Promise.all(PIX_SITE_APPS.map((appName) => releasesService.deployPixRepo(PIX_SITE_REPO_NAME, appName, releaseTag)));
+    const environment = 'production';
+    await Promise.all(PIX_SITE_APPS.map((appName) => releasesService.deployPixRepo(PIX_SITE_REPO_NAME, appName, releaseTag, environment)));
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -62,8 +62,9 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
     }
     await releasesService.publishPixRepo(repoName, releaseType);
     const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+    const environment = 'production';
 
-    await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag)));
+    await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment)));
 
     sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
   } catch (e) {

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -4,6 +4,7 @@ const githubServices = require('../../../common/services/github');
 const axios = require('axios');
 const postSlackMessage = require('../../../common/services/slack/surfaces/messages/post-message');
 
+const PIX_REPO_NAME = 'pix';
 const PIX_BOT_REPO_NAME = 'pix-bot';
 const PIX_LCMS_REPO_NAME = 'pix-editor';
 const PIX_LCMS_APP_NAME = 'pix-lcms';
@@ -88,6 +89,21 @@ async function publishAndDeployPixBot(repoName, releaseType, responseUrl) {
   sendResponse(responseUrl, `Pix Bot deployed (${releaseTag})`);
 }
 
+async function getAndDeployLastVersion({ appName }) {
+  const lastReleaseTag = await githubServices.getLatestReleaseTag(PIX_REPO_NAME);
+  const sanitizedAppName = appName.trim().toLowerCase();
+
+  const appNameParts = sanitizedAppName.split('-');
+  const environment = appNameParts[appNameParts.length - 1];
+
+  if (appNameParts.length!=3 || !['integration', 'recette', 'production'].includes(environment)) {
+    throw Error('Nom de l‘application incorrect');
+  }
+
+  const shortAppName = appNameParts[0] + '-' + appNameParts[1];
+  await releasesService.deployPixRepo(PIX_REPO_NAME, shortAppName, lastReleaseTag, environment);
+}
+
 module.exports = {
 
   async createAndDeployPixLCMS(payload) {
@@ -109,5 +125,9 @@ module.exports = {
   async createAndDeployPixBotRelease(payload) {
     await publishAndDeployPixBot(PIX_BOT_REPO_NAME, payload.text, payload.response_url);
   },
+
+  async getAndDeployLastVersion({ appName }) {
+    await getAndDeployLastVersion({ appName });
+  }
 
 };

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -22,9 +22,11 @@ describe('releases', function() {
       const scalingoClient = new ScalingoClient(null, 'production');
       scalingoClient.deployFromArchive = sinon.stub();
       scalingoClient.deployFromArchive.withArgs('app-name', 'v1.0.0', 'pix-site').resolves('OK');
-      sinon.stub(ScalingoClient, 'getInstance').resolves(scalingoClient);
+      sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves(scalingoClient);
+
       // when
-      const response = await releasesService.deployPixRepo('Pix-Site', 'app-name', 'V1.0.0 ');
+      const response = await releasesService.deployPixRepo('Pix-Site', 'app-name', 'V1.0.0 ', 'production');
+
       // then
       expect(response).to.equal('OK');
     });

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -1,12 +1,14 @@
 const { describe, it } = require('mocha');
+const { expect } = require('chai');
 const axios = require('axios');
-const { sinon } = require('../../../../test-helper');
+const { catchErr, sinon } = require('../../../../test-helper');
 const {
   createAndDeployPixLCMS,
   createAndDeployPixUI,
   createAndDeployPixSiteRelease,
   createAndDeployPixDatawarehouse,
   createAndDeployPixBotRelease,
+  getAndDeployLastVersion,
 } = require('../../../../../run/services/slack/commands');
 const releasesServices = require('../../../../../common/services/releases');
 const githubServices = require('../../../../../common/services/github');
@@ -171,6 +173,30 @@ describe('Services | Slack | Commands', () => {
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixRepo);
+    });
+  });
+
+  describe('#getAndDeployLastVersion', () => {
+    it('should redeploy last version of an app', async () => {
+      // given
+      const appName = 'pix-admin-integration';
+
+      // when
+      await getAndDeployLastVersion({ appName });
+
+      // then
+      sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix', 'pix-admin', 'v1.0.0', 'integration');
+    });
+
+    it('should throw an error if appName is incorrect', async () => {
+      // given
+      const appName = 'pix-admin';
+
+      // when
+      const response = await catchErr(getAndDeployLastVersion)({ appName });
+
+      // then
+      expect(response).to.be.instanceOf(Error);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, pour redéployer une application il faut passer par Scalingo.
Pour l'intégration et la recette, cela peut se faire via l'interface de Scalingo.
Mais pour la production, il faut se connecter au client en ligne de commande.
Il nous faudrait un moyen simple pour redéployer une application.

## :robot: Solution
Grâce à la commande `/redeploy-app [_app-name_]`:
- le dernier tag Github du repo pix sera récupéré
- le redéploiment de la dernière version sera démarré

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._