### PR TITLE
[FEATURE] Génére correctement le changelog pour une release après une correction de release à chaud 

### DIFF
--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -8,8 +8,8 @@ const PullRequestGroupFactory = require('../models/PullRequestGroupFactory');
 
 const CHANGELOG_HEADER_LINES = 2;
 
-async function getLastMEPDate(repoOwner, repoName) {
-  const latestTagUrl = await github.getLatestReleaseTagUrl(repoOwner, repoName);
+async function getTagReleaseDate(repoOwner, repoName, tagName) {
+  const latestTagUrl = await github.getLastCommitUrl({ tagName, owner: repoOwner, repo: repoName });
 
   const commit = await github.getCommitAtURL(latestTagUrl);
   return commit.committer.date;
@@ -66,7 +66,7 @@ module.exports = {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getLastMEPDate,
+  getTagReleaseDate,
   getNewChangeLogLines,
   orderPr,
 };

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -39,8 +39,7 @@ function push_commit_and_tag_to_remote() {
 }
 
 function complete_change_log() {
-  LAST_TAG_ON_BRANCH=$(git tag --merged | sort --version-sort | tail -1)
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}" "${LAST_TAG_ON_BRANCH}"
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}" "v${PREVIOUS_PACKAGE_VERSION}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -39,7 +39,8 @@ function push_commit_and_tag_to_remote() {
 }
 
 function complete_change_log() {
-  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}"
+  LAST_TAG_ON_BRANCH=$(git tag --merged | sort --version-sort | tail -1)
+  node "${CWD_DIR}/scripts/get-pull-requests-to-release-in-prod.js" "${NEW_PACKAGE_VERSION}" "${GITHUB_OWNER}" "${GITHUB_REPOSITORY}" "${BRANCH_NAME}" "${LAST_TAG_ON_BRANCH}"
 
   echo "Updated CHANGELOG.md"
 }

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const github = require('../common/services/github');
 const {
-  getLastMEPDate,
+  getTagReleaseDate,
   filterPullRequest,
   getNewChangeLogLines,
   getHeadOfChangelog,
@@ -17,17 +17,18 @@ async function main() {
   const repoOwner = process.argv[3];
   const repoName = process.argv[4];
   const branchName = process.argv[5];
+  const lastTagNameOnBranch = process.argv[6];
 
   try {
-    const dateOfLastMEP = await getLastMEPDate(repoOwner, repoName);
+    const dateOfLastRelease = await getTagReleaseDate(repoOwner, repoName, lastTagNameOnBranch);
 
     const pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
 
-    const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+    const pullRequestsSinceLastRelease = filterPullRequest(pullRequests, dateOfLastRelease);
 
     const newChangeLogLines = getNewChangeLogLines({
       headOfChangelogTitle: getHeadOfChangelog(tagVersion),
-      pullRequests: pullRequestsSinceLastMEP,
+      pullRequests: pullRequestsSinceLastRelease,
     });
 
     let currentChangeLog = '';

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -45,6 +45,7 @@ function update_pix_module_version() {
 }
 
 function update_all_pix_modules_version() {
+  PREVIOUS_PACKAGE_VERSION=$(get_package_version)
   # TODO: refacto using dynamic package.json update => find . -name package.json  ! -path '*/node_modules/*'
   update_pix_module_version "admin/"
   update_pix_module_version "api/"

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -19,6 +19,7 @@ function executeCommandRecursivelyInPackageJsonDir {
 }
 
 function create_release {
+  PREVIOUS_PACKAGE_VERSION=$(get_package_version)
   npm_arg="" && [[ -n "$VERSION_TYPE" ]]  && npm_arg="$VERSION_TYPE"
   executeCommandRecursivelyInPackageJsonDir "npm version ${npm_arg} --no-git-tag-version"
   NEW_PACKAGE_VERSION=$(get_package_version)

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Scripts | publish.sh', function() {
     };
 
     // when
-    const { stdout, stderr } = await runScriptWithArgument(scriptName, [versionType, testRepositoryPath, branchName], { env });
+    const { stdout, stderr } = await runScriptWithArgument(scriptName, [versionType, 'file://' +testRepositoryPath, branchName], { env });
 
     // then
     const expectedStdout = [
@@ -80,8 +80,6 @@ describe('Acceptance | Scripts | publish.sh', function() {
     ];
     const expectedStderr = [
       /^Cloning into/,
-      'warning: --depth is ignored in local clones; use file:// instead.',
-      'done.',
       /To (.+)/,
       /dev -> dev/,
       /v0.2.0 -> v0.2.0/,

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 const simpleGit = require('simple-git');
+const dayjs = require('dayjs');
 
 const { runScriptWithArgument, expectLines } = require('./script-helpers');
 
@@ -68,7 +69,7 @@ describe('Acceptance | Scripts | publish.sh', function() {
       'Updated CHANGELOG.md',
       'Set Git user information',
       /A minor is being released to 0.2.0.$/,
-      ' 8 files changed, 8 insertions(+), 8 deletions(-)',
+      ' 9 files changed, 14 insertions(+), 8 deletions(-)',
       'Created the release commit',
       'Created annotated tag',
       'Pushed release commit to the origin',
@@ -92,6 +93,13 @@ describe('Acceptance | Scripts | publish.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
-    expect(changelog).to.eql('');
+    const now = dayjs().format('DD/MM/YYYY');
+    expect(changelog).to.eql(`
+## v0.2.0 (${now})
+
+
+### :rocket: Amélioration
+- [#1](https://github.com/1024pix/pix-bot-publish-test/pull/1) [FEATURE] Ajout d'un index pour Pix App
+`);
   });
 });

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 const simpleGit = require('simple-git');
+const dayjs = require('dayjs');
 
 const { runScriptWithArgument, expectLines } = require('./script-helpers');
 
@@ -66,7 +67,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
       'Writing to CHANGELOG.md',
       'Updated CHANGELOG.md',
       /A minor is being released to 0.2.0.$/,
-      ' 8 files changed, 8 insertions(+), 8 deletions(-)',
+      ' 9 files changed, 14 insertions(+), 8 deletions(-)',
       'Created the release commit',
       'Created annotated tag',
       'Pushed release commit to the origin',
@@ -88,6 +89,13 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
     const tags = await git.tag();
     expect(tags).to.eql('v0.1.0\nv0.1.1\nv0.2.0\n');
     const changelog = await git.show('dev:CHANGELOG.md');
-    expect(changelog).to.eql('');
+    const now = dayjs().format('DD/MM/YYYY');
+    expect(changelog).to.eql(`
+## v0.2.0 (${now})
+
+
+### :rocket: Amélioration
+- [#1](https://github.com/1024pix/pix-bot-publish-test/pull/1) [FEATURE] Ajout d'un index pour Pix App
+`);
   });
 });

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -46,7 +46,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
     };
 
     // when
-    const { stdout, stderr } = await runScriptWithArgument(scriptName, [githubOwner, githubRepository, versionType, branchName, testRepositoryPath], { env });
+    const { stdout, stderr } = await runScriptWithArgument(scriptName, [githubOwner, githubRepository, versionType, branchName, 'file://'+ testRepositoryPath], { env });
 
     // then
     const expectedStdout = [
@@ -76,8 +76,6 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
     ];
     const expectedStderr = [
       /^Cloning into/,
-      'warning: --depth is ignored in local clones; use file:// instead.',
-      'done.',
       /To (.+)/,
       /dev -> dev/,
       /v0.2.0 -> v0.2.0/,

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -7,7 +7,7 @@ const {
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
-  getLastMEPDate,
+  getTagReleaseDate,
   getNewChangeLogLines,
   orderPr,
 } = require('../../../../common/services/changelog');
@@ -123,14 +123,15 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getLastMEPDate', () => {
+  describe('#getTagReleaseDate', () => {
 
     const repoOwner = '1024pix';
     const repoName = 'pix';
+    const tagName = 'v3.193.1';
 
     beforeEach(() => {
-      sinon.stub(github, 'getLatestReleaseTagUrl')
-        .withArgs(repoOwner, repoName)
+      sinon.stub(github, 'getLastCommitUrl')
+        .withArgs({ owner: repoOwner, repo: repoName, tagName })
         .resolves(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`);
 
       sinon.stub(github, 'getCommitAtURL')
@@ -143,7 +144,7 @@ describe('Unit | Common | Services | Changelog', () => {
       const expectedDate = '2019-01-18T15:29:51Z';
 
       // when
-      const date = await getLastMEPDate(repoOwner, repoName);
+      const date = await getTagReleaseDate(repoOwner, repoName, tagName);
 
       // then
       expect(date).to.be.equal(expectedDate);


### PR DESCRIPTION
## :unicorn: Problème
Reprise de #101 
En cas de hotfix, si des PRs sont mergé sur dev avant le hotfix (qui crée un tag sur une autre branche), le changelog de la version suivante ne contient pas ces PRs mergés.

## :robot: Solution
On récupére la derniere version qui a été releaser via le package.json.

## :100: Pour tester
`npm run test`