### PR TITLE
[FEATURE] Être en capacité d'être notifié en cas d'erreur de deploiement

### DIFF
--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -1,0 +1,67 @@
+const dayjs = require('dayjs');
+const slackPostMessageService = require('../../common/services/slack/surfaces/messages/post-message');
+const {
+  Message,
+  Section,
+  Context,
+  Attachment,
+} = require('slack-block-builder');
+const config = require('../../config');
+
+function getSlackMessageAttachments(payload) {
+  const appName = payload.app_name;
+  const scalingoAppUrl = `${config.scalingo.oscFr1Url}/${appName}/`;
+  const appActivityUrl = `${scalingoAppUrl}activity`;
+  const appDeploymentUrl = `${scalingoAppUrl}deploy/${payload.type_data.deployment_uuid}`;
+  const deploymentStatus = payload.type_data.status;
+  const pusher = payload.type_data.pusher;
+  const gitRef = payload.type_data.git_ref;
+  const userName = payload.user?.username;
+  const eventDate = dayjs(payload.type_data.finished_at).format('MMM D');
+  const message = `[${appName}] App deployment error`;
+
+  return {
+    message,
+    attachments: Message()
+      .attachments(
+        Attachment({ color: '#A95800' })
+          .blocks(
+            Section({
+              text: `*<${appActivityUrl}|[${appName}] App deployed>*`,
+            }),
+            Section().fields(
+              `*Deployment failed*\nWith status '${deploymentStatus}'`,
+              `*Deployment logs*\n<${appDeploymentUrl}|${appName}>`
+            ),
+            Section().fields(`*Pusher*\n${pusher}`, `*Git SHA*\n${gitRef}`),
+            Context().elements(`By ${userName} | ${eventDate}`)
+          )
+          .fallback(message)
+      )
+      .buildToObject().attachments,
+  };
+}
+
+module.exports = {
+  async deployEndpoint(request) {
+    console.log('Scalingo request received');
+    if (request.payload.type_data?.status !== 'build-error') {
+      return 'Slack error notification not sent';
+    }
+
+    console.log(`Failed deployement on the ${request.payload.app_name} app`);
+
+    const { message, attachments } = getSlackMessageAttachments(
+      request.payload
+    );
+
+    await slackPostMessageService.postMessage(
+      message,
+      JSON.stringify(attachments)
+    );
+
+    console.log('Slack error notification sent');
+
+    return 'Slack error notification sent';
+  },
+};

--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -2,7 +2,7 @@ const github = require('../../common/services/github');
 const { environments, deploy, publish } = require('../../common/services/releases');
 const shortcuts = require('../services/slack/shortcuts');
 const viewSubmissions = require('../services/slack/view-submissions');
-const postSlackMessage = require('../../common/services/slack/surfaces/messages/post-message');
+const postMessageService = require('../../common/services/slack/surfaces/messages/post-message');
 const sendSlackBlockMessage = require('../../common/services/slack/surfaces/messages/block-message');
 const _ = require('lodash');
 
@@ -82,7 +82,7 @@ module.exports = {
   },
 
   _interruptRelease() {
-    postSlackMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
+    postMessageService.postSlackMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
     return {
       response_action: 'clear',
     };

--- a/build/routes/scalingo.js
+++ b/build/routes/scalingo.js
@@ -1,0 +1,9 @@
+const scalingoController = require('../../build/controllers/scalingo');
+
+module.exports = [
+  {
+    method: 'POST',
+    path: '/build/scalingo/deploy-endpoint',
+    handler: scalingoController.deployEndpoint,
+  },
+];

--- a/common/services/slack/surfaces/messages/post-message.js
+++ b/common/services/slack/surfaces/messages/post-message.js
@@ -1,18 +1,28 @@
 const axios = require('axios');
 const config = require('../../../../../config');
 
-module.exports = (message) => {
-  const options = {
-    method: 'POST',
-    url: 'https://slack.com/api/chat.postMessage',
-    headers: {
-      'content-type': 'application/json',
-      'authorization': `Bearer ${config.slack.botToken}`
-    },
-    data: {
-      'channel': '#tech-releases',
-      'text': message,
+module.exports = {
+  async postMessage(message, attachments) {
+    const options = {
+      method: 'POST',
+      url: 'https://slack.com/api/chat.postMessage',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${config.slack.botToken}`,
+      },
+      data: {
+        channel: '#tech-releases',
+        message: message,
+        attachments: attachments,
+      },
+    };
+
+    const response = await axios(options);
+    if (!response.data.ok) {
+      console.error(response.data);
+      throw new Error('Slack error received');
     }
-  };
-  return axios(options);
+
+    return response;
+  },
 };

--- a/config.js
+++ b/config.js
@@ -30,6 +30,7 @@ module.exports = (function() {
     },
 
     scalingo: {
+      oscFr1Url: 'https://dashboard.scalingo.com/apps/osc-fr1',
       reviewApps: {
         token: process.env.SCALINGO_TOKEN_REVIEW_APPS,
         apiUrl: process.env.SCALINGO_API_URL_REVIEW_APPS || 'https://api.osc-fr1.scalingo.com',

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -1,0 +1,119 @@
+const { expect, sinon } = require('../../test-helper');
+const slackPostMessageService = require('../../../common/services/slack/surfaces/messages/post-message');
+const server = require('../../../server');
+const { describe } = require('mocha');
+
+describe('Integration | Build | Scalingo', function () {
+  beforeEach(function () {
+    sinon.stub(console, 'log');
+  });
+
+  describe('POST /build/scalingo/deploy-endpoint', function () {
+    describe('when scalingo build status is "build-error" ', () => {
+      it('should send slack message and return 200', async () => {
+        // Given
+        const body = {
+          app_name: 'pix-github-actions-test',
+          user: {
+            username: 'pix-dev',
+          },
+          type_data: {
+            pusher: 'pix-dev',
+            git_ref: '23f2471edd07284945abf0f303c99c6c5582986c',
+            status: 'build-error',
+            finished_at: '2022-07-22T13:17:01.873+00:00',
+            deployment_uuid: 'c6535ea5-ef4c-46af-aa1d-c71d214e17a9',
+          },
+        };
+        sinon.stub(slackPostMessageService, 'postMessage').resolves('ok');
+
+        // When
+        const res = await server.inject({
+          method: 'POST',
+          url: '/build/scalingo/deploy-endpoint',
+          payload: body,
+        });
+
+        // Then
+        const expectedPayload = [
+          {
+            color: '#A95800',
+            blocks: [
+              {
+                text: {
+                  type: 'mrkdwn',
+                  text: '*<https://dashboard.scalingo.com/apps/osc-fr1/pix-github-actions-test/activity|[pix-github-actions-test] App deployed>*',
+                },
+                type: 'section',
+              },
+              {
+                fields: [
+                  {
+                    type: 'mrkdwn',
+                    text: '*Deployment failed*\nWith status \'build-error\'',
+                  },
+                  {
+                    type: 'mrkdwn',
+                    text: '*Deployment logs*\n<https://dashboard.scalingo.com/apps/osc-fr1/pix-github-actions-test/deploy/c6535ea5-ef4c-46af-aa1d-c71d214e17a9|pix-github-actions-test>',
+                  },
+                ],
+                type: 'section',
+              },
+              {
+                fields: [
+                  { type: 'mrkdwn', text: '*Pusher*\npix-dev' },
+                  {
+                    type: 'mrkdwn',
+                    text: '*Git SHA*\n23f2471edd07284945abf0f303c99c6c5582986c',
+                  },
+                ],
+                type: 'section',
+              },
+              {
+                elements: [{ type: 'mrkdwn', text: 'By pix-dev | Jul 22' }],
+                type: 'context',
+              },
+            ],
+            fallback: '[pix-github-actions-test] App deployment error',
+          },
+        ];
+        expect(slackPostMessageService.postMessage).to.have.been.calledWith(
+          '[pix-github-actions-test] App deployment error',
+          JSON.stringify(expectedPayload)
+        );
+        expect(res.statusCode).to.equal(200);
+      });
+    });
+
+    describe('when scalingo build status is not "build-error" ', () => {
+      it('should not send slack message and return 200', async () => {
+        // Given
+        const body = {
+          app_name: 'pix-github-actions-test',
+          user: {
+            username: 'pix-dev',
+          },
+          type_data: {
+            pusher: 'pix-dev',
+            git_ref: '23f2471edd07284945abf0f303c99c6c5582986c',
+            status: 'success',
+            finished_at: '2022-07-22T13:17:01.873+00:00',
+            deployment_uuid: 'c6535ea5-ef4c-46af-aa1d-c71d214e17a9',
+          },
+        };
+        sinon.stub(slackPostMessageService, 'postMessage').resolves('ok');
+
+        // When
+        const res = await server.inject({
+          method: 'POST',
+          url: '/build/scalingo/deploy-endpoint',
+          payload: body,
+        });
+
+        // Then
+        expect(slackPostMessageService.postMessage).not.to.have.been.called;
+        expect(res.statusCode).to.equal(200);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On est notifié lors d'une erreur de déploiement sur la recette et la production mais pas sur l'intégration.

## :robot: Solution
Créer un endpoint pour recevoir les webhooks Scalingo et envoyer un message Slack si une erreur de déploiement survient.

## :rainbow: Remarques
La solution proposée devrait être générique pour n'importe quel app Scalingo `osc-fr1`. Donc on peut l'ajouter sur l'intégration mais aussi sur n'importe quelle autre appli.

## :100: Pour tester
Dans les notifiers d'une app de test, essayer d'ajouter l'URL de cette RA 
> `https://pix-bot-review-pr135.osc-fr1.scalingo.io/build/scalingo/deploy-endpoint`

Exemple sur [pix-github-actions-test](https://dashboard.scalingo.com/apps/osc-fr1/pix-github-actions-test/settings/notifiers/no-90a7d2d2-1301-403f-81d4-fe005d79b970/edit).

Résultats attendus :
- Les déploiements en succès ne doivent rien faire.
- Les déploiements en erreur doivent envoyer un message sur [le Slack de test](https://app.slack.com/client/T016LK24U3F/C02ALSW5QJU).