### PR TITLE
[CLEANUP] Supprimer l'utilisation de moment.js et nettoyage des dépendances

### DIFF
--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
 const { sortBy, indexOf } = require('lodash');
 const github = require('./github');
 
@@ -33,7 +33,7 @@ function filterPullRequest(pullrequests, dateOfLastMEP) {
 }
 
 function getHeadOfChangelog(tagVersion) {
-  const date = ' (' + moment().format('DD/MM/YYYY') + ')';
+  const date = ' (' + dayjs().format('DD/MM/YYYY') + ')';
   return '## v' + tagVersion + date + '\n';
 }
 

--- a/package.json
+++ b/package.json
@@ -38,11 +38,9 @@
     "dayjs": "^1.9.4",
     "dotenv": "^8.2.0",
     "lodash": "^4.17.21",
-    "proxyquire": "^2.1.3",
     "scalingo": "^0.3.11",
     "scalingo-review-app-manager": "^1.0.1",
     "sib-api-v3-sdk": "^8.0.1",
-    "simple-git": "^3.5.0",
     "tsscmp": "^1.0.6"
   },
   "devDependencies": {
@@ -51,6 +49,8 @@
     "fs-extra": "^10.0.1",
     "mocha": "^8.2.1",
     "nock": "^13.0.5",
+    "proxyquire": "^2.1.3",
+    "simple-git": "^3.5.0",
     "sinon": "^9.2.2",
     "sinon-chai": "^3.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "dayjs": "^1.9.4",
     "dotenv": "^8.2.0",
     "lodash": "^4.17.21",
-    "moment": "^2.27.0",
     "proxyquire": "^2.1.3",
     "scalingo": "^0.3.11",
     "scalingo-review-app-manager": "^1.0.1",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons deux dépendances directes a des librairie de date. Une seule suffit par rapport a nos besoins. Pour rester cohérent avec le dépot Pix, c'est dayjs qui est gardé. 
Des dépendances n'étaient pas non dans la partie dev.

## :robot: Solution
Supprimer moment.js et utiliser dayjs. 
Déplacer les dépendances uniquement utilisé dans les tests en dépendances de dev.

## :100: Pour tester
1. Vérifier la génération du changelog
2. Vérifier que les dépendances de dev ne sont utilisées que dans les tests, en vérifiant que l'application fonctionne en RA