### PR TITLE
[FEATURE] Créer une commande Slack pour donner les rôles par tour lors d'un mob

### DIFF
--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -18,6 +18,10 @@ module.exports = {
     };
   },
 
+  startMobRoles() {
+    return { 'text': 'doudou' };
+  },
+
   createAndDeployPixHotfix(request) {
     const payload = request.pre.payload;
     const branchName = payload.text;

--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -9,6 +9,10 @@ const viewSubmissions = require('../services/slack/view-submissions');
 const postSlackMessage = require('../../common/services/slack/surfaces/messages/post-message');
 const _ = require('lodash');
 
+function _getUserSurname(username) {
+  return _.capitalize(username.split('.')[0]);
+}
+
 module.exports = {
   async getPullRequests(request) {
     const label = request.pre.payload.text;
@@ -26,12 +30,12 @@ module.exports = {
   startMobRoles(request) {
     const payload = request.pre.payload;
     const participants = payload.text.split(' ');
-    const organizer = payload.user_name;
+    const organizer = _getUserSurname(payload.user_name);
     participants.push(organizer);
     const shuffledParticipants = _.shuffle(participants);
 
     const message = shuffledParticipants.map((participant,index) => {
-      const nextParticipant = participants[index + 1] ?? participants[0];
+      const nextParticipant = shuffledParticipants[index + 1] ?? shuffledParticipants[0];
       return  `tour ${index+1} \n pilote : ${participant} \n copilote : ${nextParticipant} \n `; });
 
     return { text: message.join('\n') };

--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -7,6 +7,7 @@ const {
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
 const postSlackMessage = require('../../common/services/slack/surfaces/messages/post-message');
+const _ = require('lodash');
 
 module.exports = {
   async getPullRequests(request) {
@@ -27,11 +28,12 @@ module.exports = {
     const participants = payload.text.split(' ');
     const organizer = payload.user_name;
     participants.push(organizer);
+    const shuffledParticipants = _.shuffle(participants);
 
-    const message = participants.map((participant,index)=>{
-      const nextParticipant = participants[index + 1] ?? participants[0] 
-      return  `tour ${index+1} \n pilote : ${participant} \n copilote : ${nextParticipant} \n ` });
-    
+    const message = shuffledParticipants.map((participant,index) => {
+      const nextParticipant = participants[index + 1] ?? participants[0];
+      return  `tour ${index+1} \n pilote : ${participant} \n copilote : ${nextParticipant} \n `; });
+
     return { text: message.join('\n') };
   },
 

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -38,6 +38,14 @@ manifest.registerSlashCommand({
   handler: slackbotController.createAndDeployPixHotfix,
 });
 
+manifest.registerSlashCommand({
+  command: '/mob',
+  path: '/slack/commands/mob',
+  description: 'Afficher une liste de couples pilote/co-pilote',
+  should_escape: false,
+  handler: slackbotController.startMobRoles,
+});
+
 manifest.registerShortcut({
   name: 'Publier une version/MER',
   type: 'global',

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -41,7 +41,8 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/mob',
   path: '/slack/commands/mob',
-  description: 'Afficher une liste de couples pilote/co-pilote',
+  description: 'Afficher des couples pilote/co-pilote à partir d\'une liste de participants',
+  usage_hint: '[@quelqu\'un @quelqu\'une]',
   should_escape: false,
   handler: slackbotController.startMobRoles,
 });

--- a/test/acceptance/build/manifest_test.js
+++ b/test/acceptance/build/manifest_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | Build | Manifest', function() {
       });
       const hostname = server.info.host + ':0';
       expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql({
+      expect(res.result).to.deep.equal({
         display_information: {
           name: 'Pix Bot Build'
         },
@@ -54,6 +54,13 @@ describe('Acceptance | Build | Manifest', function() {
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-hotfix`,
               description: 'Créer une version patch à partir d\'une branche et la déployer en recette',
               usage_hint: '[branch-name]',
+              should_escape: false
+            },
+            {
+              command: '/mob',
+              url: `http://${hostname}/slack/commands/mob`,
+              description: 'Afficher des couples pilote/co-pilote à partir d\'une liste de participants',
+              usage_hint: '[@quelqu\'un @quelqu\'une]',
               should_escape: false
             }
           ],


### PR DESCRIPTION
## :unicorn: Problème
On souhaite créer un bot pour donner les rôles par tour lors d'un mob.

## :robot: Solution
Créer un bot qui prend en entrée les noms des participants, celui-ci affichera ensuite les tours avec pour chaque tour les personnes assignées aux rôles de pilote et co-pilote.

## :rainbow: Remarques
L'installation d'un bot Slack c'est chouette.

## :100: Pour tester
Installer le bot en local et utiliser la commande `/mob @Pierre @Paul @Jacques`