### PR TITLE
[CLEANUP] Nettoyer les routes du module common

### DIFF
--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -1,4 +1,5 @@
 const github = require('../../common/services/github');
+const { environments, deploy, publish } = require('../../common/services/releases');
 
 module.exports = {
   async getPullRequests(request) {
@@ -11,6 +12,19 @@ module.exports = {
     return {
       response_type: 'in_channel',
       'text': prTitlesList.join('\n'),
+    };
+  },
+
+  createAndDeployPixHotfix(request) {
+    const payload = request.pre.payload;
+    const branchName = payload.text;
+
+    publish('patch', branchName).then(async (latestReleaseTag) => {
+      await deploy(environments.recette, latestReleaseTag);
+    });
+
+    return {
+      'text': 'Commande de déploiement de hotfix de PIX en recette.'
     };
   },
 };

--- a/build/routes/slack.js
+++ b/build/routes/slack.js
@@ -1,7 +1,6 @@
 const { slackConfig } = require('../../common/config');
-const googleSheet = require('../../build/services/google-sheet');
-const slackbotController = require('../../build/controllers/slack');
-
+const googleSheet = require('../services/google-sheet');
+const slackbotController = require('../controllers/slack');
 
 module.exports = [
   {
@@ -20,6 +19,12 @@ module.exports = [
     method: 'POST',
     path: '/slack/commands/changelog',
     handler: slackbotController.getChangelogSinceLatestRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-hotfix',
+    handler: slackbotController.createAndDeployPixHotfix,
     config: slackConfig
   },
 ];

--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -1,71 +1,10 @@
-const commandsFromRun = require('../../run/services/slack/commands');
-const { getAppStatusFromScalingo } = require('../../run/services/slack/app-status-from-scalingo');
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
 const { environments, deploy, publish } = require('../services/releases');
 const github = require('../services/github');
 const postSlackMessage = require('../services/slack/surfaces/messages/post-message');
-const sendSlackBlockMessage = require('../services/slack/surfaces/messages/block-message');
-
-function _getDeployStartedMessage(release, appName) {
-  return `Commande de déploiement de la release "${release}" pour ${appName} en production bien reçue.`;
-}
 
 module.exports = {
-
-  createAndDeployPixSiteRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixSiteRelease(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX site and pro')
-    };
-  },
-
-  createAndDeployPixUIRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixUI(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX UI')
-    };
-  },
-
-  createAndDeployEmberTestingLibraryRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployEmberTestingLibrary(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'EMBER-TESTING-LIBRARY')
-    };
-  },
-
-  createAndDeployPixBotRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixBotRelease(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX Bot')
-    };
-  },
-
-  createAndDeployPixLCMSRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixLCMS(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX LCMS')
-    };
-  },
-
-  createAndDeployPixDatawarehouseRelease(request) {
-    const payload = request.pre.payload;
-    commandsFromRun.createAndDeployPixDatawarehouse(payload);
-
-    return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX Datawarehouse')
-    };
-  },
 
   createAndDeployPixHotfix(request) {
     const payload = request.pre.payload;
@@ -78,23 +17,6 @@ module.exports = {
     return {
       'text': 'Commande de déploiement de hotfix de PIX en recette.'
     };
-  },
-
-  getAppStatus(request) {
-    const appName= request.pre.payload.text;
-    return getAppStatusFromScalingo(appName);
-  },
-
-  async deployLastVersion(request) {
-    const appName = request.pre.payload.text;
-
-    try {
-      await commandsFromRun.getAndDeployLastVersion({ appName });
-    } catch(e) {
-      return sendSlackBlockMessage(e.message);
-    }
-
-    return sendSlackBlockMessage(`Re-déploiement de ${appName} déclenché`);
   },
 
   interactiveEndpoint(request) {

--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -1,23 +1,9 @@
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
-const { environments, deploy, publish } = require('../services/releases');
 const github = require('../services/github');
 const postSlackMessage = require('../services/slack/surfaces/messages/post-message');
 
 module.exports = {
-
-  createAndDeployPixHotfix(request) {
-    const payload = request.pre.payload;
-    const branchName = payload.text;
-
-    publish('patch', branchName).then(async (latestReleaseTag) => {
-      await deploy(environments.recette, latestReleaseTag);
-    });
-
-    return {
-      'text': 'Commande de déploiement de hotfix de PIX en recette.'
-    };
-  },
 
   interactiveEndpoint(request) {
     const payload = request.pre.payload;

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -4,56 +4,8 @@ const slackbotController = require('../controllers/slack');
 module.exports = [
   {
     method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-lcms-release',
-    handler: slackbotController.createAndDeployPixLCMSRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-site-release',
-    handler: slackbotController.createAndDeployPixSiteRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-ui-release',
-    handler: slackbotController.createAndDeployPixUIRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/create-and-deploy-ember-testing-library-release',
-    handler: slackbotController.createAndDeployEmberTestingLibraryRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-bot-release',
-    handler: slackbotController.createAndDeployPixBotRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
-    handler: slackbotController.createAndDeployPixDatawarehouseRelease,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
     path: '/slack/commands/create-and-deploy-pix-hotfix',
     handler: slackbotController.createAndDeployPixHotfix,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/app-status',
-    handler: slackbotController.getAppStatus,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
-    path: '/slack/commands/deploy-last-version',
-    handler: slackbotController.deployLastVersion,
     config: slackConfig
   },
   {

--- a/common/routes/slack.js
+++ b/common/routes/slack.js
@@ -4,12 +4,6 @@ const slackbotController = require('../controllers/slack');
 module.exports = [
   {
     method: 'POST',
-    path: '/slack/commands/create-and-deploy-pix-hotfix',
-    handler: slackbotController.createAndDeployPixHotfix,
-    config: slackConfig
-  },
-  {
-    method: 'POST',
     path: '/slack/interactive-endpoint',
     handler: slackbotController.interactiveEndpoint,
     config: slackConfig

--- a/run/controllers/manifest.js
+++ b/run/controllers/manifest.js
@@ -22,13 +22,6 @@ module.exports = {
         ],
         slash_commands: [
           {
-            command: '/publish-release',
-            url: `${url}/slack/commands/publish-release`,
-            description: 'Edit and publish a new release',
-            usage_hint: '[version_type (ex: "major", "minor", "patch")]',
-            should_escape: false
-          },
-          {
             command: '/deploy-pix-sites',
             url: `${url}/slack/commands/create-and-deploy-pix-site-release`,
             description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -1,0 +1,81 @@
+const commands = require('../services/slack/commands');
+const { getAppStatusFromScalingo } = require('../services/slack/app-status-from-scalingo');
+const sendSlackBlockMessage = require('../../common/services/slack/surfaces/messages/block-message');
+
+function _getDeployStartedMessage(release, appName) {
+  return `Commande de déploiement de la release "${release}" pour ${appName} en production bien reçue.`;
+}
+
+module.exports = {
+
+  createAndDeployPixSiteRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixSiteRelease(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX site and pro')
+    };
+  },
+
+  createAndDeployPixUIRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixUI(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX UI')
+    };
+  },
+
+  createAndDeployPixLCMSRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixLCMS(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX LCMS')
+    };
+  },
+
+  createAndDeployPixDatawarehouseRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixDatawarehouse(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX Datawarehouse')
+    };
+  },
+
+  createAndDeployPixBotRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixBotRelease(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX Bot')
+    };
+  },
+
+  getAppStatus(request) {
+    const appName = request.pre.payload.text;
+    return getAppStatusFromScalingo(appName);
+  },
+
+  async deployLastVersion(request) {
+    const appName = request.pre.payload.text;
+
+    try {
+      await commands.getAndDeployLastVersion({ appName });
+    } catch(e) {
+      return sendSlackBlockMessage(e.message);
+    }
+
+    return sendSlackBlockMessage(`Re-déploiement de ${appName} déclenché`);
+  },
+
+  createAndDeployEmberTestingLibraryRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployEmberTestingLibrary(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'EMBER-TESTING-LIBRARY')
+    };
+  },
+};

--- a/run/routes/slack.js
+++ b/run/routes/slack.js
@@ -1,0 +1,53 @@
+const { slackConfig } = require('../../common/config');
+const slackbotController = require('../controllers/slack');
+
+module.exports = [
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-site-release',
+    handler: slackbotController.createAndDeployPixSiteRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-ui-release',
+    handler: slackbotController.createAndDeployPixUIRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-lcms-release',
+    handler: slackbotController.createAndDeployPixLCMSRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
+    handler: slackbotController.createAndDeployPixDatawarehouseRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-pix-bot-release',
+    handler: slackbotController.createAndDeployPixBotRelease,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/app-status',
+    handler: slackbotController.getAppStatus,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/deploy-last-version',
+    handler: slackbotController.deployLastVersion,
+    config: slackConfig
+  },
+  {
+    method: 'POST',
+    path: '/slack/commands/create-and-deploy-ember-testing-library-release',
+    handler: slackbotController.createAndDeployEmberTestingLibraryRelease,
+    config: slackConfig
+  },
+];

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -29,13 +29,6 @@ describe('Acceptance | Run | Manifest', function() {
           ],
           slash_commands: [
             {
-              command: '/publish-release',
-              url: `http://${hostname}/slack/commands/publish-release`,
-              description: 'Edit and publish a new release',
-              usage_hint: '[version_type (ex: "major", "minor", "patch")]',
-              should_escape: false
-            },
-            {
               command: '/deploy-pix-sites',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-site-release`,
               description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',


### PR DESCRIPTION
## :unicorn: Problème
Les routes dans le dossier `common` sont mélangé entre la partie `build` et la partie `run` de pix-bot. Elles sont suffisamment spécifique pour être placés correctement dans l'arborescence de `pix-bot`.

## :robot: Solution
Déplacer les routes `run` dans la partie `run`. Déplacer les routes `build` dans la partie `build`.

## :rainbow: Remarques
Il reste la route `/slack/interactive-endpoint` a séparer entre `build` et `run`. Cela va nécessiter des changements de routes. Ce sera pour la prochaine !

## :100: Pour tester
Tester les différentes routes.