### PR TITLE
[CLEANUP] Supprimer de la duplication sur le webhook Slack

### DIFF
--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -1,15 +1,5 @@
-const { verifySignatureAndParseBody } = require('../services/slack/security');
+const { slackConfig } = require('../config');
 const slackbotController = require('../controllers/slack');
-
-const slackConfig = {
-  payload: {
-    allow: ['application/json', 'application/x-www-form-urlencoded'],
-    parse: false
-  },
-  pre: [
-    { method: verifySignatureAndParseBody, assign: 'payload' }
-  ]
-};
 
 module.exports = [
   {

--- a/config.js
+++ b/config.js
@@ -112,6 +112,8 @@ module.exports = (function() {
     config.github.owner = 'github-owner';
     config.github.repository = 'github-repository';
 
+    config.slack.requestSigningSecret = 'slack-super-signing-secret';
+
     config.openApi.authorizationToken = 'open-api-token';
 
     config.scalingo.recette.token = 'tk-us-scalingo-token-recette';

--- a/test/acceptance/common/slack_test.js
+++ b/test/acceptance/common/slack_test.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+const crypto = require('crypto');
+const server = require('../../../server');
+const config = require('../../../config');
+
+function createSlackWebhookSignatureHeaders(body) {
+  const timestamp = Date.now();
+  const version = 'v0';
+  const hmac = crypto.createHmac('sha256', config.slack.requestSigningSecret);
+  hmac.update(`${version}:${timestamp}:${body}`);
+
+  return {
+    'x-slack-signature': version +'='+ hmac.digest('hex'),
+    'x-slack-request-timestamp': timestamp
+  };
+}
+
+describe('Acceptance | Common | Slack', function() {
+  describe('POST /slack/interactive-endpoint', function() {
+    it('responds with 204', async () => {
+      const body = {
+        type: 'view_closed'
+      };
+      const res = await server.inject({
+        method: 'POST',
+        url: '/slack/interactive-endpoint',
+        headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(204);
+    });
+
+    it('responds with 401', async () => {
+      const body = {
+        type: 'view_closed'
+      };
+      const res = await server.inject({
+        method: 'POST',
+        url: '/slack/interactive-endpoint',
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(401);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La vérification du webhook slack était dupliqué.

## :robot: Solution
Supprimer la duplication

## :100: Pour tester
Vérifie que les nouveaux tests sont au vert