### PR TITLE
Obfusquer le token dans les logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:minor": "npm version minor && npm run deploy:tag",
     "deploy:patch": "npm version patch && npm run deploy:tag",
     "deploy:tag": "git push --tags && git push",
-    "start": "node bin/www",
+    "start": "node bin/www | sed \"s/$GITHUB_PERSONAL_ACCESS_TOKEN/**TOKEN**/\"",
     "test": "NODE_ENV=test mocha --recursive --exit test",
     "lint": "eslint common/* run/* build/* bin/* test/*"
   },


### PR DESCRIPTION
## :unicorn: Problème
Le processus de release mentionne les tokens Github dans les logs (le token ci-dessous est révoqué bien sûr).
Il est dans les bonnes pratiques de ne pas le mentionner
```
2021-05-25 12:25:41.466896865 +0200 CEST [web-1] + git clone --depth 1 --branch dev https://pix-service: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@github.com/1024pix/pix.git /tmp/tmp.ErKVCMBYwx
2021-05-25 12:25:41.466896368 +0200 CEST [web-1] + echo 'Created temporary directory /tmp/tmp.ErKVCMBYwx'
```

## :robot: Solution
Le remplacer par une chaîne symbolique ` **TOKEN**` lors de la sortie de `npm start` (Hapi)

## :rainbow: Remarques
Le script qui mentionne le token est [release-pix-repo.sh](http://github.com/1024pix/pix-bot/blob/main/scripts/release-pix-repo.sh), dans les fonction de [common.sh](http://github.com/1024pix/pix-bot/blob/main/scripts/common.sh)
* `clone_repository_and_move_inside`
* `push_commit_and_tag_to_remote`

## :100: Pour tester
Faire une release et vérifier que seul ` **TOKEN**` est mentionné