### PR TITLE
[BUGFIX] Utiliser le bon attribut comme lien vers les PR dans le changelog. 

### DIFF
--- a/scripts/models/PullRequest.js
+++ b/scripts/models/PullRequest.js
@@ -2,8 +2,8 @@ const { Tags } = require('./Tags');
 
 class PullRequest {
 
-  constructor({ htmlUrl, number, title }) {
-    this.htmlUrl = htmlUrl;
+  constructor({ html_url, number, title }) {
+    this.htmlUrl = html_url;
     this.number = number;
     this.title = title;
 

--- a/test/unit/scripts/get-pull-requests-to-release-in-prod_test.js
+++ b/test/unit/scripts/get-pull-requests-to-release-in-prod_test.js
@@ -230,22 +230,22 @@ describe('Unit | Script | GET Pull Request to release in Prod', () => {
 
       const pullRequests = [
         {
-          htmlUrl: 'https://github.com/foo/foo/pull/100',
+          html_url: 'https://github.com/foo/foo/pull/100',
           number: 100,
           title: '[FEATURE] PIX-1',
         },
         {
-          htmlUrl: 'https://github.com/foo/foo/pull/101',
+          html_url: 'https://github.com/foo/foo/pull/101',
           number: 101,
           title: '[TECH] PIX-2',
         },
         {
-          htmlUrl: 'https://github.com/foo/foo/pull/102',
+          html_url: 'https://github.com/foo/foo/pull/102',
           number: 102,
           title: '[BUGFIX] PIX-3',
         },
         {
-          htmlUrl: 'https://github.com/foo/foo/pull/104',
+          html_url: 'https://github.com/foo/foo/pull/104',
           number: 104,
           title: 'Foo PIX-4',
         }

--- a/test/unit/scripts/models/PullRequest_test.js
+++ b/test/unit/scripts/models/PullRequest_test.js
@@ -10,7 +10,7 @@ describe('Unit | Script | Models | PullRequest', () => {
     it('should create an instance of PullRequest', () => {
       // given
       const properties = {
-        htmlUrl: 'url',
+        html_url: 'url',
         number: 1,
         title: 'title',
       };
@@ -25,7 +25,7 @@ describe('Unit | Script | Models | PullRequest', () => {
     it('should have title, number and htmlUrl properties', () => {
       // given
       const properties = {
-        htmlUrl: 'url',
+        html_url: 'url',
         number: 1,
         title: 'title',
       };
@@ -34,7 +34,7 @@ describe('Unit | Script | Models | PullRequest', () => {
       const createdInstance = new PullRequest(properties);
 
       // then
-      expect(createdInstance.htmlUrl).to.equal(properties.htmlUrl);
+      expect(createdInstance.htmlUrl).to.equal(properties.html_url);
       expect(createdInstance.number).to.equal(properties.number);
       expect(createdInstance.title).to.equal(properties.title);
     });
@@ -43,7 +43,7 @@ describe('Unit | Script | Models | PullRequest', () => {
       // given
       sinon.spy(Tags, 'getTagByTitle');
       const properties = {
-        htmlUrl: 'url',
+        html_url: 'url',
         number: 1,
         title: 'title',
       };
@@ -58,7 +58,7 @@ describe('Unit | Script | Models | PullRequest', () => {
     it('should have a tag property', () => {
       // given
       const properties = {
-        htmlUrl: 'url',
+        html_url: 'url',
         number: 1,
         title: 'title',
       };
@@ -75,12 +75,12 @@ describe('Unit | Script | Models | PullRequest', () => {
 
     it('should return a string with properties', () => {
       // given
-      const htmlUrl = 'https://github.com/1024pix/pix/pull/2971';
+      const html_url = 'https://github.com/1024pix/pix/pull/2971';
       const number = 2971;
       const title = '[FEATURE] Passer les sessions assignées comme sessions "à traiter" (PIX-2571).';
-      const properties = { htmlUrl, number, title };
+      const properties = { html_url, number, title };
 
-      const expectedString = `- [#${number}](${htmlUrl}) ${title}`;
+      const expectedString = `- [#${number}](${html_url}) ${title}`;
 
       // when
       const createdInstance = new PullRequest(properties);


### PR DESCRIPTION
## :unicorn: Problème
Depuis la PR #87 les urls vers les PR ne sont plus définis dans le changelog. 

## :robot: Solution
Utiliser l'attribut `html_url` retourné par l'API de Github dans le constructeur du model `PullRequest`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._