### PR TITLE
[TECH] Ajouter une commande de création et de déploiement de Pix Tutos (PIX-5127).

### DIFF
--- a/config.js
+++ b/config.js
@@ -105,6 +105,8 @@ module.exports = (function() {
 
     PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api'],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
+    PIX_TUTOS_REPO_NAME: 'pix-tutos',
+    PIX_TUTOS_APP_NAME: 'pix-tutos',
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -55,6 +55,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixTutosRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixTutosRelease(payload);
+
+    return {
+      'text': _getDeployStartedMessage(payload.text, 'PIX Tutos')
+    };
+  },
+
   getAppStatus(request) {
     const appName = request.pre.payload.text;
     return getAppStatusFromScalingo(appName);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -93,6 +93,15 @@ manifest.registerSlashCommand({
   handler: slackbotController.deployMetabase,
 });
 
+manifest.registerSlashCommand({
+  command: '/deploy-pix-tutos',
+  path: '/slack/commands/create-and-deploy-pix-tutos-release',
+  description: 'Crée une release de Pix Tutos',
+  usage_hint: '[patch, minor, major]',
+  should_escape: false,
+  handler: slackbotController.createAndDeployPixTutosRelease,
+});
+
 manifest.registerShortcut({
   name: 'Déployer une version/MEP',
   type: 'global',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -16,6 +16,8 @@ const {
   PIX_DB_STATS_APPS_NAME,
   PIX_METABASE_REPO_NAME,
   PIX_METABASE_APPS_NAME,
+  PIX_TUTOS_REPO_NAME,
+  PIX_TUTOS_APP_NAME,
 } = require('../../../config');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
@@ -186,5 +188,9 @@ module.exports = {
     await PIX_METABASE_APPS_NAME.map((appName) => {
       return client.deployFromArchive(appName, 'master', repoName, { withEnvSuffix: false });
     });
+  },
+
+  async createAndDeployPixTutosRelease(payload) {
+    await publishAndDeployRelease(PIX_TUTOS_REPO_NAME, [PIX_TUTOS_APP_NAME], payload.text, payload.response_url);
   }
 };

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -97,6 +97,13 @@ describe('Acceptance | Run | Manifest', function() {
               should_escape: false,
               url: `http://${hostname}/slack/commands/deploy-metabase`,
               usage_hint: '/deploy-metabase'
+            },
+            {
+              command: '/deploy-pix-tutos',
+              description: 'Crée une release de Pix Tutos',
+              should_escape: false,
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-tutos-release`,
+              usage_hint: '[patch, minor, major]'
             }
           ]
         },

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -12,6 +12,7 @@ const {
   getAndDeployLastVersion,
   createAndDeployDbStats,
   deployMetabase,
+  createAndDeployPixTutosRelease,
 } = require('../../../../../run/services/slack/commands');
 const releasesServices = require('../../../../../common/services/releases');
 const githubServices = require('../../../../../common/services/github');
@@ -283,6 +284,31 @@ describe('Services | Slack | Commands', () => {
     it('should retrieve the last release tag from GitHub', () => {
       // then
       sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-db-stats');
+    });
+
+    it('should deploy the release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.deployPixRepo);
+    });
+  });
+
+  describe('#createAndDeployPixTutosRelease', () => {
+
+    beforeEach(async () => {
+      // given
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixTutosRelease(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-tutos', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', () => {
+      // then
+      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-tutos');
     });
 
     it('should deploy the release', () => {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous faisons les MEP de Pix Tutos directement via Scalingo, nous avons donc pas de tag associé à une version, ni de changelog. 

## :robot: Solution
- Ajouter une commande gérant la création et le déploiement d'une release de Pix Tutos.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._