### PR TITLE
[TECH] Correction de la commande de hotfix Slack

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -60,12 +60,11 @@ module.exports = {
 
   createAndDeployPixHotfix(request) {
     const payload = request.pre.payload;
+    const branchName = payload.text;
 
-    publish('patch', payload.text).then(async () => {
-      const latestReleaseTag = await github.getLatestReleaseTag();
+    publish('patch', branchName).then(async (latestReleaseTag) => {
       await deploy(environments.recette, latestReleaseTag);
     });
-
 
     return {
       'text': 'Commande de déploiement de hotfix de PIX en recette.'

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -156,8 +156,8 @@ async function _getDefaultBranch(repoOwner, repoName) {
   return data.default_branch;
 }
 
-async function _getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName) {
-  const defaultBranch = await _getDefaultBranch(repoOwner, repoName);
+async function _getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName) {
+  const defaultBranch = branchName || await _getDefaultBranch(repoOwner, repoName);
   const { pulls } = _createOctokit();
   const { data } = await pulls.list({
     owner: repoOwner,
@@ -223,8 +223,8 @@ module.exports = {
     return _getCommitAtURL(commitUrl);
   },
 
-  async getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName) {
-    return _getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName);
+  async getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName) {
+    return _getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
   },
 
   async isBuildStatusOK({ branchName, tagName }) {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -41,7 +41,7 @@ function push_commit_and_tag_to_remote() {
 }
 
 function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}"
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -40,11 +40,12 @@ async function main() {
   const tagVersion = process.argv[2];
   const repoOwner = process.argv[3];
   const repoName = process.argv[4];
+  const branchName = process.argv[5];
 
   try {
     const dateOfLastMEP = await getLastMEPDate(repoOwner, repoName);
 
-    const pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName);
+    const pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
 
     const newChangeLogLines = [];
 

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -168,6 +168,23 @@ describe('#getMergedPullRequestsSortedByDescendingDate', () => {
     expect(response).to.deep.equal(pullRequests);
   });
 
+  it('should call GitHub "Pulls" API with given branch name', async () => {
+    // given
+    const pullRequests = [
+      { merged_at: '2020-09-02T12:26:47Z' },
+      { merged_at: '2020-09-01T12:26:47Z' }
+    ];
+    nock('https://api.github.com')
+      .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc&base=toto')
+      .reply(200, pullRequests);
+
+    // when
+    const response = await githubService.getMergedPullRequestsSortedByDescendingDate('github-owner', 'github-repository', 'toto');
+
+    // then
+    expect(response).to.deep.equal(pullRequests);
+  });
+
 });
 
 describe('#getCommitAtURL', () => {


### PR DESCRIPTION
## :unicorn: Problème

La commande de hotfix a échouée, car elle ne récupérait pas la bonne version à déployer et ne générait pas le changelog à partir de la branche de hotfix.

## :robot: Solution
- Récupérer correctement la version du hotfix à déployer
- Donner le nom de la branche de hotfix au script de génération du changelog

## :rainbow: Remarques
N/A

## :100: Pour tester
Faire un hotfix 🤯