### PR TITLE
[FEATURE] Ajout du support d'ember-testing-library

### DIFF
--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -31,6 +31,15 @@ module.exports = {
     };
   },
 
+  createAndDeployEmberTestingLibraryRelease(request) {
+    const payload = request.pre.payload;
+    commandsFromRun.createAndDeployEmberTestingLibrary(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'EMBER-TESTING-LIBRARY')
+    };
+  },
+
   createAndDeployPixBotRelease(request) {
     const payload = request.pre.payload;
     commandsFromRun.createAndDeployPixBotRelease(payload);

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -32,6 +32,12 @@ module.exports = [
   },
   {
     method: 'POST',
+    path: '/slack/commands/create-and-deploy-ember-testing-library-release',
+    handler: slackbotController.createAndDeployEmberTestingLibraryRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
     path: '/slack/commands/create-and-deploy-pix-bot-release',
     handler: slackbotController.createAndDeployPixBotRelease,
     config: slackConfig

--- a/config.js
+++ b/config.js
@@ -93,6 +93,7 @@ module.exports = (function() {
     PIX_LCMS_REPO_NAME: 'pix-editor',
     PIX_LCMS_APP_NAME: 'pix-lcms',
     PIX_UI_REPO_NAME: 'pix-ui',
+    PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_SITE_REPO_NAME: 'pix-site',
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -11,6 +11,7 @@ const {
   PIX_LCMS_REPO_NAME,
   PIX_LCMS_APP_NAME,
   PIX_UI_REPO_NAME,
+  PIX_EMBER_TESTING_LIBRARY_REPO_NAME,
 } = require('../../../config');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
@@ -57,6 +58,23 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
     sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
     postSlackMessage(`[PIX-UI] App deployed (${releaseTagAfterRelease})`);
+    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
+  }
+}
+
+async function publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
+  if (_isReleaseTypeInvalid(releaseType)) {
+    postSlackMessage('Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".');
+    throw new Error('Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".');
+  }
+  const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
+  await releasesService.publishPixRepo(repoName, releaseType);
+  const releaseTagAfterRelease = await githubServices.getLatestReleaseTag(repoName);
+
+  if (releaseTagBeforeRelease === releaseTagAfterRelease) {
+    sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
+  } else {
+    postSlackMessage(`[EMBER-TESTING-LIBRARY] Lib deployed (${releaseTagAfterRelease})`);
     sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
   }
 }
@@ -128,6 +146,10 @@ module.exports = {
 
   async createAndDeployPixUI(payload) {
     await publishAndDeployPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
+  },
+
+  async createAndDeployEmberTestingLibrary(payload) {
+    await publishAndDeployEmberTestingLibrary(PIX_EMBER_TESTING_LIBRARY_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixSiteRelease(payload) {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -5,6 +5,7 @@ const { catchErr, sinon } = require('../../../../test-helper');
 const {
   createAndDeployPixLCMS,
   createAndDeployPixUI,
+  createAndDeployEmberTestingLibrary,
   createAndDeployPixSiteRelease,
   createAndDeployPixDatawarehouse,
   createAndDeployPixBotRelease,
@@ -107,6 +108,42 @@ describe('Services | Slack | Commands', () => {
 
       // when
       const response = await catchErr(createAndDeployPixUI)(payload);
+
+      // then
+      expect(response).to.be.instanceOf(Error);
+    });
+  });
+
+  describe('#createAndDeployEmberTestingLibrary', () => {
+
+    it('should publish a new release', async () => {
+      // given
+      const payload = { text: 'minor' };
+
+      // when
+      await createAndDeployEmberTestingLibrary(payload);
+
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'ember-testing-library', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', async () => {
+      // given
+      const payload = { text: 'minor' };
+
+      // when
+      await createAndDeployEmberTestingLibrary(payload);
+
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'ember-testing-library');
+    });
+
+    it('should stop release if no version is given', async () => {
+      // given
+      const payload = { text: '' };
+
+      // when
+      const response = await catchErr(createAndDeployEmberTestingLibrary)(payload);
 
       // then
       expect(response).to.be.instanceOf(Error);


### PR DESCRIPTION
## :unicorn: Problème
Le nouveau projet [ember-testing-library](https://github.com/1024pix/ember-testing-library) ne peut pas encore être release depuis pix-bot.

## :robot: Solution
Ajout de la possibilité de release ember-testing-library via pix-bot.

## :rainbow: Remarque
RAS

## :100: Pour tester
Aucune idée de comment valider ça ?