### PR TITLE
[BUGFIX] Corrige la première release

### DIFF
--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -28,7 +28,7 @@ async function main() {
 
   try {
     let pullRequests;
-    if (lastTagNameOnBranch === '0.0.0') {
+    if (lastTagNameOnBranch === 'v0.0.0') {
       pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
     } else {
       try {


### PR DESCRIPTION
## :unicorn: Problème
La première release d'un repository ne fonctionne pas car on checkait `0.0.0 `au lieu de `v0.0.0`.

## :robot: Solution
Corrigeait le code

## :rainbow: Remarques
:ok_hand: 

## :100: Pour tester
