### PR TITLE
[TECH] Mettre à jour la version de node utilisé par CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build-and-test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:14.16.0
     steps:
       - checkout
       - run: npm ci


### PR DESCRIPTION
## :unicorn: Problème
CircleCI utilise node 12 et non pas node 14 comme c'est mentionné dans le fichier `.nvmrc`.

## :robot: Solution
- Utiliser la bonne image de node 

## :rainbow: Remarques


## :100: Pour tester
- Constater le bon fonctionnement de la CI.