### PR TITLE
[BUGFIX] Corrige le nom de l'application a déployer pour pix-bot-build

### DIFF
--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -105,7 +105,7 @@ async function publishAndDeployPixBot(repoName, releaseType, responseUrl) {
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
 
   const recette = await ScalingoClient.getInstance('recette');
-  await recette.deployFromArchive('pix-bot-build', releaseTag, repoName, { withEnvSuffix: false });
+  await recette.deployFromArchive('pix-bot-build-production', releaseTag, repoName, { withEnvSuffix: false });
 
   const production = await ScalingoClient.getInstance('production');
   await production.deployFromArchive('pix-bot-run', releaseTag, repoName);

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -197,7 +197,7 @@ describe('Services | Slack | Commands', () => {
 
     it('should deploy the release for pix-bot-build', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build-production');
     });
 
     it('should deploy the release for pix-bot-run', () => {


### PR DESCRIPTION
## :unicorn: Problème
Le déploiement en production des instances de pix-bot est cassé car nous avons renommé l'application scalingo de pix-bot build en pix-bot-build-production

## :robot: Solution
Donner le nom correct de l'application a déployer sur scalingo

## :100: Pour tester
:green_circle: 