### PR TITLE
[FEATURE] Générer le manifest pour configurer les applications slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ GITHUB_OWNER=#github_owner# GITHUB_REPOSITORY=#github_repository# GITHUB_PERSONA
 ### Test the endpoint on Slack
 
 If you want to test your new endpoint before deploying it, 
-you will need to run your server locally and make it visible (with ngrok for example).
+you will need to run your server locally and make it visible (with [ngrok][] for example).
 
-Ensure you have the access rights to Pix Bot Build and Pix Bot Run on Slack, 
-then go to [https://api.slack.com/apps](https://api.slack.com/apps).
-Click on the Bot you want to create the new endpoint (Pix Bot Build or Pix Bot Run), 
-then in "Slash commands" tab, click "Create new command".
-In the popup, register ${ngrok url}/slack/commands/my-slack-command.
+Add your new slash command to the corresponding manifest: ./{run,build}/controllers/manifest.js.
+
+Go to [https://api.slack.com/apps](https://api.slack.com/apps), and create a new slack app, and create it from a manifest. The manifest is available a {ngrok_url}/{run,build}/manifest.
 
 ## Deploy
 
@@ -80,3 +78,5 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License along with this program. If not, see [gnu.org/licenses](https://www.gnu.org/licenses/).
+
+[ngrok]: https://ngrok.com/

--- a/build/controllers/manifest.js
+++ b/build/controllers/manifest.js
@@ -1,0 +1,73 @@
+module.exports = {
+  async get(request) {
+    const protocol = request.headers['x-forwarded-proto'] ? request.headers['x-forwarded-proto'] : 'http';
+    const { host } = request.info;
+    const url = `${protocol}://${host}`;
+    return {
+      display_information: {
+        name: 'Pix Bot Build'
+      },
+      features: {
+        bot_user: {
+          display_name: 'Pix Bot Build',
+          always_online: false
+        },
+        shortcuts: [
+          {
+            name: 'Publier une version/MER',
+            type: 'global',
+            callback_id: 'publish-release',
+            description: 'Publie une nouvelle version et la déploie sur l\'environnement de recette'
+          }
+        ],
+        slash_commands: [
+          {
+            command: '/pr-pix',
+            url: `${url}/slack/commands/pull-requests`,
+            description: 'Afficher les PR à review de l\'application Pix',
+            usage_hint: '[cross-team|team-acces|team-evaluation|team-certif|team-prescription]',
+            should_escape: false
+          },
+          {
+            command: '/tips-a11y',
+            url: `${url}/slack/commands/accessibility-tip`,
+            description: 'Je veux un tips sur l\'accessibilité !',
+            should_escape: false
+          },
+          {
+            command: '/changelog',
+            url: `${url}/slack/commands/changelog`,
+            description: 'Afficher le changelog depuis la dernière release',
+            should_escape: false
+          },
+          {
+            command: '/hotfix',
+            url: `${url}/slack/commands/create-and-deploy-pix-hotfix`,
+            description: 'Créer une version patch à partir d\'une branche et la déployer en recette',
+            usage_hint: '[branch-name]',
+            should_escape: false
+          }
+        ]
+      },
+      oauth_config: {
+        scopes: {
+          bot: [
+            'commands',
+            'incoming-webhook',
+            'workflow.steps:execute'
+          ]
+        }
+      },
+      settings: {
+        interactivity: {
+          is_enabled: true,
+          request_url: `${url}/slack/interactive-endpoint`
+        },
+        org_deploy_enabled: false,
+        socket_mode_enabled: false,
+        token_rotation_enabled: false
+      }
+    };
+  },
+};
+

--- a/build/routes/manifest.js
+++ b/build/routes/manifest.js
@@ -1,0 +1,9 @@
+const manifestController = require('../controllers/manifest');
+
+module.exports = [
+  {
+    method: 'GET',
+    path: '/build/manifest',
+    handler: manifestController.get,
+  },
+];

--- a/run/controllers/manifest.js
+++ b/run/controllers/manifest.js
@@ -1,0 +1,110 @@
+module.exports = {
+  async get(request) {
+    const protocol = request.headers['x-forwarded-proto'] ? request.headers['x-forwarded-proto'] : 'http';
+    const { host } = request.info;
+    const url = `${protocol}://${host}`;
+    return {
+      display_information: {
+        name: 'Pix Bot Run'
+      },
+      features: {
+        bot_user: {
+          display_name: 'Pix Bot Run',
+          always_online: false
+        },
+        shortcuts: [
+          {
+            name: 'Déployer une version/MEP',
+            type: 'global',
+            callback_id: 'deploy-release',
+            description: 'Lance le déploiement d\'une version sur l\'environnement de production'
+          }
+        ],
+        slash_commands: [
+          {
+            command: '/publish-release',
+            url: `${url}/slack/commands/publish-release`,
+            description: 'Edit and publish a new release',
+            usage_hint: '[version_type (ex: "major", "minor", "patch")]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-pix-sites',
+            url: `${url}/slack/commands/create-and-deploy-pix-site-release`,
+            description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',
+            usage_hint: 'patch|minor|major (minor par défaut)',
+            should_escape: false
+          },
+          {
+            command: '/publish-pix-ui',
+            url: `${url}/slack/commands/create-and-deploy-pix-ui-release`,
+            description: 'Crée une release de Pix-UI et la déploie sur les Github pages !',
+            usage_hint: '[patch, minor, major]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-pix-lcms',
+            url: `${url}/slack/commands/create-and-deploy-pix-lcms-release`,
+            description: 'Crée une release de Pix-LCMS et la déploie en production (https://lcms-api.pix.fr)',
+            usage_hint: '[patch, minor, major]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-pix-datawarehouse',
+            url: `${url}/slack/commands/create-and-deploy-pix-datawarehouse-release`,
+            description: 'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
+            usage_hint: '[patch, minor, major]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-pix-bot',
+            url: `${url}/slack/commands/create-and-deploy-pix-bot-release`,
+            description: 'Releaser et déployer pix-bot-run et pix-bot-build',
+            usage_hint: '[patch, minor, major]',
+            should_escape: false
+          },
+          {
+            command: '/app-status',
+            url: `${url}/slack/commands/app-status`,
+            description: 'Returns the app status given the app name as parameter',
+            usage_hint: '[pix-app-production, production]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-last-version',
+            url: `${url}/slack/commands/deploy-last-version`,
+            description: 'Deploy last version of an app',
+            usage_hint: '[pix-admin-production]',
+            should_escape: false
+          },
+          {
+            command: '/deploy-ember-testing-library',
+            url: `${url}/slack/commands/create-and-deploy-ember-testing-library-release`,
+            description: 'Crée une release de Ember-testing-library',
+            usage_hint: '[patch, minor, major]',
+            should_escape: false
+          }
+        ]
+      },
+      oauth_config: {
+        scopes: {
+          bot: [
+            'commands',
+            'incoming-webhook',
+            'chat:write'
+          ]
+        }
+      },
+      settings: {
+        interactivity: {
+          is_enabled: true,
+          request_url: `${url}/slack/interactive-endpoint`
+        },
+        org_deploy_enabled: false,
+        socket_mode_enabled: false,
+        token_rotation_enabled: false
+      }
+    };
+  },
+};
+

--- a/run/routes/manifest.js
+++ b/run/routes/manifest.js
@@ -1,0 +1,10 @@
+const manifestController = require('../controllers/manifest');
+
+module.exports = [
+  {
+    method: 'GET',
+    path: '/run/manifest',
+    handler: manifestController.get,
+  }
+];
+

--- a/test/acceptance/build/manifest_test.js
+++ b/test/acceptance/build/manifest_test.js
@@ -1,0 +1,80 @@
+const { expect } = require('chai');
+const server = require('../../../server');
+
+describe('Acceptance | Build | Manifest', function() {
+  describe('GET /build/manifest', function() {
+    it('responds with 200 and returns the manifest', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/build/manifest',
+      });
+      const hostname = server.info.host + ':0';
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql({
+        display_information: {
+          name: 'Pix Bot Build'
+        },
+        features: {
+          bot_user: {
+            display_name: 'Pix Bot Build',
+            always_online: false
+          },
+          shortcuts: [
+            {
+              name: 'Publier une version/MER',
+              type: 'global',
+              callback_id: 'publish-release',
+              description: 'Publie une nouvelle version et la déploie sur l\'environnement de recette'
+            }
+          ],
+          slash_commands: [
+            {
+              command: '/pr-pix',
+              url: `http://${hostname}/slack/commands/pull-requests`,
+              description: 'Afficher les PR à review de l\'application Pix',
+              usage_hint: '[cross-team|team-acces|team-evaluation|team-certif|team-prescription]',
+              should_escape: false
+            },
+            {
+              command: '/tips-a11y',
+              url: `http://${hostname}/slack/commands/accessibility-tip`,
+              description: 'Je veux un tips sur l\'accessibilité !',
+              should_escape: false
+            },
+            {
+              command: '/changelog',
+              url: `http://${hostname}/slack/commands/changelog`,
+              description: 'Afficher le changelog depuis la dernière release',
+              should_escape: false
+            },
+            {
+              command: '/hotfix',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-hotfix`,
+              description: 'Créer une version patch à partir d\'une branche et la déployer en recette',
+              usage_hint: '[branch-name]',
+              should_escape: false
+            }
+          ],
+        },
+        oauth_config: {
+          scopes: {
+            bot: [
+              'commands',
+              'incoming-webhook',
+              'workflow.steps:execute'
+            ]
+          }
+        },
+        settings: {
+          interactivity: {
+            is_enabled: true,
+            request_url: `http://${hostname}/slack/interactive-endpoint`
+          },
+          org_deploy_enabled: false,
+          socket_mode_enabled: false,
+          token_rotation_enabled: false
+        }
+      });
+    });
+  });
+});

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -1,0 +1,117 @@
+const { expect } = require('chai');
+const server = require('../../../server');
+
+describe('Acceptance | Run | Manifest', function() {
+  describe('GET /run/manifest', function() {
+    it('responds with 200 and returns the manifest', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/run/manifest',
+      });
+      const hostname = server.info.host + ':0';
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql({
+        display_information: {
+          name: 'Pix Bot Run'
+        },
+        features: {
+          bot_user: {
+            display_name: 'Pix Bot Run',
+            always_online: false
+          },
+          shortcuts: [
+            {
+              name: 'Déployer une version/MEP',
+              type: 'global',
+              callback_id: 'deploy-release',
+              description: 'Lance le déploiement d\'une version sur l\'environnement de production'
+            }
+          ],
+          slash_commands: [
+            {
+              command: '/publish-release',
+              url: `http://${hostname}/slack/commands/publish-release`,
+              description: 'Edit and publish a new release',
+              usage_hint: '[version_type (ex: "major", "minor", "patch")]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-pix-sites',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-site-release`,
+              description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',
+              usage_hint: 'patch|minor|major (minor par défaut)',
+              should_escape: false
+            },
+            {
+              command: '/publish-pix-ui',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-ui-release`,
+              description: 'Crée une release de Pix-UI et la déploie sur les Github pages !',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-pix-lcms',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-lcms-release`,
+              description: 'Crée une release de Pix-LCMS et la déploie en production (https://lcms-api.pix.fr)',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-pix-datawarehouse',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-datawarehouse-release`,
+              description: 'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-pix-bot',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-bot-release`,
+              description: 'Releaser et déployer pix-bot-run et pix-bot-build',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false
+            },
+            {
+              command: '/app-status',
+              url: `http://${hostname}/slack/commands/app-status`,
+              description: 'Returns the app status given the app name as parameter',
+              usage_hint: '[pix-app-production, production]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-last-version',
+              url: `http://${hostname}/slack/commands/deploy-last-version`,
+              description: 'Deploy last version of an app',
+              usage_hint: '[pix-admin-production]',
+              should_escape: false
+            },
+            {
+              command: '/deploy-ember-testing-library',
+              url: `http://${hostname}/slack/commands/create-and-deploy-ember-testing-library-release`,
+              description: 'Crée une release de Ember-testing-library',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false
+            }
+          ]
+        },
+        oauth_config: {
+          scopes: {
+            bot: [
+              'commands',
+              'incoming-webhook',
+              'chat:write'
+            ]
+          }
+        },
+        settings: {
+          interactivity: {
+            is_enabled: true,
+            request_url: `http://${hostname}/slack/interactive-endpoint`
+          },
+          org_deploy_enabled: false,
+          socket_mode_enabled: false,
+          token_rotation_enabled: false
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La configuration des applications slack Pix est manuelle. Il faut se baser sur ce qui se passe sur la production, mais nous n'avons pas de documentation de ce qui est fait.

## :robot: Solution
Slack a rajouté le support des app manifest qui permettent de configurer une application slack d'un coup: https://api.slack.com/reference/manifests. 2 routes ont été rajouté pour retourner les manifest de build et de run.

## :rainbow: Remarques
Les manifest sont généré et mis à jour manuellement. Ca va bientôt changer.

## :100: Pour tester
1. Lancer pix-bot
2. Aller sur http://localhost:3000/run/manifest et regarder la config
3. Aller sur http://localhost:3000/build/manifest et regarder la config