### PR TITLE
[CLEANUP] Refactoring des modals slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Add your new slash command to the corresponding manifest: ./{run,build}/controll
 
 Go to [https://api.slack.com/apps](https://api.slack.com/apps), and create a new slack app, and create it from a manifest. The manifest is available a {ngrok_url}/{run,build}/manifest.
 
+### Test slack views
+
+Go to http://localhost:3000/slackviews to test and debug slack views.
+
 ## Deploy
 
 Pix Bot has a Slack command that allow to release itself:

--- a/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
@@ -1,9 +1,11 @@
+const callbackId = 'release-publication-confirmation';
+
 module.exports = (releaseType, hasConfigFileChanged) => {
   const modalReleasePublicationConfirmation = {
     'response_action': 'push',
     'view': {
       'type': 'modal',
-      'callback_id': 'release-publication-confirmation',
+      'callback_id': callbackId,
       'private_metadata': releaseType,
       'title': {
         'type': 'plain_text',
@@ -43,3 +45,5 @@ module.exports = (releaseType, hasConfigFileChanged) => {
 
   return modalReleasePublicationConfirmation;
 };
+
+module.exports.callbackId = callbackId;

--- a/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
@@ -1,49 +1,26 @@
+const { Modal, Blocks } = require('slack-block-builder');
+
 const callbackId = 'release-publication-confirmation';
 
 module.exports = (releaseType, hasConfigFileChanged) => {
-  const modalReleasePublicationConfirmation = {
-    'response_action': 'push',
-    'view': {
-      'type': 'modal',
-      'callback_id': callbackId,
-      'private_metadata': releaseType,
-      'title': {
-        'type': 'plain_text',
-        'text': 'Confirmation'
-      },
-      'submit': {
-        'type': 'plain_text',
-        'text': '🚀 Go !',
-        'emoji': true
-      },
-      'close': {
-        'type': 'plain_text',
-        'text': 'Annuler',
-        'emoji': true
-      },
-      'blocks': [
-        {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': `Vous vous apprêtez à publier une version *${releaseType}* et la déployer en recette. Êtes-vous sûr de vous ?`
-          }
-        },
-      ]
-    }
+  const modal = Modal({
+    title: 'Confirmation',
+    callbackId,
+    privateMetaData: releaseType,
+    submit: '🚀 Go !',
+    close: 'Annuler'
+  }).blocks([
+    ...hasConfigFileChanged ? [Blocks.Section({
+      text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
+    })] : [],
+    Blocks.Section({
+      text: `Vous vous apprêtez à publier une version *${releaseType}* et la déployer en recette. Êtes-vous sûr de vous ?`
+    })
+  ]);
+  return {
+    response_action: 'push',
+    view: modal.buildToObject()
   };
-
-  if (hasConfigFileChanged) {
-    modalReleasePublicationConfirmation.view.blocks.unshift({
-      'type': 'section',
-      'text': {
-        'type': 'mrkdwn',
-        'text': ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
-      },
-    });
-  }
-
-  return modalReleasePublicationConfirmation;
 };
 
 module.exports.callbackId = callbackId;

--- a/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
@@ -2,8 +2,8 @@ const { Modal, Blocks } = require('slack-block-builder');
 
 const callbackId = 'release-publication-confirmation';
 
-module.exports = (releaseType, hasConfigFileChanged) => {
-  const modal = Modal({
+function modal(releaseType, hasConfigFileChanged) {
+  return Modal({
     title: 'Confirmation',
     callbackId,
     privateMetaData: releaseType,
@@ -17,10 +17,17 @@ module.exports = (releaseType, hasConfigFileChanged) => {
       text: `Vous vous apprêtez à publier une version *${releaseType}* et la déployer en recette. Êtes-vous sûr de vous ?`
     })
   ]);
+}
+
+module.exports = (releaseType, hasConfigFileChanged) => {
   return {
     response_action: 'push',
-    view: modal.buildToObject()
+    view: modal(releaseType, hasConfigFileChanged).buildToObject()
   };
+};
+
+module.exports.sampleView = () => {
+  return modal('minor', true);
 };
 
 module.exports.callbackId = callbackId;

--- a/common/controllers/index.js
+++ b/common/controllers/index.js
@@ -1,4 +1,8 @@
 const { name, version, description } = require('../../package.json');
+const { sampleView: releaseTypeSelection } = require('../services/slack/surfaces/modals/publish-release/release-type-selection');
+const { sampleView: releaseTagSelection } = require('../services/slack/surfaces/modals/deploy-release/release-tag-selection');
+const { sampleView: releaseDeploymentConfirmation } = require('../../run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation');
+const { sampleView: releasePublicationConfirmation } = require('../../build/services/slack/surfaces/modals/publish-release/release-publication-confirmation');
 
 module.exports = {
 
@@ -7,5 +11,17 @@ module.exports = {
       name, version, description
     };
   },
+
+  getSlackViews() {
+    const views = [
+      { name: 'release-type-selection', view: releaseTypeSelection() },
+      { name: 'release-tag-selection', view: releaseTagSelection() },
+      { name: 'release-deployment-confirmation', view: releaseDeploymentConfirmation() },
+      { name: 'release-publication-confirmation', view: releasePublicationConfirmation() },
+    ];
+    return views.map(({ name, view }) => {
+      return `<a href="${view.getPreviewUrl()}">View ${name}</a>`;
+    }).join('<br>');
+  }
 
 };

--- a/common/controllers/slack.js
+++ b/common/controllers/slack.js
@@ -25,16 +25,16 @@ module.exports = {
       }
       return null;
     case 'view_submission':
-      if (payload.view.callback_id === 'release-type-selection') {
+      if (payload.view.callback_id === shortcuts.openViewPublishReleaseTypeSelectionCallbackId) {
         return viewSubmissions.submitReleaseTypeSelection(payload);
       }
-      if (payload.view.callback_id === 'release-publication-confirmation') {
+      if (payload.view.callback_id === viewSubmissions.submitReleaseTypeSelectionCallbackId) {
         return viewSubmissions.submitReleasePublicationConfirmation(payload);
       }
-      if (payload.view.callback_id === 'release-tag-selection') {
+      if (payload.view.callback_id === shortcuts.openViewDeployReleaseTagSelectionCallbackId) {
         return viewSubmissions.submitReleaseTagSelection(payload);
       }
-      if (payload.view.callback_id === 'release-deployment-confirmation') {
+      if (payload.view.callback_id === viewSubmissions.submitReleaseTagSelectionCallbackId) {
         return viewSubmissions.submitReleaseDeploymentConfirmation(payload);
       }
       return null;

--- a/common/routes/index.js
+++ b/common/routes/index.js
@@ -5,5 +5,10 @@ module.exports = [
     method: 'GET',
     path: '/',
     handler: indexController.getApiInfo
+  },
+  {
+    method: 'GET',
+    path: '/slackviews',
+    handler: indexController.getSlackViews
   }
 ];

--- a/common/services/slack/shortcuts.js
+++ b/common/services/slack/shortcuts.js
@@ -5,6 +5,7 @@ const config = require('../../../config');
 
 module.exports = {
 
+  openViewPublishReleaseTypeSelectionCallbackId: publishReleaseTypeSelectionModal.callbackId,
   openViewPublishReleaseTypeSelection(payload) {
     const options = {
       method: 'POST',
@@ -17,6 +18,8 @@ module.exports = {
     };
     return axios(options);
   },
+
+  openViewDeployReleaseTagSelectionCallbackId: deployReleaseTagSelectionModal.callbackId,
 
   openViewDeployReleaseTagSelection(payload) {
     const options = {

--- a/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
+++ b/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
@@ -2,8 +2,8 @@ const { Modal, Blocks, Elements } = require('slack-block-builder');
 
 const callbackId = 'release-tag-selection';
 
-module.exports = (triggerId) => {
-  const modal = Modal({
+function modal() {
+  return Modal({
     title: 'Déployer une release',
     callbackId,
     submit: 'Déployer',
@@ -17,11 +17,17 @@ module.exports = (triggerId) => {
       placeholder: 'Ex : v2.130.0'
     }))
   ]);
+}
 
+module.exports = (triggerId) => {
   return {
     trigger_id: triggerId,
-    view: modal.buildToObject()
+    view: modal().buildToObject()
   };
+};
+
+module.exports.sampleView = () => {
+  return modal();
 };
 
 module.exports.callbackId = callbackId;

--- a/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
+++ b/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
@@ -1,47 +1,26 @@
+const { Modal, Blocks, Elements } = require('slack-block-builder');
+
 const callbackId = 'release-tag-selection';
 
 module.exports = (triggerId) => {
+  const modal = Modal({
+    title: 'Déployer une release',
+    callbackId,
+    submit: 'Déployer',
+    close: 'Annuler'
+  }).blocks([
+    Blocks.Input({
+      blockId: 'deploy-release-tag',
+      label: 'Numéro de release',
+    }).element(Elements.TextInput({
+      actionId: 'release-tag-value',
+      placeholder: 'Ex : v2.130.0'
+    }))
+  ]);
+
   return {
-    'trigger_id': triggerId,
-    'view': {
-      'type': 'modal',
-      'callback_id': callbackId,
-      'title': {
-        'type': 'plain_text',
-        'text': 'Déployer une release',
-        'emoji': true
-      },
-      'submit': {
-        'type': 'plain_text',
-        'text': 'Déployer',
-        'emoji': true
-      },
-      'close': {
-        'type': 'plain_text',
-        'text': 'Annuler',
-        'emoji': true
-      },
-      'blocks': [
-        {
-          'type': 'input',
-          'block_id': 'deploy-release-tag',
-          'label': {
-            'type': 'plain_text',
-            'text': 'Numéro de release',
-            'emoji': true
-          },
-          'element': {
-            'type': 'plain_text_input',
-            'action_id': 'release-tag-value',
-            'placeholder': {
-              'type': 'plain_text',
-              'text': 'Ex : v2.130.0',
-              'emoji': true
-            }
-          }
-        },
-      ]
-    }
+    trigger_id: triggerId,
+    view: modal.buildToObject()
   };
 };
 

--- a/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
+++ b/common/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
@@ -1,9 +1,11 @@
+const callbackId = 'release-tag-selection';
+
 module.exports = (triggerId) => {
   return {
     'trigger_id': triggerId,
     'view': {
       'type': 'modal',
-      'callback_id': 'release-tag-selection',
+      'callback_id': callbackId,
       'title': {
         'type': 'plain_text',
         'text': 'Déployer une release',
@@ -42,3 +44,5 @@ module.exports = (triggerId) => {
     }
   };
 };
+
+module.exports.callbackId = callbackId;

--- a/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
+++ b/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
@@ -1,86 +1,48 @@
+const { Modal, Blocks, Elements, Bits } = require('slack-block-builder');
+
 const callbackId = 'release-type-selection';
 
 module.exports = (triggerId) => {
+  const modal = Modal({
+    title: 'Publier une release',
+    callbackId,
+    submit: 'Publier',
+    close: 'Annuler'
+  }).blocks([
+    Blocks.Section({
+      text: 'Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d\'architecture'
+    }),
+    Blocks.Divider(),
+    Blocks.Input({
+      blockId: 'publish-release-type',
+      label: 'Type de release',
+    }).element(
+      Elements.StaticSelect({
+        actionId: 'release-type-option',
+        placeholder: 'Selectionnez un élément',
+      }).options([
+        Bits.Option({
+          text: 'Minor',
+          value: 'minor'
+        }),
+        Bits.Option({
+          text: 'Patch',
+          value: 'patch'
+        }),
+        Bits.Option({
+          text: 'Major',
+          value: 'major'
+        })
+      ]).initialOption(Bits.Option({
+        text: 'Minor',
+        value: 'minor'
+      }))
+    )
+  ]);
+
   return {
-    'trigger_id': `${triggerId}`,
-    'view': {
-      'type': 'modal',
-      'callback_id': callbackId,
-      'title': {
-        'type': 'plain_text',
-        'text': 'Publier une release',
-        'emoji': true
-      },
-      'submit': {
-        'type': 'plain_text',
-        'text': 'Publier',
-        'emoji': true
-      },
-      'close': {
-        'type': 'plain_text',
-        'text': 'Annuler',
-        'emoji': true
-      },
-      'blocks': [
-        {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': 'Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d\'architecture'
-          }
-        },
-        {
-          'type': 'divider'
-        },
-        {
-          'type': 'input',
-          'block_id': 'publish-release-type',
-          'label': {
-            'type': 'plain_text',
-            'text': 'Type de release',
-            'emoji': true
-          },
-          'element': {
-            'action_id': 'release-type-option',
-            'type': 'static_select',
-            'placeholder': {
-              'type': 'plain_text',
-              'text': 'Selectionnez un élément'
-            },
-            'initial_option': {
-              'text': {
-                'type': 'plain_text',
-                'text': 'Minor'
-              },
-              'value': 'minor'
-            },
-            'options': [
-              {
-                'text': {
-                  'type': 'plain_text',
-                  'text': 'Minor'
-                },
-                'value': 'minor'
-              },
-              {
-                'text': {
-                  'type': 'plain_text',
-                  'text': 'Patch'
-                },
-                'value': 'patch'
-              },
-              {
-                'text': {
-                  'type': 'plain_text',
-                  'text': 'Major'
-                },
-                'value': 'major'
-              }
-            ]
-          }
-        }
-      ]
-    }
+    trigger_id: triggerId,
+    view: modal.buildToObject()
   };
 };
 

--- a/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
+++ b/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
@@ -1,9 +1,11 @@
+const callbackId = 'release-type-selection';
+
 module.exports = (triggerId) => {
   return {
     'trigger_id': `${triggerId}`,
     'view': {
       'type': 'modal',
-      'callback_id': 'release-type-selection',
+      'callback_id': callbackId,
       'title': {
         'type': 'plain_text',
         'text': 'Publier une release',
@@ -81,3 +83,5 @@ module.exports = (triggerId) => {
     }
   };
 };
+
+module.exports.callbackId = callbackId;

--- a/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
+++ b/common/services/slack/surfaces/modals/publish-release/release-type-selection.js
@@ -2,8 +2,8 @@ const { Modal, Blocks, Elements, Bits } = require('slack-block-builder');
 
 const callbackId = 'release-type-selection';
 
-module.exports = (triggerId) => {
-  const modal = Modal({
+function modal() {
+  return Modal({
     title: 'Publier une release',
     callbackId,
     submit: 'Publier',
@@ -39,11 +39,17 @@ module.exports = (triggerId) => {
       }))
     )
   ]);
+}
 
+module.exports = (triggerId) => {
   return {
     trigger_id: triggerId,
-    view: modal.buildToObject()
+    view: modal().buildToObject()
   };
+};
+
+module.exports.sampleView = () => {
+  return modal();
 };
 
 module.exports.callbackId = callbackId;

--- a/common/services/slack/view-submissions.js
+++ b/common/services/slack/view-submissions.js
@@ -14,6 +14,8 @@ module.exports = {
     return openModalReleasePublicationConfirmation(releaseType, hasConfigFileChanged);
   },
 
+  submitReleaseTypeSelectionCallbackId: openModalReleasePublicationConfirmation.callbackId,
+
   submitReleasePublicationConfirmation(payload) {
     const releaseType = payload.view.private_metadata;
 
@@ -36,6 +38,8 @@ module.exports = {
     const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
     return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
   },
+
+  submitReleaseTagSelectionCallbackId: openModalReleaseDeploymentConfirmation.callbackId,
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,6 +2348,11 @@
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true
     },
+    "slack-block-builder": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/slack-block-builder/-/slack-block-builder-2.5.0.tgz",
+      "integrity": "sha512-Gekb6jSKmyZtYXFrMXN637/FttYiUFvcoDeKt5epcwTDggxQvtw/Q3aO5eR4JNe5UW2JoSGao+6GX3NZf2yceA=="
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "scalingo": "^0.3.11",
     "scalingo-review-app-manager": "^1.0.1",
     "sib-api-v3-sdk": "^8.3.0",
+    "slack-block-builder": "^2.5.0",
     "tsscmp": "^1.0.6"
   },
   "devDependencies": {

--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -2,8 +2,8 @@ const { Modal, Blocks } = require('slack-block-builder');
 
 const callbackId = 'release-deployment-confirmation';
 
-module.exports = (releaseTag, hasConfigFileChanged) => {
-  const modal = Modal({
+function modal(releaseTag, hasConfigFileChanged) {
+  return Modal({
     title: 'Confirmation',
     callbackId,
     privateMetaData: releaseTag,
@@ -19,10 +19,17 @@ module.exports = (releaseTag, hasConfigFileChanged) => {
       text: `Vous vous apprêtez à déployer la version *${releaseTag}* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?`
     })
   ]);
+}
+
+module.exports = (releaseTag, hasConfigFileChanged) => {
   return {
     response_action: 'push',
-    view: modal.buildToObject()
+    view: modal(releaseTag, hasConfigFileChanged).buildToObject()
   };
+};
+
+module.exports.sampleView = () => {
+  return modal('v6.6.6', true);
 };
 
 module.exports.callbackId = callbackId;

--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -1,9 +1,11 @@
+const callbackId = 'release-deployment-confirmation';
+
 module.exports = (releaseTag, hasConfigFileChanged) => {
   const modalReleaseDeploymentConfirmation = {
     'response_action': 'push',
     'view': {
       'type': 'modal',
-      'callback_id': 'release-deployment-confirmation',
+      'callback_id': callbackId,
       'private_metadata': `${releaseTag}`,
       'title': {
         'type': 'plain_text',
@@ -29,17 +31,8 @@ module.exports = (releaseTag, hasConfigFileChanged) => {
         },
       ]
     }
-  };
-
-  if(hasConfigFileChanged) {
-    modalReleaseDeploymentConfirmation.view.blocks.unshift({
-      'type': 'section',
-      'text': {
-        'type': 'mrkdwn',
-        'text': ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
-      },
-    });
-  }
 
   return modalReleaseDeploymentConfirmation;
 };
+
+module.exports.callbackId = callbackId;

--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -1,38 +1,28 @@
+const { Modal, Blocks } = require('slack-block-builder');
+
 const callbackId = 'release-deployment-confirmation';
 
 module.exports = (releaseTag, hasConfigFileChanged) => {
-  const modalReleaseDeploymentConfirmation = {
-    'response_action': 'push',
-    'view': {
-      'type': 'modal',
-      'callback_id': callbackId,
-      'private_metadata': `${releaseTag}`,
-      'title': {
-        'type': 'plain_text',
-        'text': 'Confirmation'
-      },
-      'submit': {
-        'type': 'plain_text',
-        'text': '🚀 Go !',
-        'emoji': true
-      },
-      'close': {
-        'type': 'plain_text',
-        'text': 'Annuler',
-        'emoji': true
-      },
-      'blocks': [
-        {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': `Vous vous apprêtez à déployer la version *${releaseTag}* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?`
-          }
-        },
-      ]
-    }
-
-  return modalReleaseDeploymentConfirmation;
+  const modal = Modal({
+    title: 'Confirmation',
+    callbackId,
+    privateMetaData: releaseTag,
+    submit: '🚀 Go !',
+    close: 'Annuler'
+  }).blocks([
+    ...hasConfigFileChanged ? [
+      Blocks.Section({
+        text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
+      })
+    ] : [],
+    Blocks.Section({
+      text: `Vous vous apprêtez à déployer la version *${releaseTag}* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?`
+    })
+  ]);
+  return {
+    response_action: 'push',
+    view: modal.buildToObject()
+  };
 };
 
 module.exports.callbackId = callbackId;

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -1,0 +1,30 @@
+const { expect } = require('../../test-helper');
+const server = require('../../../server');
+const { version } = require('../../../package.json');
+
+describe('Acceptance | Common | Index', function() {
+  describe('GET /', function() {
+    it('responds with 200', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/'
+      });
+      expect(res.statusCode).to.equal(200);
+      expect(JSON.parse(res.payload)).to.deep.equal({
+        name: 'pix-bot',
+        version,
+        description: 'Pix Bot application'
+      });
+    });
+  });
+
+  describe('GET /slackviews', function() {
+    it('responds with 200', async () => {
+      const res = await server.inject({
+        method: 'GET',
+        url: '/slackviews'
+      });
+      expect(res.statusCode).to.equal(200);
+    });
+  });
+});

--- a/test/acceptance/common/slack_test.js
+++ b/test/acceptance/common/slack_test.js
@@ -101,17 +101,14 @@ describe('Acceptance | Common | Slack', function() {
               'title': {
                 'type': 'plain_text',
                 'text': 'Publier une release',
-                'emoji': true
               },
               'submit': {
                 'type': 'plain_text',
                 'text': 'Publier',
-                'emoji': true
               },
               'close': {
                 'type': 'plain_text',
                 'text': 'Annuler',
-                'emoji': true
               },
               'blocks': [
                 {
@@ -130,7 +127,6 @@ describe('Acceptance | Common | Slack', function() {
                   'label': {
                     'type': 'plain_text',
                     'text': 'Type de release',
-                    'emoji': true
                   },
                   'element': {
                     'action_id': 'release-type-option',
@@ -232,12 +228,10 @@ describe('Acceptance | Common | Slack', function() {
               submit: {
                 type: 'plain_text',
                 text: '🚀 Go !',
-                emoji: true,
               },
               close: {
                 type: 'plain_text',
                 text: 'Annuler',
-                emoji: true,
               },
               blocks: [
                 {
@@ -293,12 +287,10 @@ describe('Acceptance | Common | Slack', function() {
               submit: {
                 type: 'plain_text',
                 text: '🚀 Go !',
-                emoji: true,
               },
               close: {
                 type: 'plain_text',
                 text: 'Annuler',
-                emoji: true,
               },
               blocks: [
                 {
@@ -355,17 +347,14 @@ describe('Acceptance | Common | Slack', function() {
               'title': {
                 'type': 'plain_text',
                 'text': 'Déployer une release',
-                'emoji': true
               },
               'submit': {
                 'type': 'plain_text',
                 'text': 'Déployer',
-                'emoji': true
               },
               'close': {
                 'type': 'plain_text',
                 'text': 'Annuler',
-                'emoji': true
               },
               'blocks': [
                 {
@@ -374,7 +363,6 @@ describe('Acceptance | Common | Slack', function() {
                   'label': {
                     'type': 'plain_text',
                     'text': 'Numéro de release',
-                    'emoji': true
                   },
                   'element': {
                     'type': 'plain_text_input',
@@ -382,7 +370,6 @@ describe('Acceptance | Common | Slack', function() {
                     'placeholder': {
                       'type': 'plain_text',
                       'text': 'Ex : v2.130.0',
-                      'emoji': true
                     }
                   }
                 },
@@ -446,12 +433,10 @@ describe('Acceptance | Common | Slack', function() {
               submit: {
                 type: 'plain_text',
                 text: '🚀 Go !',
-                emoji: true,
               },
               close: {
                 type: 'plain_text',
                 text: 'Annuler',
-                emoji: true,
               },
               blocks: [
                 {
@@ -504,12 +489,10 @@ describe('Acceptance | Common | Slack', function() {
               submit: {
                 type: 'plain_text',
                 text: '🚀 Go !',
-                emoji: true,
               },
               close: {
                 type: 'plain_text',
                 text: 'Annuler',
-                emoji: true,
               },
               blocks: [
                 {

--- a/test/acceptance/common/slack_test.js
+++ b/test/acceptance/common/slack_test.js
@@ -219,39 +219,37 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify(
-            {
-              response_action: 'push',
-              view: {
-                type: 'modal',
-                callback_id: 'release-publication-confirmation',
-                private_metadata: 'minor',
-                title: {
-                  type: 'plain_text',
-                  text: 'Confirmation',
-                },
-                submit: {
-                  type: 'plain_text',
-                  text: '🚀 Go !',
-                  emoji: true,
-                },
-                close: {
-                  type: 'plain_text',
-                  text: 'Annuler',
-                  emoji: true,
-                },
-                blocks: [
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: 'Vous vous apprêtez à publier une version *minor* et la déployer en recette. Êtes-vous sûr de vous ?',
-                    },
-                  },
-                ],
+          expect(JSON.parse(res.payload)).to.deep.equal({
+            response_action: 'push',
+            view: {
+              type: 'modal',
+              callback_id: 'release-publication-confirmation',
+              private_metadata: 'minor',
+              title: {
+                type: 'plain_text',
+                text: 'Confirmation',
               },
-            }
-          ));
+              submit: {
+                type: 'plain_text',
+                text: '🚀 Go !',
+                emoji: true,
+              },
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
+                emoji: true,
+              },
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: 'Vous vous apprêtez à publier une version *minor* et la déployer en recette. Êtes-vous sûr de vous ?',
+                  },
+                },
+              ],
+            },
+          });
         });
 
         it('returns the confirmation modal with a warning', async function () {
@@ -282,46 +280,44 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify(
-            {
-              response_action: 'push',
-              view: {
-                type: 'modal',
-                callback_id: 'release-publication-confirmation',
-                private_metadata: 'major',
-                title: {
-                  type: 'plain_text',
-                  text: 'Confirmation',
-                },
-                submit: {
-                  type: 'plain_text',
-                  text: '🚀 Go !',
-                  emoji: true,
-                },
-                close: {
-                  type: 'plain_text',
-                  text: 'Annuler',
-                  emoji: true,
-                },
-                blocks: [
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
-                    }
-                  },
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: 'Vous vous apprêtez à publier une version *major* et la déployer en recette. Êtes-vous sûr de vous ?',
-                    },
-                  },
-                ],
+          expect(JSON.parse(res.payload)).to.deep.equal({
+            response_action: 'push',
+            view: {
+              type: 'modal',
+              callback_id: 'release-publication-confirmation',
+              private_metadata: 'major',
+              title: {
+                type: 'plain_text',
+                text: 'Confirmation',
               },
-            }
-          ));
+              submit: {
+                type: 'plain_text',
+                text: '🚀 Go !',
+                emoji: true,
+              },
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
+                emoji: true,
+              },
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
+                  }
+                },
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: 'Vous vous apprêtez à publier une version *major* et la déployer en recette. Êtes-vous sûr de vous ?',
+                  },
+                },
+              ],
+            },
+          });
         });
       });
 
@@ -341,9 +337,9 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify({
+          expect(JSON.parse(res.payload)).to.deep.equal({
             response_action: 'clear'
-          }));
+          });
         });
       });
     });
@@ -437,39 +433,37 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify(
-            {
-              response_action: 'push',
-              view: {
-                type: 'modal',
-                callback_id: 'release-deployment-confirmation',
-                private_metadata: 'v2.130.0',
-                title: {
-                  type: 'plain_text',
-                  text: 'Confirmation',
-                },
-                submit: {
-                  type: 'plain_text',
-                  text: '🚀 Go !',
-                  emoji: true,
-                },
-                close: {
-                  type: 'plain_text',
-                  text: 'Annuler',
-                  emoji: true,
-                },
-                blocks: [
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
-                    },
-                  },
-                ],
+          expect(JSON.parse(res.payload)).to.deep.equal({
+            response_action: 'push',
+            view: {
+              type: 'modal',
+              callback_id: 'release-deployment-confirmation',
+              private_metadata: 'v2.130.0',
+              title: {
+                type: 'plain_text',
+                text: 'Confirmation',
               },
-            }
-          ));
+              submit: {
+                type: 'plain_text',
+                text: '🚀 Go !',
+                emoji: true,
+              },
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
+                emoji: true,
+              },
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
+                  },
+                },
+              ],
+            },
+          });
         });
 
         it('returns the confirmation modal with a warning', async function () {
@@ -497,46 +491,44 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify(
-            {
-              response_action: 'push',
-              view: {
-                type: 'modal',
-                callback_id: 'release-deployment-confirmation',
-                private_metadata: 'v2.130.0',
-                title: {
-                  type: 'plain_text',
-                  text: 'Confirmation',
-                },
-                submit: {
-                  type: 'plain_text',
-                  text: '🚀 Go !',
-                  emoji: true,
-                },
-                close: {
-                  type: 'plain_text',
-                  text: 'Annuler',
-                  emoji: true,
-                },
-                blocks: [
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
-                    }
-                  },
-                  {
-                    type: 'section',
-                    text: {
-                      type: 'mrkdwn',
-                      text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
-                    },
-                  },
-                ],
+          expect(JSON.parse(res.payload)).to.deep.equal({
+            response_action: 'push',
+            view: {
+              type: 'modal',
+              callback_id: 'release-deployment-confirmation',
+              private_metadata: 'v2.130.0',
+              title: {
+                type: 'plain_text',
+                text: 'Confirmation',
               },
-            }
-          ));
+              submit: {
+                type: 'plain_text',
+                text: '🚀 Go !',
+                emoji: true,
+              },
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
+                emoji: true,
+              },
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
+                  }
+                },
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
+                  },
+                },
+              ],
+            },
+          });
         });
       });
 
@@ -556,9 +548,9 @@ describe('Acceptance | Common | Slack', function() {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.payload).to.deep.equal(JSON.stringify({
+          expect(JSON.parse(res.payload)).to.deep.equal({
             response_action: 'clear'
-          }));
+          });
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
- Les modals slack sont écrite en dur et ne sont pas super claires.
- On a des identifiant de callback slack qui sont référencé a plusieurs endroits sans liaison claire dans le code.

## :robot: Solution
- Utiliser `slack-block-builder`
- Utiliser des constantes pour référencer les callbacks

## :rainbow: Remarques
 `slack-block-builder` a le bon gout de créer un lien vers le block builder de slack pour faire de la prévisualisation. Du coup j'ai rajouté une route /slackviews qui permet de visualiser cela.

## :100: Pour tester
Pas de changement dans les tests (ou vaiment mineur avec le `emoji: true` qui n'est plus nécessaire).