### PR TITLE
[BUGFIX] Utiliser les commits entre les 2 releases pour afficher une notification de changement de config lors du déploiement

### DIFF
--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -6,7 +6,7 @@ const postSlackMessage = require('../../../common/services/slack/surfaces/messag
 module.exports = {
   async submitReleaseTagSelection(payload) {
     const releaseTag = payload.view.state.values['deploy-release-tag']['release-tag-value'].value;
-    const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
+    const hasConfigFileChanged = await githubService.hasConfigFileChangedInLatestRelease();
     return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
   },
 

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -3,6 +3,7 @@ const server = require('../../../server');
 
 describe('Acceptance | Run | Slack', function() {
   describe('POST /run/slack/interactive-endpoint', function() {
+
     it('responds with 204', async () => {
       const body = {
         type: 'view_closed'

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -51,48 +51,86 @@ function createSlackWebhookSignatureHeaders(body) {
 function nockGithubWithNoConfigChanges() {
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/tags')
-    .reply(200, [{
-      'commit': {
-        'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+    .twice()
+    .reply(200, [
+      {
+        'commit': {
+          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+        },
       },
-    }]);
+      {
+        'commit': {
+          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/456',
+        },
+      }
+    ]);
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/1234')
     .reply(200, {
       commit: {
         'committer': {
-          'date': '2011-04-14'
+          'date': '2021-04-14T12:40:50.326Z'
         },
       }
     });
 
   nock('https://api.github.com')
-    .get('/repos/github-owner/github-repository/commits?since=2011-04-14&path=api%2Flib%2Fconfig.js')
+    .get('/repos/github-owner/github-repository/commits/456')
+    .reply(200, {
+      commit: {
+        'committer': {
+          'date': '2021-04-10T12:40:50.326Z'
+        },
+      }
+    });
+
+  nock('https://api.github.com')
+    .filteringPath(/since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g, 'since=XXXX&until=XXXX')
+    .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, []);
 }
 
 function nockGithubWithConfigChanges() {
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/tags')
-    .reply(200, [{
-      'commit': {
-        'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+    .twice()
+    .reply(200, [
+      {
+        'commit': {
+          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+        },
       },
-    }]);
+      {
+        'commit': {
+          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/456',
+        },
+      }
+    ]);
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/1234')
     .reply(200, {
       commit: {
         'committer': {
-          'date': '2011-04-14'
+          'date': '2021-04-14T12:40:50.326Z'
         },
       }
     });
 
   nock('https://api.github.com')
-    .get('/repos/github-owner/github-repository/commits?since=2011-04-14&path=api%2Flib%2Fconfig.js')
+    .get('/repos/github-owner/github-repository/commits/456')
+    .reply(200, {
+      commit: {
+        'committer': {
+          'date': '2021-04-10T12:40:50.326Z'
+        },
+      }
+    });
+
+  nock('https://api.github.com')
+    .filteringPath(/since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g, 'since=XXXX&until=XXXX')
+    .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, [{}]);
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lors de la MEP d'une release un message de modification du fichier de config peut-être affichée si un commit a modifié le fichier entre la release et le dernier commit sur dev.

Cependant, une MEP correspond à la mise en production d'une release créé pendant la MER. 

## :robot: Solution
- Utiliser les bons commits pour déterminer sur un changement sur le fichier config a été fait.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI 