### PR TITLE
[TECH] Corriger l'utilisation de la variable BRANCH_NAME dans common.sh

### DIFF
--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -2,12 +2,14 @@
 
 set -euxo pipefail
 
-source "$(dirname $0)"/common.sh
 
 CWD_DIR=$(pwd)
 GITHUB_OWNER=(${1})
 GITHUB_REPOSITORY=(${2})
 VERSION_TYPE=(${3-""})
+BRANCH_NAME=""
+
+source "$(dirname $0)"/common.sh
 
 echo "Version type ${VERSION_TYPE} for ${GITHUB_OWNER}/${GITHUB_REPOSITORY}"
 


### PR DESCRIPTION
## :unicorn: Problème

Au moment du hotfix, une erreur apparait:
'/app/scripts/common.sh: line 19: BRANCH_NAME: unbound variable\n'

## :robot: Solution
Définir la variable BRANCH_NAME dans release-pix-repo.sh

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._