### PR TITLE
[BUGFIX] Suppression de l'étape d'installation des packages npm lors de la release

### DIFF
--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -17,11 +17,6 @@ function executeCommandRecursivelyInPackageJsonDir {
   find . -name package.json -type f ! -path '*/node_modules/*' -execdir ${1} \;
 }
 
-function install_required_packages {
-  echo "Install packages"
-  executeCommandRecursivelyInPackageJsonDir "npm ci --dev --no-optional"
-}
-
 function create_release {
   npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
   executeCommandRecursivelyInPackageJsonDir "npm version ${npm_arg} --no-git-tag-version"
@@ -41,7 +36,6 @@ echo "Start deploying version ${VERSION_TYPE}…"
 
 clone_repository_and_move_inside
 configure_git_user_information
-install_required_packages
 create_release
 complete_change_log
 create_a_release_commit


### PR DESCRIPTION
## :unicorn: Problème
Lors de la release d'un projet PIX, on installait les packages npm de tout les sous dossiers. Ça ne sert a rien.

## :robot: Solution
Supprimer l'étape, ce qui va accélérer la release.

## :rainbow: Remarques
Mais pourquoi c'était la ?

## :100: Pour tester
1. Faites nous confiance
2. Continuez a nous faire confiance