### PR TITLE
[TECH] Avoir le même workflow de merge que sur les autres repositories.

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
 name: automerge check
+
 on:
   pull_request:
     types:
@@ -6,16 +7,20 @@ on:
   check_suite:
     types:
       - completed
+
+permissions: write-all
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.3"
+        uses: "pascalgn/automerge-action@v0.14.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"
           MERGE_FORKS: "false"
+          LOG: "TRACE"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur ce repository, nous devons cliquer sur le bouton de merge et ajouter le titre de la PR à la main. Cela est sujet aux oublies.

## :robot: Solution
Avoir le même workflow de merge sur ce repository via le label : 🚀 Ready to merge.

## :rainbow: Remarques
Le token : `PIX_SERVICE_ACTIONS_TOKEN` a bien été ajouté au repository. 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._