### PR TITLE
[BUGFIX] Empêcher le run de /deploy-last-version sur une application autre que celle du repo Pix

### DIFF
--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -13,6 +13,8 @@ const PIX_SITE_REPO_NAME = 'pix-site';
 const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
 const PIX_DATAWAREHOUSE_REPO_NAME = 'pix-db-replication';
 const PIX_DATAWAREHOUSE_APPS_NAME = ['pix-datawarehouse', 'pix-datawarehouse-ex'];
+const PIX_APPS = ['app', 'certif', 'admin', 'orga', 'api'];
+const PIX_APPS_ENVIRONMENTS = ['integration', 'recette', 'production'];
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,
@@ -96,12 +98,26 @@ async function getAndDeployLastVersion({ appName }) {
   const appNameParts = sanitizedAppName.split('-');
   const environment = appNameParts[appNameParts.length - 1];
 
-  if (appNameParts.length!=3 || !['integration', 'recette', 'production'].includes(environment)) {
-    throw Error('Nom de l‘application incorrect');
+  if (!_isAppFromPixRepo({ appName: sanitizedAppName })) {
+    throw Error('L‘application doit faire partie du repo Pix');
   }
 
   const shortAppName = appNameParts[0] + '-' + appNameParts[1];
   await releasesService.deployPixRepo(PIX_REPO_NAME, shortAppName, lastReleaseTag, environment);
+}
+
+function _isAppFromPixRepo({ appName }) {
+  const appNameParts = appName.split('-');
+
+  if(appNameParts.length != 3) {
+    return false;
+  }
+
+  const [appNamePrefix, shortAppName, environment] = appName.split('-');
+
+  return appNamePrefix === 'pix'
+    && PIX_APPS.includes(shortAppName)
+    && PIX_APPS_ENVIRONMENTS.includes(environment);
 }
 
 module.exports = {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -198,5 +198,16 @@ describe('Services | Slack | Commands', () => {
       // then
       expect(response).to.be.instanceOf(Error);
     });
+
+    it('should throw an error if appName is not from pix repo', async () => {
+      // given
+      const appName = 'pix-site-production';
+
+      // when
+      const response = await catchErr(getAndDeployLastVersion)({ appName });
+
+      // then
+      expect(response).to.be.instanceOf(Error);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La commande Slack `/deploy-last-version pix-site-production` n'aurait pas dû être exécutée car la commande déploie seulement les applications issues du repository Pix.

## :robot: Solution
Ajouter un retour d'erreur si le nom de l'application passée en paramètre ne correspond pas à une application au format`pix-['app', 'certif', 'admin', 'orga', 'api']-['integration', 'recette', 'production']`.

## :rainbow: Remarques
Il existe une commande Slack pour déployer pix-site: `/deploy-pix-sites`.
Merger les deux commandes ?

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._