### PR TITLE
[FEAT] Ajout d'un CRON pour déployer Pix site tous les mois pour maintenir les statistiques à jour (PIX-2939).

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -4,12 +4,14 @@ const config = require('../config');
 const server = require('../server');
 const { createCronJob } = require('../common/services/cron-job');
 const sendInBlueReport = require('../run/services/sendinblue-report');
+const { deploy } = require('../run/services/deploy');
 const ecoModeService = require('../build/services/eco-mode-service');
 
 const init = async () => {
   await ecoModeService.start();
 
   createCronJob('SendInBlue Report', sendInBlueReport.getReport, config.thirdServicesUsageReport.schedule);
+  createCronJob('Deploy Pix site', () => { deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS); }, config.pixSiteDeploy.schedule);
 
   await server.start();
   console.log('Server running on %s', server.info.uri);

--- a/config.js
+++ b/config.js
@@ -84,6 +84,10 @@ module.exports = (function() {
       secret: process.env.PRISMIC_SECRET,
     },
 
+    pixSiteDeploy: {
+      schedule: process.env.PIX_SITE_DEPLOY_SCHEDULE,
+    },
+
     PIX_REPO_NAME: 'pix',
     PIX_BOT_REPO_NAME: 'pix-bot',
     PIX_LCMS_REPO_NAME: 'pix-editor',

--- a/config.js
+++ b/config.js
@@ -83,6 +83,18 @@ module.exports = (function() {
     prismic: {
       secret: process.env.PRISMIC_SECRET,
     },
+
+    PIX_REPO_NAME: 'pix',
+    PIX_BOT_REPO_NAME: 'pix-bot',
+    PIX_LCMS_REPO_NAME: 'pix-editor',
+    PIX_LCMS_APP_NAME: 'pix-lcms',
+    PIX_UI_REPO_NAME: 'pix-ui',
+    PIX_SITE_REPO_NAME: 'pix-site',
+    PIX_SITE_APPS: ['pix-site', 'pix-pro'],
+    PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
+    PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex'],
+    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api'],
+    PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -3,9 +3,6 @@ const { deploy } = require('../services/deploy');
 
 const Boom = require('@hapi/boom');
 
-const PIX_SITE_REPO_NAME = 'pix-site';
-const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
-
 module.exports = {
 
   async deploySites(request) {
@@ -14,7 +11,7 @@ module.exports = {
       throw Boom.unauthorized('Secret is missing or is incorrect');
     }
 
-    const releaseTag = await deploy(PIX_SITE_REPO_NAME, PIX_SITE_APPS);
+    const releaseTag = await deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS);
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -1,6 +1,6 @@
-const githubServices = require('../../common/services/github');
-const releasesService = require('../../common/services/releases');
 const config = require('../../config');
+const { deploy } = require('../services/deploy');
+
 const Boom = require('@hapi/boom');
 
 const PIX_SITE_REPO_NAME = 'pix-site';
@@ -14,9 +14,7 @@ module.exports = {
       throw Boom.unauthorized('Secret is missing or is incorrect');
     }
 
-    const releaseTag = await githubServices.getLatestReleaseTag(PIX_SITE_REPO_NAME);
-    const environment = 'production';
-    await Promise.all(PIX_SITE_APPS.map((appName) => releasesService.deployPixRepo(PIX_SITE_REPO_NAME, appName, releaseTag, environment)));
+    const releaseTag = await deploy(PIX_SITE_REPO_NAME, PIX_SITE_APPS);
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },

--- a/run/services/deploy.js
+++ b/run/services/deploy.js
@@ -1,0 +1,13 @@
+const githubServices = require('../../common/services/github');
+const releasesService = require('../../common/services/releases');
+
+async function deploy(repoName, appNamesList) {
+  const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+  const environment = 'production';
+  await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment)));
+  return releaseTag;
+}
+
+module.exports = {
+  deploy,
+};

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -1,21 +1,22 @@
 const { deploy } = require('../deploy');
+const {
+  PIX_REPO_NAME,
+  PIX_APPS,
+  PIX_APPS_ENVIRONMENTS,
+  PIX_SITE_REPO_NAME,
+  PIX_SITE_APPS,
+  PIX_BOT_REPO_NAME,
+  PIX_DATAWAREHOUSE_REPO_NAME,
+  PIX_DATAWAREHOUSE_APPS_NAME,
+  PIX_LCMS_REPO_NAME,
+  PIX_LCMS_APP_NAME,
+  PIX_UI_REPO_NAME,
+} = require('../../../config');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
 const githubServices = require('../../../common/services/github');
 const axios = require('axios');
 const postSlackMessage = require('../../../common/services/slack/surfaces/messages/post-message');
-
-const PIX_REPO_NAME = 'pix';
-const PIX_BOT_REPO_NAME = 'pix-bot';
-const PIX_LCMS_REPO_NAME = 'pix-editor';
-const PIX_LCMS_APP_NAME = 'pix-lcms';
-const PIX_UI_REPO_NAME = 'pix-ui';
-const PIX_SITE_REPO_NAME = 'pix-site';
-const PIX_SITE_APPS = ['pix-site', 'pix-pro'];
-const PIX_DATAWAREHOUSE_REPO_NAME = 'pix-db-replication';
-const PIX_DATAWAREHOUSE_APPS_NAME = ['pix-datawarehouse', 'pix-datawarehouse-ex'];
-const PIX_APPS = ['app', 'certif', 'admin', 'orga', 'api'];
-const PIX_APPS_ENVIRONMENTS = ['integration', 'recette', 'production'];
 
 function sendResponse(responseUrl, text) {
   axios.post(responseUrl,

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -1,3 +1,4 @@
+const { deploy } = require('../deploy');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
 const githubServices = require('../../../common/services/github');
@@ -64,10 +65,7 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
       releaseType = 'minor';
     }
     await releasesService.publishPixRepo(repoName, releaseType);
-    const releaseTag = await githubServices.getLatestReleaseTag(repoName);
-    const environment = 'production';
-
-    await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment)));
+    const releaseTag = await deploy(repoName, appNamesList);
 
     sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
   } catch (e) {


### PR DESCRIPTION
## :unicorn: Problème
Depuis la PR https://github.com/1024pix/pix-site/pull/288 le site vitrine build les graphiques de statistiques à chaque déploiement. Seulement pour que ceux-ci soient à jour il faut qu'il y ait au moins un déploiement par mois.

## :robot: Solution
Ajouter un CRON permettant de déployer une fois par mois Pix Site.

## :rainbow: Remarques
Ajouter la variable PIX_SITE_DEPLOY_SCHEDULE=0 0 1 * *

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._