### PR TITLE
[FEATURE] Déploiement de metabase

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,12 +93,16 @@ module.exports = (function() {
     PIX_LCMS_APP_NAME: 'pix-lcms',
     PIX_UI_REPO_NAME: 'pix-ui',
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
-    PIX_SITE_REPO_NAME: 'pix-site',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',
     PIX_DB_STATS_APPS_NAME: ['pix-db-stats', 'pix-db-stats-datawarehouse', 'pix-db-stats-datawarehouse-ext'],
+    PIX_SITE_REPO_NAME: 'pix-site',
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex'],
+
+    PIX_METABASE_REPO_NAME: 'metabase-deploy',
+    PIX_METABASE_APPS_NAME: ['pix-metabase-production', 'pix-data-metabase-dev'],
+
     PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api'],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
   };

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -90,6 +90,14 @@ module.exports = {
     };
   },
 
+  deployMetabase() {
+    commands.deployMetabase();
+
+    return {
+      text: 'Commande de déploiement de Metabase en production bien reçue.',
+    };
+  },
+
   interactiveEndpoint(request) {
     const payload = request.pre.payload;
 

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -75,7 +75,6 @@ manifest.registerSlashCommand({
   handler: slackbotController.createAndDeployEmberTestingLibraryRelease,
 });
 
-
 manifest.registerSlashCommand({
   command: '/deploy-db-stats',
   path: '/slack/commands/create-and-deploy-db-stats',
@@ -83,6 +82,15 @@ manifest.registerSlashCommand({
   usage_hint: '[patch, minor, major]',
   should_escape: false,
   handler: slackbotController.createAndDeployDbStats,
+});
+
+manifest.registerSlashCommand({
+  command: '/deploy-metabase',
+  path: '/slack/commands/deploy-metabase',
+  description: 'Déploie metabase',
+  usage_hint: '/deploy-metabase',
+  should_escape: false,
+  handler: slackbotController.deployMetabase,
 });
 
 manifest.registerShortcut({

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -14,6 +14,8 @@ const {
   PIX_EMBER_TESTING_LIBRARY_REPO_NAME,
   PIX_DB_STATS_REPO_NAME,
   PIX_DB_STATS_APPS_NAME,
+  PIX_METABASE_REPO_NAME,
+  PIX_METABASE_APPS_NAME,
 } = require('../../../config');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
@@ -176,5 +178,13 @@ module.exports = {
 
   async createAndDeployDbStats(payload) {
     await publishAndDeployRelease(PIX_DB_STATS_REPO_NAME, PIX_DB_STATS_APPS_NAME, payload.text, payload.response_url);
+  },
+
+  async deployMetabase() {
+    const repoName = PIX_METABASE_REPO_NAME;
+    const client = await ScalingoClient.getInstance('production');
+    await PIX_METABASE_APPS_NAME.map((appName) => {
+      return client.deployFromArchive(appName, 'master', repoName, { withEnvSuffix: false });
+    });
   }
 };

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -90,6 +90,13 @@ describe('Acceptance | Run | Manifest', function() {
               should_escape: false,
               url: `http://${hostname}/slack/commands/create-and-deploy-db-stats`,
               usage_hint: '[patch, minor, major]'
+            },
+            {
+              command: '/deploy-metabase',
+              description: 'Déploie metabase',
+              should_escape: false,
+              url: `http://${hostname}/slack/commands/deploy-metabase`,
+              usage_hint: '/deploy-metabase'
             }
           ]
         },

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -11,6 +11,7 @@ const {
   createAndDeployPixBotRelease,
   getAndDeployLastVersion,
   createAndDeployDbStats,
+  deployMetabase,
 } = require('../../../../../run/services/slack/commands');
 const releasesServices = require('../../../../../common/services/releases');
 const githubServices = require('../../../../../common/services/github');
@@ -273,6 +274,7 @@ describe('Services | Slack | Commands', () => {
       // when
       await createAndDeployDbStats(payload);
     });
+
     it('should publish a new release', () => {
       // then
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-stats', 'minor');
@@ -286,6 +288,24 @@ describe('Services | Slack | Commands', () => {
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixRepo);
+    });
+  });
+
+  describe('#deployMetabase', () => {
+    let client;
+
+    beforeEach(async () => {
+      // given
+      client = { deployFromArchive: sinon.spy() };
+      sinon.stub(ScalingoClient, 'getInstance').resolves(client);
+      // when
+      await deployMetabase();
+    });
+
+    it('should deploy the release', () => {
+      // then
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-metabase-production', 'master', 'metabase-deploy', { withEnvSuffix: false });
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-data-metabase-dev', 'master', 'metabase-deploy', { withEnvSuffix: false });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous déployons métabase encore manuellement via scalingo

## :robot: Solution
Avec la multiplication des environnements de metabase et par souci de standardisation, on rajoute une commande slash sur pix-bot

## :rainbow: Remarques
Pas de tag ni de changelog crée.

## :100: Pour tester
1. Sur le pix-bot de test taper /deploy-metabase