### PR TITLE
[CLEANUP] Supprime la config PIX_APPS_TO_DEPLOY

### DIFF
--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -34,8 +34,8 @@ module.exports = {
 
     const client = await ScalingoClient.getInstance(sanitizedEnvironment);
 
-    const results = await Promise.all(config.pixApps.map(pixApp => {
-      return client.deployFromArchive(pixApp, sanitizedReleaseTag);
+    const results = await Promise.all(config.PIX_APPS.map(pixApp => {
+      return client.deployFromArchive(`pix-${pixApp}`, sanitizedReleaseTag);
     }));
 
     return results;

--- a/config.js
+++ b/config.js
@@ -24,8 +24,6 @@ module.exports = (function() {
     port: _getNumber(process.env.PORT, 3000),
     environment: (process.env.NODE_ENV || 'development'),
 
-    pixApps: _getCommaSeparatedValues(process.env.PIX_APPS_TO_DEPLOY),
-
     baleen: {
       pat: process.env.BALEEN_PERSONAL_ACCESS_TOKEN,
       appNamespaces: _getJSON(process.env.BALEEN_APP_NAMESPACES),
@@ -124,8 +122,6 @@ module.exports = (function() {
     config.scalingo.recette.apiUrl = 'https://scalingo.recette';
     config.scalingo.production.token = 'tk-us-scalingo-token-production';
     config.scalingo.production.apiUrl = 'https://scalingo.production';
-
-    config.pixApps = ['pix-app1', 'pix-app2', 'pix-app3'];
 
     config.prismic.secret = 'prismic-secret';
   }

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -43,10 +43,12 @@ describe('releases', function() {
       // when
       const response = await releasesService.deploy('production', 'v1.0');
       // then
-      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app1', 'v1.0');
-      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app2', 'v1.0');
-      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app3', 'v1.0');
-      expect(response).to.deep.equal(['OK', 'OK', 'OK']);
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-app', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-certif', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-admin', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-orga', 'v1.0');
+      sinon.assert.calledWithExactly(scalingoClient.deployFromArchive, 'pix-api', 'v1.0');
+      expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK']);
     });
 
     it('should trigger deployments of managed applications', async () => {


### PR DESCRIPTION
## :unicorn: Problème
La configuration `PIX_APPS_TO_DEPLOY` que l'on récupère en variable d'environnement est en doublon avec `PIX_APPS`.

## :robot: Solution
Utiliser `PIX_APPS` la on on utilisait `config.pixApps`.

## :rainbow: Remarques


## :100: Pour tester
:green_circle: 