### PR TITLE
[TECH] Documenter l'accès aux changements d'une release d'un projet Pix

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -47,6 +47,6 @@ function complete_change_log() {
 }
 
 function tag_release_commit() {
-  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "v${NEW_PACKAGE_VERSION}"
+  git tag --annotate "v${NEW_PACKAGE_VERSION}" --message "See CHANGELOG file to see what's changed in new release."
   echo "Created annotated tag"
 }


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'utilisation de Pix-UI nous avons constaté qu'il était difficile de comprendre les changements cassants d'une montée de version majeure. 

## :robot: Solution
En comparant le fonctionnement des autres projets existant sur le web on a pu observer plusieurs manière de fonctionner : 
- soit pas de description sur les releases ou les tags 
- soit des descriptions pour chaques release et tags avec des catégories de changements (voir https://github.com/twbs/bootstrap/releases)
- soit un message indiquant de se référé au CHANGELOG (voir https://github.com/material-components/material-components-web/releases/tag/v13.0.0) 

Comme sur nos projets nous ne faisons pas de releases git mais juste des tags je propose de faire comme la dernière méthode, à savoir : indiquer dans les tags où trouver les changement correspondants à ce tag ci (c'est à dire dans le CHANGELOG). Cela facilitera l'accès aux changements qu'embarque une nouvelle version de Pix-UI, notamment aux nouveaux venus qui avaient pour réflexe d'aller regarder les descriptions des tags / release pour se documenter sur les changements.

## :rainbow: Remarques
Ce changement de description de tag sera aussi appliqué dans Pix.
Actuellement la description de nos tag se résume au numéro du tag (ce qui n'apporte pas plus d'info).
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/38167520/143271990-1eb2d173-4394-4498-a211-0a53384c5dda.png">


## :100: Pour tester
Une fois le ticket mergé, faire une release sur Pix ou Pix-UI.