### PR TITLE
[FEATURE] Utilise une seule application de production pour pix-db-stats

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,7 +94,7 @@ module.exports = (function() {
     PIX_UI_REPO_NAME: 'pix-ui',
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',
-    PIX_DB_STATS_APPS_NAME: ['pix-db-stats', 'pix-db-stats-datawarehouse', 'pix-db-stats-datawarehouse-ext'],
+    PIX_DB_STATS_APPS_NAME: ['pix-db-stats'],
     PIX_SITE_REPO_NAME: 'pix-site',
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',


### PR DESCRIPTION
## :unicorn: Problème
Lorsque pix-db-stats ne supportait qu'une seule application, nous avions dupliqué les instances pour monitorer d'autres bases de données de production. Les applications ont été unifiées.

## :robot: Solution
Maintenant que nous avons une seule application, on ne veut que déployer sur une seule application.

## :rainbow: Remarques


## :100: Pour tester
