### PR TITLE
[FEATURE] Rajoute le déploiement des reviews app de pix-pro et de pix-ui

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -6,7 +6,8 @@ const repositoryToScalingoAppsReview = {
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
-  'pix-bot': ['pix-bot-review']
+  'pix-bot': ['pix-bot-review'],
+  'pix-ui': ['pix-ui-review']
 };
 
 module.exports = {

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -1,13 +1,13 @@
 const ScalingoClient = require('../../common/services/scalingo-client');
 
 const repositoryToScalingoAppsReview = {
-  pix: ['pix-front-review', 'pix-api-review'],
-  'pix-editor': ['pix-lcms-review'],
+  'pix-bot': ['pix-bot-review'],
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
+  'pix-editor': ['pix-lcms-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
-  'pix-bot': ['pix-bot-review'],
-  'pix-ui': ['pix-ui-review']
+  'pix-ui': ['pix-ui-review'],
+  pix: ['pix-front-review', 'pix-api-review'],
 };
 
 module.exports = {

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -5,7 +5,7 @@ const repositoryToScalingoAppsReview = {
   'pix-editor': ['pix-lcms-review'],
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
-  'pix-site': ['pix-site-review'],
+  'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-bot': ['pix-bot-review']
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Des application scalingo sont toujours en review app automatique: pix-pro-review et pix-ui-review.

## :robot: Solution
Rajouter le mapping correspondant dépot <-> application pour les faire déployer par pix-bot.
