### PR TITLE
[FEATURE] Génére correctement le changelog pour une release après une correction de release à chaud

### DIFF
--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -8,8 +8,8 @@ const PullRequestGroupFactory = require('../models/PullRequestGroupFactory');
 
 const CHANGELOG_HEADER_LINES = 2;
 
-async function getLastMEPDate(repoOwner, repoName) {
-  const latestTagUrl = await github.getLatestReleaseTagUrl(repoOwner, repoName);
+async function getTagReleaseDate(repoOwner, repoName, tagName) {
+  const latestTagUrl = await github.getLastCommitUrl({ tagName, owner: repoOwner, repo: repoName });
 
   const commit = await github.getCommitAtURL(latestTagUrl);
   return commit.committer.date;
@@ -66,7 +66,7 @@ module.exports = {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getLastMEPDate,
+  getTagReleaseDate,
   getNewChangeLogLines,
   orderPr,
 };

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -113,16 +113,14 @@ function _sortWithInProgressLast(prA, prB) {
   return fieldA.localeCompare(fieldB);
 }
 
-async function getLastCommitUrl({ branchName, tagName }) {
+async function getLastCommitUrl({ branchName, tagName, owner, repo }) {
   if (branchName) {
-    return await _getBranchLastCommitUrl(branchName);
+    return await _getBranchLastCommitUrl({ owner, repo, branch: branchName });
   }
-  return _getTagCommitUrl(tagName);
+  return _getTagCommitUrl({ owner, repo, tagName });
 }
 
-async function _getBranchLastCommitUrl(branch) {
-  const owner = settings.github.owner;
-  const repo = settings.github.repository;
+async function _getBranchLastCommitUrl({ owner, repo, branch }) {
   const octokit = _createOctokit();
   const { data } = await octokit.repos.getBranch({
     owner,
@@ -132,9 +130,7 @@ async function _getBranchLastCommitUrl(branch) {
   return data.commit.url;
 }
 
-async function _getTagCommitUrl(tagName) {
-  const owner = settings.github.owner;
-  const repo = settings.github.repository;
+async function _getTagCommitUrl({ owner, repo, tagName }) {
   const tags = await _getTags(owner, repo);
   const tag = tags.find((tag) => tag.name === tagName);
   return tag.commit.url;
@@ -251,6 +247,8 @@ module.exports = {
     return _getLatestReleaseTagUrl(repoOwner, repoName);
   },
 
+  getLastCommitUrl,
+
   async getCommitAtURL(commitUrl) {
     return _getCommitAtURL(commitUrl);
   },
@@ -265,7 +263,8 @@ module.exports = {
 
   async isBuildStatusOK({ branchName, tagName }) {
     const githubCICheckName = 'build-test-and-deploy';
-    const commitUrl = await getLastCommitUrl({ branchName, tagName });
+    const { owner, repository: repo } = settings.github;
+    const commitUrl = await getLastCommitUrl({ branchName, tagName, owner, repo });
     const commitStatusUrl = commitUrl + '/check-runs';
     const octokit = _createOctokit();
     const { data } = await octokit.request(commitStatusUrl);

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -164,12 +164,12 @@ async function _getDefaultBranch(repoOwner, repoName) {
 }
 
 async function _getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName) {
-  const defaultBranch = branchName || await _getDefaultBranch(repoOwner, repoName);
+  const baseBranch = branchName || await _getDefaultBranch(repoOwner, repoName);
   const { pulls } = _createOctokit();
   const { data } = await pulls.list({
     owner: repoOwner,
     repo: repoName,
-    base: defaultBranch,
+    base: baseBranch,
     state: 'closed',
     sort: 'updated',
     direction: 'desc'

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -39,7 +39,8 @@ function push_commit_and_tag_to_remote() {
 }
 
 function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}"
+  LAST_TAG_ON_BRANCH=$(git tag --merged | sort --version-sort | tail -1)
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}" "${LAST_TAG_ON_BRANCH}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const github = require('../common/services/github');
 const {
-  getLastMEPDate,
+  getTagReleaseDate,
   filterPullRequest,
   getNewChangeLogLines,
   getHeadOfChangelog,
@@ -17,17 +17,18 @@ async function main() {
   const repoOwner = process.argv[3];
   const repoName = process.argv[4];
   const branchName = process.argv[5];
+  const lastTagNameOnBranch = process.argv[6];
 
   try {
-    const dateOfLastMEP = await getLastMEPDate(repoOwner, repoName);
+    const dateOfLastRelease = await getTagReleaseDate(repoOwner, repoName, lastTagNameOnBranch);
 
     const pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
 
-    const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+    const pullRequestsSinceLastRelease = filterPullRequest(pullRequests, dateOfLastRelease);
 
     const newChangeLogLines = getNewChangeLogLines({
       headOfChangelogTitle: getHeadOfChangelog(tagVersion),
-      pullRequests: pullRequestsSinceLastMEP,
+      pullRequests: pullRequestsSinceLastRelease,
     });
 
     let currentChangeLog = '';

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 const simpleGit = require('simple-git');
+const dayjs = require('dayjs');
 
 async function _runScriptWithArgument (scriptFileName, args=[], options={}) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
@@ -108,8 +109,9 @@ describe('Acceptance | Scripts | publish.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
+    const now = dayjs().format('DD/MM/YYYY');
     expect(changelog).to.eql(`
-## v0.2.0 (06/04/2022)
+## v0.2.0 (${now})
 
 
 ### :rocket: Amélioration

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -84,7 +84,7 @@ describe('Acceptance | Scripts | publish.sh', function() {
       'Updated CHANGELOG.md',
       'Set Git user information',
       /A minor is being released to 0.2.0.$/,
-      ' 8 files changed, 8 insertions(+), 8 deletions(-)',
+      ' 9 files changed, 14 insertions(+), 8 deletions(-)',
       'Created the release commit',
       'Created annotated tag',
       'Pushed release commit to the origin',
@@ -108,6 +108,12 @@ describe('Acceptance | Scripts | publish.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
-    expect(changelog).to.eql('');
+    expect(changelog).to.eql(`
+## v0.2.0 (06/04/2022)
+
+
+### :rocket: Amélioration
+- [#1](https://github.com/1024pix/pix-bot-publish-test/pull/1) [FEATURE] Ajout d'un index pour Pix App
+`);
   });
 });

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -7,7 +7,7 @@ const {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getLastMEPDate,
+  getTagReleaseDate,
   getNewChangeLogLines,
   orderPr,
 } = require('../../../../common/services/changelog');
@@ -123,14 +123,15 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getLastMEPDate', () => {
+  describe('#getTagReleaseDate', () => {
 
     const repoOwner = '1024pix';
     const repoName = 'pix';
+    const tagName = 'v3.193.1';
 
     beforeEach(() => {
-      sinon.stub(github, 'getLatestReleaseTagUrl')
-        .withArgs(repoOwner, repoName)
+      sinon.stub(github, 'getLastCommitUrl')
+        .withArgs({ owner: repoOwner, repo: repoName, tagName })
         .resolves(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`);
 
       sinon.stub(github, 'getCommitAtURL')
@@ -143,7 +144,7 @@ describe('Unit | Common | Services | Changelog', () => {
       const expectedDate = '2019-01-18T15:29:51Z';
 
       // when
-      const date = await getLastMEPDate(repoOwner, repoName);
+      const date = await getTagReleaseDate(repoOwner, repoName, tagName);
 
       // then
       expect(date).to.be.equal(expectedDate);


### PR DESCRIPTION
## :unicorn: Problème
En cas de hotfix, si des PRs sont mergé sur dev avant le hotfix (qui crée un tag sur une autre branche), le changelog de la version suivante ne contient pas ces PRs mergés.

## :robot: Solution
Lors de la récupération du dernier tag sur le dépot, on ne prend en compte que ceux qui sont accessible depuis la branche courante. Comme le tag de hotfix ne peut pas être mergé sur dev, on est sur de ne pas avoir de mauvais cas.

## :rainbow: Remarques
Pour réussir a faire ça, on a du d'abord #100.

## :100: Pour tester
1. `npm run test`