### PR TITLE
Ne pas afficher les commandes exécutés dans les scripts de publication pour ne pas afficher les tokens en prod

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 CWD_DIR=$(pwd)
 GITHUB_OWNER=${GITHUB_OWNER:-1024pix}

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 
 CWD_DIR=$(pwd)


### PR DESCRIPTION
## :unicorn: Problème
Voir #78. L'utilisation de sed n'étant pas idéale, chez repris la proposition de Jonathan.

## :robot: Solution
Ne pas afficher les commandes bash dans la sortie du script

## :rainbow: Remarques
J'ai tenté d'utiliser le stockage des credentials de git, mais je ne vois pas comment l'utiliser tout en évitant d'afficher le token dans la sortie.

## :100: Pour tester
Faire une release et vérifier que les commandes bash ne sont plus affichées.