### PR TITLE
[TECH] Notifier s'il y a eu des changements de variables d'environnement lors d'une mise en recette ou d'une mise en production.

### DIFF
--- a/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
@@ -1,5 +1,5 @@
-module.exports = (releaseType) => {
-  return {
+module.exports = (releaseType, hasConfigFileChanged) => {
+  const modalReleasePublicationConfirmation = {
     'response_action': 'push',
     'view': {
       'type': 'modal',
@@ -30,4 +30,16 @@ module.exports = (releaseType) => {
       ]
     }
   };
+
+  if (hasConfigFileChanged) {
+    modalReleasePublicationConfirmation.view.blocks.unshift({
+      'type': 'section',
+      'text': {
+        'type': 'mrkdwn',
+        'text': ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
+      },
+    });
+  }
+
+  return modalReleasePublicationConfirmation;
 };

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -193,6 +193,18 @@ async function _getLatestReleaseDate(repoOwner, repoName) {
   return commit.committer.date;
 }
 
+async function _getCommitsWhereConfigFileHasChangedSinceDate(repoOwner, repoName, date) {
+  const { repos } = _createOctokit();
+  const { data } = await repos.listCommits({
+    owner: repoOwner,
+    repo: repoName,
+    since: date,
+    path: 'api/lib/config.js',
+  });
+  
+  return data;
+}
+
 module.exports = {
 
   async getPullRequests(label) {
@@ -250,5 +262,11 @@ module.exports = {
 
     return pullRequestsSinceLatestRelease.map((PR) => `${PR.title}`);
   },
+
+  async hasConfigFileChangedSinceLatestRelease(repoOwner = settings.github.owner, repoName = settings.github.repository) {
+    const latestReleaseDate = await _getLatestReleaseDate(repoOwner, repoName);
+    const commits = await _getCommitsWhereConfigFileHasChangedSinceDate(repoOwner, repoName, latestReleaseDate);
+    return commits.length > 0;
+  }
 
 };

--- a/common/services/slack/view-submissions.js
+++ b/common/services/slack/view-submissions.js
@@ -31,9 +31,10 @@ module.exports = {
 
   // Release deployment
 
-  submitReleaseTagSelection(payload) {
+  async submitReleaseTagSelection(payload) {
     const releaseTag = payload.view.state.values['deploy-release-tag']['release-tag-value'].value;
-    return openModalReleaseDeploymentConfirmation(releaseTag);
+    const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
+    return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
   },
 
   submitReleaseDeploymentConfirmation(payload) {

--- a/common/services/slack/view-submissions.js
+++ b/common/services/slack/view-submissions.js
@@ -8,9 +8,10 @@ module.exports = {
 
   // Release publication
 
-  submitReleaseTypeSelection(payload) {
+  async submitReleaseTypeSelection(payload) {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
-    return openModalReleasePublicationConfirmation(releaseType);
+    const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
+    return openModalReleasePublicationConfirmation(releaseType, hasConfigFileChanged);
   },
 
   submitReleasePublicationConfirmation(payload) {

--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -1,5 +1,5 @@
-module.exports = (releaseTag) => {
-  return {
+module.exports = (releaseTag, hasConfigFileChanged) => {
+  const modalReleaseDeploymentConfirmation = {
     'response_action': 'push',
     'view': {
       'type': 'modal',
@@ -30,4 +30,16 @@ module.exports = (releaseTag) => {
       ]
     }
   };
+
+  if(hasConfigFileChanged) {
+    modalReleaseDeploymentConfirmation.view.blocks.unshift({
+      'type': 'section',
+      'text': {
+        'type': 'mrkdwn',
+        'text': ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
+      },
+    });
+  }
+
+  return modalReleaseDeploymentConfirmation;
 };


### PR DESCRIPTION
## :unicorn: Problème
Quand on ajoute/enlève des variables d'env du fichier config.js, souvent il nous arrive d'oublier de faire la modification sur Scalingo recette/prod.

## :robot: Solution
Si des variables ont été modifiées, alors lors d'une mise en prod/recette, une pop up slack nous en informera avant de confirmer la publication/le déploiement.
![image](https://user-images.githubusercontent.com/35958509/133471466-2ca37936-84f2-4ca3-bf52-584bb65dbda1.png)


## :rainbow: Remarques


## :100: Pour tester LOCALEMENT sur Pix Bot Test
- pour une mise en recette

1. Aller sur  Slack API de Pix Bot BUILD Test  https://api.slack.com/apps/A01LUSH342F et récuéper le `Signing Secret` dans l'onglet **Basic information**  et le `bot user token` dans l'onglet **OAuth & permissions**. Mettre le tout dans le point .env

> SLACK_BOT_TOKEN= `Signing Secret`
> SLACK_SIGNING_SECRET=`bot user token`

2. Lancer 2 terminaux: 1 pour lancer votre api, et l'autre pour lancer `npx ngrok http 3000` ce qui va vous générer une url.
3. Cette url vous aller la mettre dans `Request url` dans l'onglet **Interactivity & Shortcuts**
>http://URL_GÉNÉRÉE.ngrok.io/slack/interactive-endpoint

4.  Une fois que tout ça est fait, il n'a plus qu'à lancer la commande pix bot run test sur pix bot test