### PR TITLE
[BUGFIX] Meilleur message de succès lors du déploiement d'ember-testing-library

### DIFF
--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -38,6 +38,10 @@ function getSuccessMessage(release, appName) {
   return `Le script de déploiement de la release '${release}' pour ${appName} en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…`;
 }
 
+function getSuccessReleaseMessage(release, libName) {
+  return `Le script de déploiement de la release '${release}' pour ${libName} s'est déroulé avec succès.`;
+}
+
 function getErrorAppMessage(appName) {
   return `Erreur lors du déploiement de ${appName} en production.`;
 }
@@ -75,7 +79,7 @@ async function publishAndDeployEmberTestingLibrary(repoName, releaseType, respon
     sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
     postSlackMessage(`[EMBER-TESTING-LIBRARY] Lib deployed (${releaseTagAfterRelease})`);
-    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
+    sendResponse(responseUrl, getSuccessReleaseMessage(releaseTagAfterRelease, repoName));
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Affichait le message "En attente de l'installation des applications sur Scalingo…" lors de la release d'ember-testing-library alors que ne nécessite pas d'installation d'app.

## :robot: Solution
Nouvelle méthode avec message plus simple dans le cas d'une release de lib.

## :rainbow: Remarques
RAS

## :100: Pour tester
Refaire une release.