### PR TITLE
[REVERT] Génére correctement le changelog pour une release après une correction de release à chaud

### DIFF
--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -8,8 +8,8 @@ const PullRequestGroupFactory = require('../models/PullRequestGroupFactory');
 
 const CHANGELOG_HEADER_LINES = 2;
 
-async function getTagReleaseDate(repoOwner, repoName, tagName) {
-  const latestTagUrl = await github.getLastCommitUrl({ tagName, owner: repoOwner, repo: repoName });
+async function getLastMEPDate(repoOwner, repoName) {
+  const latestTagUrl = await github.getLatestReleaseTagUrl(repoOwner, repoName);
 
   const commit = await github.getCommitAtURL(latestTagUrl);
   return commit.committer.date;
@@ -66,7 +66,7 @@ module.exports = {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getTagReleaseDate,
+  getLastMEPDate,
   getNewChangeLogLines,
   orderPr,
 };

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -39,8 +39,7 @@ function push_commit_and_tag_to_remote() {
 }
 
 function complete_change_log() {
-  LAST_TAG_ON_BRANCH=$(git tag --merged | sort --version-sort | tail -1)
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}" "${LAST_TAG_ON_BRANCH}"
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const github = require('../common/services/github');
 const {
-  getTagReleaseDate,
+  getLastMEPDate,
   filterPullRequest,
   getNewChangeLogLines,
   getHeadOfChangelog,
@@ -17,18 +17,17 @@ async function main() {
   const repoOwner = process.argv[3];
   const repoName = process.argv[4];
   const branchName = process.argv[5];
-  const lastTagNameOnBranch = process.argv[6];
 
   try {
-    const dateOfLastRelease = await getTagReleaseDate(repoOwner, repoName, lastTagNameOnBranch);
+    const dateOfLastMEP = await getLastMEPDate(repoOwner, repoName);
 
     const pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
 
-    const pullRequestsSinceLastRelease = filterPullRequest(pullRequests, dateOfLastRelease);
+    const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
 
     const newChangeLogLines = getNewChangeLogLines({
       headOfChangelogTitle: getHeadOfChangelog(tagVersion),
-      pullRequests: pullRequestsSinceLastRelease,
+      pullRequests: pullRequestsSinceLastMEP,
     });
 
     let currentChangeLog = '';

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -4,7 +4,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 const simpleGit = require('simple-git');
-const dayjs = require('dayjs');
 
 const { runScriptWithArgument, expectLines } = require('./script-helpers');
 
@@ -69,7 +68,7 @@ describe('Acceptance | Scripts | publish.sh', function() {
       'Updated CHANGELOG.md',
       'Set Git user information',
       /A minor is being released to 0.2.0.$/,
-      ' 9 files changed, 14 insertions(+), 8 deletions(-)',
+      ' 8 files changed, 8 insertions(+), 8 deletions(-)',
       'Created the release commit',
       'Created annotated tag',
       'Pushed release commit to the origin',
@@ -93,13 +92,6 @@ describe('Acceptance | Scripts | publish.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
-    const now = dayjs().format('DD/MM/YYYY');
-    expect(changelog).to.eql(`
-## v0.2.0 (${now})
-
-
-### :rocket: Amélioration
-- [#1](https://github.com/1024pix/pix-bot-publish-test/pull/1) [FEATURE] Ajout d'un index pour Pix App
-`);
+    expect(changelog).to.eql('');
   });
 });

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 const simpleGit = require('simple-git');
-const dayjs = require('dayjs');
 
 const { runScriptWithArgument, expectLines } = require('./script-helpers');
 
@@ -67,7 +66,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
       'Writing to CHANGELOG.md',
       'Updated CHANGELOG.md',
       /A minor is being released to 0.2.0.$/,
-      ' 9 files changed, 14 insertions(+), 8 deletions(-)',
+      ' 8 files changed, 8 insertions(+), 8 deletions(-)',
       'Created the release commit',
       'Created annotated tag',
       'Pushed release commit to the origin',
@@ -89,13 +88,6 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
-    const now = dayjs().format('DD/MM/YYYY');
-    expect(changelog).to.eql(`
-## v0.2.0 (${now})
-
-
-### :rocket: Amélioration
-- [#1](https://github.com/1024pix/pix-bot-publish-test/pull/1) [FEATURE] Ajout d'un index pour Pix App
-`);
+    expect(changelog).to.eql('');
   });
 });

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -7,7 +7,7 @@ const {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getTagReleaseDate,
+  getLastMEPDate,
   getNewChangeLogLines,
   orderPr,
 } = require('../../../../common/services/changelog');
@@ -123,15 +123,14 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getTagReleaseDate', () => {
+  describe('#getLastMEPDate', () => {
 
     const repoOwner = '1024pix';
     const repoName = 'pix';
-    const tagName = 'v3.193.1';
 
     beforeEach(() => {
-      sinon.stub(github, 'getLastCommitUrl')
-        .withArgs({ owner: repoOwner, repo: repoName, tagName })
+      sinon.stub(github, 'getLatestReleaseTagUrl')
+        .withArgs(repoOwner, repoName)
         .resolves(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`);
 
       sinon.stub(github, 'getCommitAtURL')
@@ -144,7 +143,7 @@ describe('Unit | Common | Services | Changelog', () => {
       const expectedDate = '2019-01-18T15:29:51Z';
 
       // when
-      const date = await getTagReleaseDate(repoOwner, repoName, tagName);
+      const date = await getLastMEPDate(repoOwner, repoName);
 
       // then
       expect(date).to.be.equal(expectedDate);


### PR DESCRIPTION
## :unicorn: Problème
#101 ne fonctionne pas car on clone le dépot avec `--depth 1` et les tests d'acceptance ne géraient pas bien ce cas

## :robot: Solution
Revert en attendant de corriger correctement le problème

## :100: Pour tester
:green_circle:  tests