### PR TITLE
[BUGFIX] Corrige le nom des applications déployées pour pix-db-stats

### DIFF
--- a/config.js
+++ b/config.js
@@ -97,7 +97,7 @@ module.exports = (function() {
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_SITE_REPO_NAME: 'pix-site',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',
-    PIX_DB_STATS_APPS_NAME: ['pix-db-stats-production', 'pix-db-stats-datawarehouse-production', 'pix-db-stats-datawarehouse-ext-production'],
+    PIX_DB_STATS_APPS_NAME: ['pix-db-stats', 'pix-db-stats-datawarehouse', 'pix-db-stats-datawarehouse-ext'],
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex'],


### PR DESCRIPTION
## :unicorn: Problème
Le nom des applications a déployer pour pix-db-stats n'est pas correct. la partie `-production` est automatiquement rajouté.

## :robot: Solution
Supprimer le suffixe -production des applications px-db-stats a déployer.

## :rainbow: Remarques


## :100: Pour tester
