### PR TITLE
[FEATURE] Ajoute la commande de création, publication et déploiement en recette d'un patch (hotfix).

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -2,6 +2,7 @@ const commandsFromRun = require('../../run/services/slack/commands');
 const { getAppStatusFromScalingo } = require('../../run/services/slack/app-status-from-scalingo');
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
+const { environments, deploy, publish } = require('../services/releases');
 const github = require('../services/github');
 const postSlackMessage = require('../services/slack/surfaces/messages/post-message');
 const sendSlackBlockMessage = require('../services/slack/surfaces/messages/block-message');
@@ -54,6 +55,20 @@ module.exports = {
 
     return {
       'text': _getDeployStartedMessage(payload.text, 'PIX Datawarehouse')
+    };
+  },
+
+  createAndDeployPixHotfix(request) {
+    const payload = request.pre.payload;
+
+    publish('patch', payload.text).then(async () => {
+      const latestReleaseTag = await github.getLatestReleaseTag();
+      await deploy(environments.recette, latestReleaseTag);
+    });
+
+
+    return {
+      'text': 'Commande de déploiement de hotfix de PIX en recette.'
     };
   },
 

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -44,6 +44,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-hotfix',
+    handler: slackbotController.createAndDeployPixHotfix,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/commands/app-status',
     handler: slackbotController.getAppStatus,
     config: slackConfig

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -67,7 +67,7 @@ async function _runScriptWithArgument (scriptFileName, ...args) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
   const {stdout, stderr} = await exec(`${scriptsDirectory}/${scriptFileName} ${args.join(' ')}`);
   console.log(`stdout: ${stdout}`);
-  const lastLine = stdout.split('\n').reverse()[1];
+  const lastLine = stdout.split('\n').slice(-2, -1).pop();
   console.error(`stderr: ${stderr}`);
   return lastLine;
 }

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -13,13 +13,17 @@ module.exports = {
     production: 'production'
   },
 
-  async deployPixRepo(repoName, appName, releaseTag, environment) {
-    const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
-    const sanitizedRepoName = _sanitizedArgument(repoName);
-    const sanitizedAppName = _sanitizedArgument(appName);
-    const client = await ScalingoClient.getInstance(environment);
-
-    return client.deployFromArchive(sanitizedAppName, sanitizedReleaseTag, sanitizedRepoName);
+  async publish(releaseType, branchName) {
+    const scriptFileName = 'publish.sh';
+    try {
+      const sanitizedReleaseType = _sanitizedArgument(releaseType);
+      const sanitizedBranchName = _sanitizedArgument(branchName);
+      const newPackageVersion = await _runScriptWithArgument(scriptFileName, sanitizedReleaseType, sanitizedBranchName);
+      return newPackageVersion;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
   },
 
   async deploy(environment, releaseTag) {
@@ -35,17 +39,6 @@ module.exports = {
     return results;
   },
 
-  async publish(releaseType) {
-    const scriptFileName = 'publish.sh';
-    try {
-      const sanitizedReleaseType = _sanitizedArgument(releaseType);
-      await _runScriptWithArgument(scriptFileName, sanitizedReleaseType);
-    } catch (err) {
-      console.error(err);
-      throw err;
-    }
-  },
-
   async publishPixRepo(repoName, releaseType) {
     try {
       const sanitizedReleaseType = _sanitizedArgument(releaseType);
@@ -58,13 +51,25 @@ module.exports = {
     }
   },
 
+  async deployPixRepo(repoName, appName, releaseTag, environment) {
+    const sanitizedReleaseTag = _sanitizedArgument(releaseTag);
+    const sanitizedRepoName = _sanitizedArgument(repoName);
+    const sanitizedAppName = _sanitizedArgument(appName);
+    const client = await ScalingoClient.getInstance(environment);
+
+    return client.deployFromArchive(sanitizedAppName, sanitizedReleaseTag, sanitizedRepoName);
+  },
+
+  _runScriptWithArgument,
 };
 
 async function _runScriptWithArgument (scriptFileName, ...args) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
   const {stdout, stderr} = await exec(`${scriptsDirectory}/${scriptFileName} ${args.join(' ')}`);
   console.log(`stdout: ${stdout}`);
+  const lastLine = stdout.split('\n').reverse()[1];
   console.error(`stderr: ${stderr}`);
+  return lastLine;
 }
 
 function _sanitizedArgument(param) {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,7 +16,7 @@ function clone_repository_and_move_inside {
   REPOSITORY_FOLDER=$(mktemp -d)
   echo "Created temporary directory ${REPOSITORY_FOLDER}"
 
-  git clone --depth 1 "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}.git" "${REPOSITORY_FOLDER}"
+  git clone --depth 1 --branch "${BRANCH_NAME}" "https://${GITHUB_USERNAME}:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPOSITORY}.git" "${REPOSITORY_FOLDER}"
   echo "Cloned repository ${GITHUB_OWNER}/${GITHUB_REPOSITORY} to temporary directory"
 
   cd "${REPOSITORY_FOLDER}" || exit 1

--- a/scripts/dummy-script.sh
+++ b/scripts/dummy-script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Hello"
+echo "Some other logs"
+echo "OK"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -104,3 +104,4 @@ push_commit_and_tag_to_remote
 publish_release_on_sentry
 
 echo -e "Release publication ${GREEN}succeeded${RESET_COLOR}."
+echo "${NEW_PACKAGE_VERSION}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,9 +7,10 @@ GITHUB_OWNER=${GITHUB_OWNER:-1024pix}
 GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-pix}
 echo "${CWD_DIR}"
 
-source "${CWD_DIR}/scripts/common.sh"
-
 NEW_VERSION_TYPE=$1
+BRANCH_NAME=${2:-dev}
+
+source "${CWD_DIR}/scripts/common.sh"
 
 function ensure_no_uncommited_changes_are_present() {
   if [ -n "$(git status --porcelain)" ]; then
@@ -29,8 +30,8 @@ function ensure_new_version_is_either_minor_or_patch_or_major() {
   echo "Version type OK"
 }
 
-function checkout_dev() {
-  git checkout dev >>/dev/null 2>&1
+function checkout() {
+  git checkout "${BRANCH_NAME}" >>/dev/null 2>&1
 }
 
 function fetch_and_rebase() {
@@ -92,7 +93,7 @@ echo "== Validate context =="
 ensure_no_uncommited_changes_are_present
 ensure_new_version_is_either_minor_or_patch_or_major
 echo "== Package release =="
-checkout_dev
+checkout
 fetch_and_rebase
 update_all_pix_modules_version
 complete_change_log

--- a/test/integration/common/services/releases_test.js
+++ b/test/integration/common/services/releases_test.js
@@ -1,0 +1,18 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const releasesService = require('../../../../common/services/releases');
+
+describe('releases', function() {
+
+  describe('#_runScriptWithArgument', async function() {
+    it('should execute and return last line of script output', async function() {
+      // when
+      const lastLine = await releasesService._runScriptWithArgument('dummy-script.sh');
+
+      // then
+      expect(lastLine).to.equal('OK');
+    });
+  });
+});
+
+

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -9,7 +9,7 @@ describe('releases', function() {
   let releasesService;
 
   before(() => {
-    exec = sinon.stub().callsFake(async () => Promise.resolve({stdout: '', stderr: ''}));
+    exec = sinon.stub().callsFake(async () => Promise.resolve({stdout: 'some heavy logs\n3.14.0\n', stderr: ''}));
     releasesService = proxyquire('../../../../common/services/releases', {
       'child_process': {exec},
       util: {promisify: fn => fn}
@@ -71,6 +71,13 @@ describe('releases', function() {
 
       // then
       sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/publish.sh minor)')));
+    });
+    it('should retrieve new package version', async function () {
+      //when
+      const newPackageVersion = await releasesService.publish('minor');
+
+      // then
+      expect(newPackageVersion).to.equal('3.14.0');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La création d‘un hotfix se fait actuellement entièrement manuellement.
Par définition, le hotfix est nécessaire dans des conditions de stress inhabituelles.
Dépendre d'une opération manuelle est une source de stress additionnelle.

## :robot: Solution
Pour la santé mentale de l‘équipe technique, on ajoute une commande slack `/deploy-hotfix [branch-name]`.
Cette commande appelle un endpoint de Pix-bot qui se charge de créée une nouvelle release de type `patch` à partir de la branche donnée.
Après publication, la release est déployée en recette.

## :rainbow: Remarques
Après la recette du hotfix, on peut le déployer en production en utilisant Slack comme à l'accoutumée.
Il suffira de préciser le nom du hotfix comme nom de version à mettre en production.
  
Il faudra par la suite créer une Pull-Request depuis la branche de hotfix vers `dev` pour que la branche principale soit à jour avec le hotfix.
  
## :100: Pour tester
En local uniquement.
Lancer Pix-bot avec `npm start`.
Lancer `ngrock` avec `ngrock http 3000`.
Configurer la commande `/deploy-hotfix` de l'environnement Slack `Pix-Bot-Test` avec l'adresse donnée par ngrock suivi de `/slack/commands/create-and-deploy-pix-hotfix`.
Taper la commande `/deploy-hotfix` suivie du nom de la branche à déployer.
Vérifier la création d'un commit `[RELEASE] A patch is being released to x.y.z.` avec z > 0.


