### PR TITLE
[TECH] Mise en place Prettier et utilise les règles standard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,26 +6,8 @@ module.exports = {
     'node': true,
     'mocha': true,
   },
-  'extends': 'eslint:recommended',
+  'extends': ['eslint:recommended', 'plugin:mocha/recommended', 'plugin:prettier/recommended'],
   'parserOptions': {
     'ecmaVersion': 11
   },
-  'rules': {
-    'indent': [
-      'error',
-      2
-    ],
-    'linebreak-style': [
-      'error',
-      'unix'
-    ],
-    'quotes': [
-      'error',
-      'single'
-    ],
-    'semi': [
-      'error',
-      'always'
-    ]
-  }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,13 @@
 module.exports = {
   root: true,
-  'env': {
-    'commonjs': true,
-    'es2020': true,
-    'node': true,
-    'mocha': true,
+  env: {
+    commonjs: true,
+    es2020: true,
+    node: true,
+    mocha: true,
   },
-  'extends': ['eslint:recommended', 'plugin:mocha/recommended', 'plugin:prettier/recommended'],
-  'parserOptions': {
-    'ecmaVersion': 11
+  extends: ['eslint:recommended', 'plugin:mocha/recommended', 'plugin:prettier/recommended'],
+  parserOptions: {
+    ecmaVersion: 11,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,4 +10,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 11,
   },
+  rules: {
+    'mocha/no-setup-in-describe': 'off',
+  },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": true
+}

--- a/bin/www
+++ b/bin/www
@@ -11,7 +11,13 @@ const init = async () => {
   await ecoModeService.start();
 
   createCronJob('SendInBlue Report', sendInBlueReport.getReport, config.thirdServicesUsageReport.schedule);
-  createCronJob('Deploy Pix site', () => { deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS); }, config.pixSiteDeploy.schedule);
+  createCronJob(
+    'Deploy Pix site',
+    () => {
+      deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS);
+    },
+    config.pixSiteDeploy.schedule
+  );
 
   await server.start();
   console.log('Server running on %s', server.info.uri);

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -6,7 +6,7 @@ const repositoryToScalingoAppsReview = {
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
-  'pix-tutos':['pix-tutos-review'],
+  'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],
   pix: ['pix-front-review', 'pix-api-review'],
 };
@@ -36,5 +36,5 @@ module.exports = {
     } else {
       return `Ignoring ${eventName} event`;
     }
-  }
+  },
 };

--- a/build/controllers/manifest.js
+++ b/build/controllers/manifest.js
@@ -7,12 +7,12 @@ module.exports = {
     const url = `${protocol}://${host}`;
     return {
       display_information: {
-        name: manifest.name
+        name: manifest.name,
       },
       features: {
         bot_user: {
           display_name: manifest.name,
-          always_online: false
+          always_online: false,
         },
         shortcuts: manifest.shortcuts,
         slash_commands: manifest.slashCommands.map(({ command, path, description, usage_hint, should_escape }) => {
@@ -23,27 +23,24 @@ module.exports = {
             usage_hint,
             should_escape,
           };
-        })
+        }),
       },
       oauth_config: {
         scopes: {
-          bot: [
-            'commands',
-            'incoming-webhook',
-            'workflow.steps:execute'
-          ]
-        }
+          bot: ['commands', 'incoming-webhook', 'workflow.steps:execute'],
+        },
       },
       settings: {
-        interactivity: manifest.interactivity ? {
-          is_enabled: true,
-          request_url: `${url}${manifest.interactivity.path}`
-        } : null,
+        interactivity: manifest.interactivity
+          ? {
+              is_enabled: true,
+              request_url: `${url}${manifest.interactivity.path}`,
+            }
+          : null,
         org_deploy_enabled: false,
         socket_mode_enabled: false,
-        token_rotation_enabled: false
-      }
+        token_rotation_enabled: false,
+      },
     };
   },
 };
-

--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -1,11 +1,6 @@
 const dayjs = require('dayjs');
 const slackPostMessageService = require('../../common/services/slack/surfaces/messages/post-message');
-const {
-  Message,
-  Section,
-  Context,
-  Attachment,
-} = require('slack-block-builder');
+const { Message, Section, Context, Attachment } = require('slack-block-builder');
 const config = require('../../config');
 
 function getSlackMessageAttachments(payload) {
@@ -51,14 +46,9 @@ module.exports = {
 
     console.log(`Failed deployement on the ${request.payload.app_name} app`);
 
-    const { message, attachments } = getSlackMessageAttachments(
-      request.payload
-    );
+    const { message, attachments } = getSlackMessageAttachments(request.payload);
 
-    await slackPostMessageService.postMessage(
-      message,
-      JSON.stringify(attachments)
-    );
+    await slackPostMessageService.postMessage(message, JSON.stringify(attachments));
 
     console.log('Slack error notification sent');
 

--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -57,27 +57,27 @@ module.exports = {
     const releaseBranch = 'dev';
 
     switch (interactionType) {
-    case 'shortcut':
-      if (payload.callback_id === 'publish-release') {
-        if (!github.isBuildStatusOK({ branchName: releaseBranch })) {
-          return this._interruptRelease();
+      case 'shortcut':
+        if (payload.callback_id === 'publish-release') {
+          if (!github.isBuildStatusOK({ branchName: releaseBranch })) {
+            return this._interruptRelease();
+          }
+          shortcuts.openViewPublishReleaseTypeSelection(payload);
         }
-        shortcuts.openViewPublishReleaseTypeSelection(payload);
-      }
-      return null;
-    case 'view_submission':
-      if (payload.view.callback_id === shortcuts.openViewPublishReleaseTypeSelectionCallbackId) {
-        return viewSubmissions.submitReleaseTypeSelection(payload);
-      }
-      if (payload.view.callback_id === viewSubmissions.submitReleaseTypeSelectionCallbackId) {
-        return viewSubmissions.submitReleasePublicationConfirmation(payload);
-      }
-      return null;
-    case 'view_closed':
-    case 'block_actions':
-    default:
-      console.log('This kind of interaction is not yet supported by Pix Bot.');
-      return null;
+        return null;
+      case 'view_submission':
+        if (payload.view.callback_id === shortcuts.openViewPublishReleaseTypeSelectionCallbackId) {
+          return viewSubmissions.submitReleaseTypeSelection(payload);
+        }
+        if (payload.view.callback_id === viewSubmissions.submitReleaseTypeSelectionCallbackId) {
+          return viewSubmissions.submitReleasePublicationConfirmation(payload);
+        }
+        return null;
+      case 'view_closed':
+      case 'block_actions':
+      default:
+        console.log('This kind of interaction is not yet supported by Pix Bot.');
+        return null;
     }
   },
 

--- a/build/manifest.js
+++ b/build/manifest.js
@@ -7,7 +7,7 @@ const manifest = new Manifest('Pix Bot Build');
 manifest.registerSlashCommand({
   command: '/pr-pix',
   path: '/slack/commands/pull-requests',
-  description: 'Afficher les PR à review de l\'application Pix',
+  description: "Afficher les PR à review de l'application Pix",
   usage_hint: '[cross-team|team-acces|team-evaluation|team-certif|team-prescription]',
   should_escape: false,
   handler: slackbotController.getPullRequests,
@@ -16,7 +16,7 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/tips-a11y',
   path: '/slack/commands/accessibility-tip',
-  description: 'Je veux un tips sur l\'accessibilité !',
+  description: "Je veux un tips sur l'accessibilité !",
   should_escape: false,
   handler: googleSheet.getA11YTip,
 });
@@ -32,7 +32,7 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/hotfix',
   path: '/slack/commands/create-and-deploy-pix-hotfix',
-  description: 'Créer une version patch à partir d\'une branche et la déployer en recette',
+  description: "Créer une version patch à partir d'une branche et la déployer en recette",
   usage_hint: '[branch-name]',
   should_escape: false,
   handler: slackbotController.createAndDeployPixHotfix,
@@ -41,8 +41,8 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/mob',
   path: '/slack/commands/mob',
-  description: 'Afficher des couples pilote/co-pilote à partir d\'une liste de participants',
-  usage_hint: '[@quelqu\'un @quelqu\'une]',
+  description: "Afficher des couples pilote/co-pilote à partir d'une liste de participants",
+  usage_hint: "[@quelqu'un @quelqu'une]",
   should_escape: false,
   handler: slackbotController.startMobRoles,
 });
@@ -51,7 +51,7 @@ manifest.registerShortcut({
   name: 'Publier une version/MER',
   type: 'global',
   callback_id: 'publish-release',
-  description: 'Publie une nouvelle version et la déploie sur l\'environnement de recette'
+  description: "Publie une nouvelle version et la déploie sur l'environnement de recette",
 });
 
 manifest.addInteractivity({

--- a/build/routes/github.js
+++ b/build/routes/github.js
@@ -6,6 +6,6 @@ module.exports = [
     method: 'POST',
     path: '/github/webhook',
     handler: githubController.processWebhook,
-    config: githubConfig
+    config: githubConfig,
   },
 ];

--- a/build/services/eco-mode-service.js
+++ b/build/services/eco-mode-service.js
@@ -18,8 +18,8 @@ module.exports = {
       stopCronTime,
       restartCronTime,
       timeZone,
-      ignoredReviewApps
+      ignoredReviewApps,
     });
     await reviewAppManager.startEcoMode();
-  }
+  },
 };

--- a/build/services/google-sheet.js
+++ b/build/services/google-sheet.js
@@ -8,65 +8,65 @@ function getGoogleSheetAPIURL() {
   return `${URL_SPREADSHEET_API}${settings.googleSheet.idA11Y}/values/${SPREADSHEET_VALUES}?key=${settings.googleSheet.key}`;
 }
 
-async function getDataFromGoogleSheet () {
+async function getDataFromGoogleSheet() {
   const url = getGoogleSheetAPIURL();
-  return axios.get(url)
-    .then(response => response.data.values)
-    .catch(error => console.log(error));
+  return axios
+    .get(url)
+    .then((response) => response.data.values)
+    .catch((error) => console.log(error));
 }
 
 function createResponseForSlack(tip) {
   const resp = {
     response_type: 'in_channel',
-    'blocks': [
+    blocks: [
       {
-        'type': 'divider'
+        type: 'divider',
       },
       {
-        'type': 'section',
-        'text': {
-          'type': 'mrkdwn',
-          'text': ':a11y: Tip A11Y :a11y:'
-        }
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ':a11y: Tip A11Y :a11y:',
+        },
       },
       {
-        'type': 'divider'
+        type: 'divider',
       },
       {
-        'type': 'section',
-        'text': {
-          'type': 'mrkdwn',
-          'text': `:book: *${tip['Titre'].toUpperCase()}* :book: \n _${tip['Sujet']}_ `
-        }
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `:book: *${tip['Titre'].toUpperCase()}* :book: \n _${tip['Sujet']}_ `,
+        },
       },
       {
-        'type': 'divider'
+        type: 'divider',
       },
       {
-        'type': 'section',
-        'text': {
-          'type': 'mrkdwn',
-          'text': `${tip['Message']} \n :link: : ${tip['Lien']} \n :pix_logo: : ${tip['Tips Pix'] || '-'}`
-        }
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `${tip['Message']} \n :link: : ${tip['Lien']} \n :pix_logo: : ${tip['Tips Pix'] || '-'}`,
+        },
       },
       {
-        'type': 'divider'
-      }
-    ]
+        type: 'divider',
+      },
+    ],
   };
   return resp;
 }
 
 function getOneRandomTip(tipsFromGoogleSheet) {
   const titles = tipsFromGoogleSheet.shift();
-  const randomTip = tipsFromGoogleSheet[Math.floor(Math.random() * (tipsFromGoogleSheet.length))];
+  const randomTip = tipsFromGoogleSheet[Math.floor(Math.random() * tipsFromGoogleSheet.length)];
   return _.zipObject(titles, randomTip);
 }
 module.exports = {
-
   async getA11YTip() {
     const tipsFromGoogleSheet = await getDataFromGoogleSheet();
     const tip = getOneRandomTip(tipsFromGoogleSheet);
     return createResponseForSlack(tip);
-  }
+  },
 };

--- a/build/services/slack/shortcuts.js
+++ b/build/services/slack/shortcuts.js
@@ -3,7 +3,6 @@ const publishReleaseTypeSelectionModal = require('./surfaces/modals/publish-rele
 const config = require('../../../config');
 
 module.exports = {
-
   openViewPublishReleaseTypeSelectionCallbackId: publishReleaseTypeSelectionModal.callbackId,
   openViewPublishReleaseTypeSelection(payload) {
     const options = {
@@ -11,9 +10,9 @@ module.exports = {
       url: 'https://slack.com/api/views.open',
       headers: {
         'content-type': 'application/json',
-        'authorization': `Bearer ${config.slack.botToken}`
+        authorization: `Bearer ${config.slack.botToken}`,
       },
-      data: publishReleaseTypeSelectionModal(payload.trigger_id)
+      data: publishReleaseTypeSelectionModal(payload.trigger_id),
     };
     return axios(options);
   },

--- a/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js
@@ -8,21 +8,25 @@ function modal(releaseType, hasConfigFileChanged) {
     callbackId,
     privateMetaData: releaseType,
     submit: '🚀 Go !',
-    close: 'Annuler'
+    close: 'Annuler',
   }).blocks([
-    ...hasConfigFileChanged ? [Blocks.Section({
-      text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
-    })] : [],
+    ...(hasConfigFileChanged
+      ? [
+          Blocks.Section({
+            text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.",
+          }),
+        ]
+      : []),
     Blocks.Section({
-      text: `Vous vous apprêtez à publier une version *${releaseType}* et la déployer en recette. Êtes-vous sûr de vous ?`
-    })
+      text: `Vous vous apprêtez à publier une version *${releaseType}* et la déployer en recette. Êtes-vous sûr de vous ?`,
+    }),
   ]);
 }
 
 module.exports = (releaseType, hasConfigFileChanged) => {
   return {
     response_action: 'push',
-    view: modal(releaseType, hasConfigFileChanged).buildToObject()
+    view: modal(releaseType, hasConfigFileChanged).buildToObject(),
   };
 };
 

--- a/build/services/slack/surfaces/modals/publish-release/release-type-selection.js
+++ b/build/services/slack/surfaces/modals/publish-release/release-type-selection.js
@@ -7,10 +7,10 @@ function modal() {
     title: 'Publier une release',
     callbackId,
     submit: 'Publier',
-    close: 'Annuler'
+    close: 'Annuler',
   }).blocks([
     Blocks.Section({
-      text: 'Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d\'architecture'
+      text: "Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d'architecture",
     }),
     Blocks.Divider(),
     Blocks.Input({
@@ -20,31 +20,35 @@ function modal() {
       Elements.StaticSelect({
         actionId: 'release-type-option',
         placeholder: 'Selectionnez un élément',
-      }).options([
-        Bits.Option({
-          text: 'Minor',
-          value: 'minor'
-        }),
-        Bits.Option({
-          text: 'Patch',
-          value: 'patch'
-        }),
-        Bits.Option({
-          text: 'Major',
-          value: 'major'
-        })
-      ]).initialOption(Bits.Option({
-        text: 'Minor',
-        value: 'minor'
-      }))
-    )
+      })
+        .options([
+          Bits.Option({
+            text: 'Minor',
+            value: 'minor',
+          }),
+          Bits.Option({
+            text: 'Patch',
+            value: 'patch',
+          }),
+          Bits.Option({
+            text: 'Major',
+            value: 'major',
+          }),
+        ])
+        .initialOption(
+          Bits.Option({
+            text: 'Minor',
+            value: 'minor',
+          })
+        )
+    ),
   ]);
 }
 
 module.exports = (triggerId) => {
   return {
     trigger_id: triggerId,
-    view: modal().buildToObject()
+    view: modal().buildToObject(),
   };
 };
 

--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -3,7 +3,6 @@ const { environments, deploy, publish } = require('../../../common/services/rele
 const githubService = require('../../../common/services/github');
 
 module.exports = {
-
   async submitReleaseTypeSelection(payload) {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
     const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
@@ -23,7 +22,7 @@ module.exports = {
 
     _publishAndDeploy({ releaseType, environment: environments.recette });
     return {
-      'response_action': 'clear'
+      response_action: 'clear',
     };
   },
 };

--- a/common/config.js
+++ b/common/config.js
@@ -5,19 +5,15 @@ module.exports = {
   slackConfig: {
     payload: {
       allow: ['application/json', 'application/x-www-form-urlencoded'],
-      parse: false
+      parse: false,
     },
-    pre: [
-      { method: verifySlackSignatureAndParseBody, assign: 'payload' }
-    ]
+    pre: [{ method: verifySlackSignatureAndParseBody, assign: 'payload' }],
   },
 
   githubConfig: {
     payload: {
       allow: ['application/json'],
     },
-    pre: [
-      { method: verifyGithubSignature }
-    ]
-  }
+    pre: [{ method: verifyGithubSignature }],
+  },
 };

--- a/common/controllers/index.js
+++ b/common/controllers/index.js
@@ -1,14 +1,23 @@
 const { name, version, description } = require('../../package.json');
-const { sampleView: releaseTypeSelection } = require('../../build/services/slack/surfaces/modals/publish-release/release-type-selection');
-const { sampleView: releaseTagSelection } = require('../../run/services/slack/surfaces/modals/deploy-release/release-tag-selection');
-const { sampleView: releaseDeploymentConfirmation } = require('../../run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation');
-const { sampleView: releasePublicationConfirmation } = require('../../build/services/slack/surfaces/modals/publish-release/release-publication-confirmation');
+const {
+  sampleView: releaseTypeSelection,
+} = require('../../build/services/slack/surfaces/modals/publish-release/release-type-selection');
+const {
+  sampleView: releaseTagSelection,
+} = require('../../run/services/slack/surfaces/modals/deploy-release/release-tag-selection');
+const {
+  sampleView: releaseDeploymentConfirmation,
+} = require('../../run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation');
+const {
+  sampleView: releasePublicationConfirmation,
+} = require('../../build/services/slack/surfaces/modals/publish-release/release-publication-confirmation');
 
 module.exports = {
-
   getApiInfo() {
     return {
-      name, version, description
+      name,
+      version,
+      description,
     };
   },
 
@@ -19,9 +28,10 @@ module.exports = {
       { name: 'release-deployment-confirmation', view: releaseDeploymentConfirmation() },
       { name: 'release-publication-confirmation', view: releasePublicationConfirmation() },
     ];
-    return views.map(({ name, view }) => {
-      return `<a href="${view.getPreviewUrl()}">View ${name}</a>`;
-    }).join('<br>');
-  }
-
+    return views
+      .map(({ name, view }) => {
+        return `<a href="${view.getPreviewUrl()}">View ${name}</a>`;
+      })
+      .join('<br>');
+  },
 };

--- a/common/models/Manifest.js
+++ b/common/models/Manifest.js
@@ -26,11 +26,15 @@ class Manifest {
           handler,
         };
       }),
-      ...(this.interactivity ? [{
-        method: 'POST',
-        path: this.interactivity.path,
-        handler: this.interactivity.handler
-      }] : [])
+      ...(this.interactivity
+        ? [
+            {
+              method: 'POST',
+              path: this.interactivity.path,
+              handler: this.interactivity.handler,
+            },
+          ]
+        : []),
     ];
   }
 }

--- a/common/models/PartialChangeLogGenerator.js
+++ b/common/models/PartialChangeLogGenerator.js
@@ -1,5 +1,4 @@
 class PartialChangeLogGenerator {
-
   constructor({ headOfChangelogTitle, pullRequestGroups }) {
     this.headOfChangelogTitle = headOfChangelogTitle;
     this.pullRequestGroups = pullRequestGroups;
@@ -12,11 +11,11 @@ class PartialChangeLogGenerator {
   }
 
   getLinesToDisplay() {
-    const linesToDisplay = this.pullRequestGroups.map((pullRequestGroup) => pullRequestGroup.getLinesToDisplay()).flat();
+    const linesToDisplay = this.pullRequestGroups
+      .map((pullRequestGroup) => pullRequestGroup.getLinesToDisplay())
+      .flat();
 
-    return linesToDisplay.length
-      ? [this.headOfChangelogTitle, ''].concat(linesToDisplay).flat()
-      : [];
+    return linesToDisplay.length ? [this.headOfChangelogTitle, ''].concat(linesToDisplay).flat() : [];
   }
 }
 

--- a/common/models/PullRequest.js
+++ b/common/models/PullRequest.js
@@ -1,7 +1,6 @@
 const { Tags } = require('./Tags');
 
 class PullRequest {
-
   constructor({ html_url, number, title }) {
     this.htmlUrl = html_url;
     this.number = number;

--- a/common/models/PullRequestGroup.js
+++ b/common/models/PullRequestGroup.js
@@ -1,8 +1,7 @@
 const { Tags } = require('./Tags');
 
 class PullRequestGroup {
-
-  constructor({ tagToGrab, groupTitle}) {
+  constructor({ tagToGrab, groupTitle }) {
     if (!Tags.isValidTag(tagToGrab)) {
       throw new TypeError('A valid Tag must be used');
     }

--- a/common/models/PullRequestGroupFactory.js
+++ b/common/models/PullRequestGroupFactory.js
@@ -2,7 +2,6 @@ const { Tag } = require('./Tags');
 const PullRequestGroup = require('./PullRequestGroup');
 
 class PullRequestGroupFactory {
-
   static build() {
     return [
       new PullRequestGroup({

--- a/common/models/Tags.js
+++ b/common/models/Tags.js
@@ -7,11 +7,8 @@ const Tag = Object.freeze({
 });
 
 class Tags {
-
   static getTagByTitle(title) {
-    const typeOfPullRequest = title
-      .substring(1, title.indexOf(']'))
-      .replace(/ /g, '_');
+    const typeOfPullRequest = title.substring(1, title.indexOf(']')).replace(/ /g, '_');
 
     return Tag[typeOfPullRequest] || Tag.OTHERS;
   }

--- a/common/routes/index.js
+++ b/common/routes/index.js
@@ -4,11 +4,11 @@ module.exports = [
   {
     method: 'GET',
     path: '/',
-    handler: indexController.getApiInfo
+    handler: indexController.getApiInfo,
   },
   {
     method: 'GET',
     path: '/slackviews',
-    handler: indexController.getSlackViews
-  }
+    handler: indexController.getSlackViews,
+  },
 ];

--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -55,9 +55,7 @@ function getNewChangeLogLines({ headOfChangelogTitle, pullRequests }) {
     pullRequestGroups: PullRequestGroupFactory.build(),
   });
 
-  partialChangeLogGenerator.grabPullRequestsByTag(
-    pullRequests.map((item) => new PullRequest(item))
-  );
+  partialChangeLogGenerator.grabPullRequestsByTag(pullRequests.map((item) => new PullRequest(item)));
   return partialChangeLogGenerator.getLinesToDisplay();
 }
 

--- a/common/services/cron-job.js
+++ b/common/services/cron-job.js
@@ -15,5 +15,5 @@ function createCronJob(jobName, jobFunction, jobSchedule) {
 }
 
 module.exports = {
-  createCronJob
+  createCronJob,
 };

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -8,10 +8,9 @@ const ScalingoClient = require('./scalingo-client');
 const RELEASE_PIX_SCRIPT = 'release-pix-repo.sh';
 
 module.exports = {
-
   environments: {
     recette: 'recette',
-    production: 'production'
+    production: 'production',
   },
 
   async publish(releaseType, branchName) {
@@ -20,7 +19,12 @@ module.exports = {
       const sanitizedReleaseType = _sanitizedArgument(releaseType);
       const sanitizedBranchName = _sanitizedArgument(branchName);
       const repositoryURL = `https://${config.github.token}@github.com/${config.github.owner}/${config.github.repository}.git`;
-      const newPackageVersion = await _runScriptWithArgument(scriptFileName, sanitizedReleaseType, repositoryURL, sanitizedBranchName);
+      const newPackageVersion = await _runScriptWithArgument(
+        scriptFileName,
+        sanitizedReleaseType,
+        repositoryURL,
+        sanitizedBranchName
+      );
       return newPackageVersion;
     } catch (err) {
       console.error(err);
@@ -34,9 +38,11 @@ module.exports = {
 
     const client = await ScalingoClient.getInstance(sanitizedEnvironment);
 
-    const results = await Promise.all(config.PIX_APPS.map(pixApp => {
-      return client.deployFromArchive(`pix-${pixApp}`, sanitizedReleaseTag);
-    }));
+    const results = await Promise.all(
+      config.PIX_APPS.map((pixApp) => {
+        return client.deployFromArchive(`pix-${pixApp}`, sanitizedReleaseTag);
+      })
+    );
 
     return results;
   },
@@ -67,9 +73,9 @@ module.exports = {
   _runScriptWithArgument,
 };
 
-async function _runScriptWithArgument (scriptFileName, ...args) {
+async function _runScriptWithArgument(scriptFileName, ...args) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
-  const {stdout, stderr} = await exec(`${scriptsDirectory}/${scriptFileName} ${args.join(' ')}`);
+  const { stdout, stderr } = await exec(`${scriptsDirectory}/${scriptFileName} ${args.join(' ')}`);
   console.log(`stdout: ${stdout}`);
   const lastLine = stdout.split('\n').slice(-2, -1).pop();
   console.error(`stderr: ${stderr}`);
@@ -77,5 +83,5 @@ async function _runScriptWithArgument (scriptFileName, ...args) {
 }
 
 function _sanitizedArgument(param) {
-  return param? param.trim().toLowerCase(): null;
+  return param ? param.trim().toLowerCase() : null;
 }

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -29,7 +29,7 @@ class ScalingoClient {
     try {
       await this.client.Deployments.create(scalingoApp, {
         git_ref: releaseTag,
-        source_url: `https://${config.github.token}@github.com/${config.github.owner}/${repository}/archive/${releaseTag}.tar.gz`
+        source_url: `https://${config.github.token}@github.com/${config.github.owner}/${repository}/archive/${releaseTag}.tar.gz`,
       });
     } catch (e) {
       console.error(e);
@@ -53,7 +53,7 @@ class ScalingoClient {
 
   async _getAllAppsInfo(environment) {
     const apps = ['api', 'app', 'orga', 'certif', 'admin'];
-    const promises = apps.map(appName => this._getSingleAppInfo(appName, environment));
+    const promises = apps.map((appName) => this._getSingleAppInfo(appName, environment));
     return Promise.all(promises);
   }
 
@@ -74,7 +74,7 @@ class ScalingoClient {
         isUp,
         lastDeployementAt: created_at,
         lastDeployedBy: pusher.username,
-        lastDeployedVersion: git_ref
+        lastDeployedVersion: git_ref,
       };
     } catch (err) {
       if (err.status === 404) {
@@ -86,7 +86,6 @@ class ScalingoClient {
 }
 
 async function _isUrlReachable(url) {
-
   let pingUrl = url;
   if (url.includes('api')) {
     pingUrl = url + '/api';

--- a/common/services/slack/security.js
+++ b/common/services/slack/security.js
@@ -16,7 +16,7 @@ function verifyRequestSignature(signingSecret, body, signature, requestTimestamp
 
   // Divide current date to match Slack ts format
   // Subtract 5 minutes from current time
-  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 5);
+  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 60 * 5;
 
   if (ts < fiveMinutesAgo) {
     throw Boom.unauthorized('Slack request signing verification failed. Timestamp is too old.');
@@ -55,7 +55,6 @@ function parseRequestBody(stringBody, contentType) {
 }
 
 module.exports = {
-
   async verifySignatureAndParseBody(request) {
     const { headers, payload } = request;
 
@@ -72,5 +71,5 @@ module.exports = {
     }
 
     return parseRequestBody(stringBody, contentType);
-  }
+  },
 };

--- a/common/services/slack/surfaces/messages/block-message.js
+++ b/common/services/slack/surfaces/messages/block-message.js
@@ -1,12 +1,14 @@
 module.exports = (message) => {
   return {
     response_type: 'in_channel',
-    blocks: [{
-      'type': 'section',
-      'text': {
-        'type': 'mrkdwn',
-        'text': message,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: message,
+        },
       },
-    }],
+    ],
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,3487 @@
 {
   "name": "pix-bot",
   "version": "1.27.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "pix-bot",
+      "version": "1.27.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@hapi/hapi": "^20.2.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/rest": "^18.12.0",
+        "@sentry/cli": "^2.0.2",
+        "axios": "^0.26.1",
+        "cron": "^1.8.2",
+        "dayjs": "^1.11.1",
+        "dotenv": "^16.0.0",
+        "lodash": "^4.17.21",
+        "scalingo": "^0.3.11",
+        "scalingo-review-app-manager": "^1.0.1",
+        "sib-api-v3-sdk": "^8.3.0",
+        "slack-block-builder": "^2.5.0",
+        "tsscmp": "^1.0.6"
+      },
+      "devDependencies": {
+        "chai": "^4.3.6",
+        "eslint": "^8.13.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-mocha": "^10.1.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "fs-extra": "^10.1.0",
+        "mocha": "^9.2.2",
+        "nock": "^13.2.4",
+        "prettier": "^2.7.1",
+        "proxyquire": "^2.1.3",
+        "simple-git": "^3.6.0",
+        "sinon": "^13.0.2",
+        "sinon-chai": "^3.7.0"
+      },
+      "engines": {
+        "node": "16.14.0",
+        "npm": "8.3.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@hapi/accept": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "node_modules/@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/catbox": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/catbox-memory": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/content": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+    },
+    "node_modules/@hapi/hapi": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.1.tgz",
+      "integrity": "sha512-OXAU+yWLwkMfPFic+KITo+XPp6Oxpgc9WUH+pxXWcTIuvWbgco5TC/jS8UDvz+NFF5IzRgF2CL6UV/KLdQYUSQ==",
+      "dependencies": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "^5.1.0",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "node_modules/@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/mimos": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/nigel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/pez": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
+      }
+    },
+    "node_modules/@hapi/podium": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/shot": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "dependencies": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/statehood": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/subtext": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
+      }
+    },
+    "node_modules/@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/vise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/wreck": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+      "dependencies": {
+        "@octokit/types": "^6.34.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.0.2.tgz",
+      "integrity": "sha512-IqBuvcCf89f92Be/L+GXuHZJId7lpM8+emznfqGGQ2y7N8LpImTGqkFCmiIFHo11jCUtMVkfsfRdD+arZQkT2w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^3.2.3",
+        "npmlog": "^6.0.1",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+      "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cron": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
+      "integrity": "sha512-Gk2c4y6xKEO8FSAUTklqtfSr7oTq0CiPQeLBG5Fl0qoXpZyMcj1SG59YL+hqq04bu6/IuEA7lMkYDAplQNKkyg==",
+      "dependencies": {
+        "moment-timezone": "^0.5.x"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA=="
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.2.1",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "rambda": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
+    "node_modules/moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
+      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
+      "integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.1.tgz",
+      "integrity": "sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.0",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/rambda": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.1.tgz",
+      "integrity": "sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==",
+      "dev": true
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/scalingo": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.3.11.tgz",
+      "integrity": "sha512-Km2UI249NmhL7ovu853F3MvG3321u8hQDQRVdUwa0HPCEWmgTLd3Ke0lKdYFjLid5zZPmSrFXNByDAocNbuojQ==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "isomorphic-ws": "4.x",
+        "ws": "^7.4.3"
+      }
+    },
+    "node_modules/scalingo-review-app-manager": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.1.tgz",
+      "integrity": "sha512-1+05PBuzc03zrkjePXPlMs4l/SE8Wdxr8YuXGNo4mdGt5Q1ioqUlQoWv8P8ijJfTFmInQ/0vi3vjRXd0o/pIHw==",
+      "dependencies": {
+        "cron": "^1.8.2",
+        "scalingo": "^0.3.1"
+      }
+    },
+    "node_modules/scalingo-review-app-manager/node_modules/scalingo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.3.1.tgz",
+      "integrity": "sha512-I9M/5lT04O1TAIIv5B498e+IN9ACE2XeH1RzBGhUK2lXPb2Ds2HdbYTefDuDncwwSHhnkQJ/c6wZF+pj/nL5RQ==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "isomorphic-ws": "4.x",
+        "ws": "^7.4.3"
+      }
+    },
+    "node_modules/scalingo-review-app-manager/node_modules/scalingo/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/scalingo-review-app-manager/node_modules/ws": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/scalingo/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sib-api-v3-sdk": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/sib-api-v3-sdk/-/sib-api-v3-sdk-8.3.0.tgz",
+      "integrity": "sha512-uIoUbl/0Hzuk3NHP5WIW5TAH9UNsfdVIjk8J318pBU3fRPsuwCJiL8LcexRjeqwLdbMHwM8039XDoGsB7xeJqA==",
+      "dependencies": {
+        "querystring": "0.2.0",
+        "superagent": "3.7.0"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-git": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.6.0.tgz",
+      "integrity": "sha512-2e+4QhOVO59GeLsHgwSMKNrSKCnuACeA/gMNrLCYR8ID9qwm4hViVt4WsODcUGjx//KDv6GMLC6Hs/MeosgXxg==",
+      "dev": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/steveukx/"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/simple-git/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
+      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slack-block-builder": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/slack-block-builder/-/slack-block-builder-2.5.0.tgz",
+      "integrity": "sha512-Gekb6jSKmyZtYXFrMXN637/FttYiUFvcoDeKt5epcwTDggxQvtw/Q3aO5eR4JNe5UW2JoSGao+6GX3NZf2yceA=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
+      "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "dependencies": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/ws": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
   "dependencies": {
     "@eslint/eslintrc": {
       "version": "1.2.1",
@@ -437,7 +3916,8 @@
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -564,7 +4044,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -1084,6 +4565,32 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-mocha": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.1.0.tgz",
+      "integrity": "sha512-xLqqWUF17llsogVOC+8C6/jvQ+4IoOREbN7ZCHuOHuD6cT5cDD4h7f2LgsZuzMAiwswWE21tO7ExaknHVDrSkw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "rambda": "^7.1.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -1167,6 +4674,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1600,7 +5113,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -2056,6 +5570,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2106,6 +5635,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "rambda": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.1.tgz",
+      "integrity": "sha512-Wswj8ZvzdI3VhaGPkZAxaCTwuMmGtgWt7Zxsgyo4P+iTmVnkojvyWaOep5q3ZjMIecW0wtQa66GWxaKkZ24RAA==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -2232,7 +5767,8 @@
         "ws": {
           "version": "7.4.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+          "requires": {}
         }
       }
     },
@@ -2346,12 +5882,21 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slack-block-builder": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/slack-block-builder/-/slack-block-builder-2.5.0.tgz",
       "integrity": "sha512-Gekb6jSKmyZtYXFrMXN637/FttYiUFvcoDeKt5epcwTDggxQvtw/Q3aO5eR4JNe5UW2JoSGao+6GX3NZf2yceA=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -2362,14 +5907,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -2556,7 +6093,8 @@
     "ws": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,13 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "eslint": "^8.13.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-mocha": "^10.1.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "fs-extra": "^10.1.0",
     "mocha": "^9.2.2",
     "nock": "^13.2.4",
+    "prettier": "^2.7.1",
     "proxyquire": "^2.1.3",
     "simple-git": "^3.6.0",
     "sinon": "^13.0.2",

--- a/run/controllers/applications.js
+++ b/run/controllers/applications.js
@@ -3,7 +3,6 @@ const config = require('../../config');
 const Boom = require('@hapi/boom');
 
 module.exports = {
-
   async invalidateCdnCache(request) {
     if (request.query.apiKey !== config.openApi.authorizationToken) {
       throw Boom.unauthorized('Token is missing or is incorrect');
@@ -18,6 +17,4 @@ module.exports = {
       return error;
     }
   },
-
 };
-

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -4,7 +4,6 @@ const { deploy } = require('../services/deploy');
 const Boom = require('@hapi/boom');
 
 module.exports = {
-
   async deploySites(request) {
     const payload = request.payload;
     if (payload.secret !== config.prismic.secret) {
@@ -15,6 +14,4 @@ module.exports = {
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },
-
 };
-

--- a/run/controllers/manifest.js
+++ b/run/controllers/manifest.js
@@ -7,12 +7,12 @@ module.exports = {
     const url = `${protocol}://${host}`;
     return {
       display_information: {
-        name: manifest.name
+        name: manifest.name,
       },
       features: {
         bot_user: {
           display_name: manifest.name,
-          always_online: false
+          always_online: false,
         },
         shortcuts: manifest.shortcuts,
         slash_commands: manifest.slashCommands.map(({ command, path, description, usage_hint, should_escape }) => {
@@ -23,27 +23,24 @@ module.exports = {
             usage_hint,
             should_escape,
           };
-        })
+        }),
       },
       oauth_config: {
         scopes: {
-          bot: [
-            'commands',
-            'incoming-webhook',
-            'chat:write'
-          ]
-        }
+          bot: ['commands', 'incoming-webhook', 'chat:write'],
+        },
       },
       settings: {
-        interactivity: manifest.interactivity ? {
-          is_enabled: true,
-          request_url: `${url}${manifest.interactivity.path}`
-        } : null,
+        interactivity: manifest.interactivity
+          ? {
+              is_enabled: true,
+              request_url: `${url}${manifest.interactivity.path}`,
+            }
+          : null,
         org_deploy_enabled: false,
         socket_mode_enabled: false,
-        token_rotation_enabled: false
-      }
+        token_rotation_enabled: false,
+      },
     };
   },
 };
-

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -9,13 +9,12 @@ function _getDeployStartedMessage(release, appName) {
 }
 
 module.exports = {
-
   createAndDeployPixSiteRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixSiteRelease(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX site and pro')
+      text: _getDeployStartedMessage(payload.text, 'PIX site and pro'),
     };
   },
 
@@ -24,7 +23,7 @@ module.exports = {
     commands.createAndDeployPixUI(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX UI')
+      text: _getDeployStartedMessage(payload.text, 'PIX UI'),
     };
   },
 
@@ -33,7 +32,7 @@ module.exports = {
     commands.createAndDeployPixLCMS(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX LCMS')
+      text: _getDeployStartedMessage(payload.text, 'PIX LCMS'),
     };
   },
 
@@ -42,7 +41,7 @@ module.exports = {
     commands.createAndDeployPixDatawarehouse(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX Datawarehouse')
+      text: _getDeployStartedMessage(payload.text, 'PIX Datawarehouse'),
     };
   },
 
@@ -51,7 +50,7 @@ module.exports = {
     commands.createAndDeployPixBotRelease(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX Bot')
+      text: _getDeployStartedMessage(payload.text, 'PIX Bot'),
     };
   },
 
@@ -60,7 +59,7 @@ module.exports = {
     commands.createAndDeployPixTutosRelease(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'PIX Tutos')
+      text: _getDeployStartedMessage(payload.text, 'PIX Tutos'),
     };
   },
 
@@ -74,7 +73,7 @@ module.exports = {
 
     try {
       await commands.getAndDeployLastVersion({ appName });
-    } catch(e) {
+    } catch (e) {
       return sendSlackBlockMessage(e.message);
     }
 
@@ -86,7 +85,7 @@ module.exports = {
     commands.createAndDeployEmberTestingLibrary(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'EMBER-TESTING-LIBRARY')
+      text: _getDeployStartedMessage(payload.text, 'EMBER-TESTING-LIBRARY'),
     };
   },
 
@@ -95,7 +94,7 @@ module.exports = {
     commands.createAndDeployDbStats(payload);
 
     return {
-      'text': _getDeployStartedMessage(payload.text, 'DB stats')
+      text: _getDeployStartedMessage(payload.text, 'DB stats'),
     };
   },
 
@@ -113,24 +112,24 @@ module.exports = {
     const interactionType = payload.type;
 
     switch (interactionType) {
-    case 'shortcut':
-      if (payload.callback_id === 'deploy-release') {
-        shortcuts.openViewDeployReleaseTagSelection(payload);
-      }
-      return null;
-    case 'view_submission':
-      if (payload.view.callback_id === shortcuts.openViewDeployReleaseTagSelectionCallbackId) {
-        return viewSubmissions.submitReleaseTagSelection(payload);
-      }
-      if (payload.view.callback_id === viewSubmissions.submitReleaseTagSelectionCallbackId) {
-        return viewSubmissions.submitReleaseDeploymentConfirmation(payload);
-      }
-      return null;
-    case 'view_closed':
-    case 'block_actions':
-    default:
-      console.log('This kind of interaction is not yet supported by Pix Bot.');
-      return null;
+      case 'shortcut':
+        if (payload.callback_id === 'deploy-release') {
+          shortcuts.openViewDeployReleaseTagSelection(payload);
+        }
+        return null;
+      case 'view_submission':
+        if (payload.view.callback_id === shortcuts.openViewDeployReleaseTagSelectionCallbackId) {
+          return viewSubmissions.submitReleaseTagSelection(payload);
+        }
+        if (payload.view.callback_id === viewSubmissions.submitReleaseTagSelectionCallbackId) {
+          return viewSubmissions.submitReleaseDeploymentConfirmation(payload);
+        }
+        return null;
+      case 'view_closed':
+      case 'block_actions':
+      default:
+        console.log('This kind of interaction is not yet supported by Pix Bot.');
+        return null;
     }
   },
 };

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -33,7 +33,8 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/deploy-pix-datawarehouse',
   path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
-  description: 'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
+  description:
+    'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
   usage_hint: '[patch, minor, major]',
   should_escape: false,
   handler: slackbotController.createAndDeployPixDatawarehouseRelease,
@@ -106,7 +107,7 @@ manifest.registerShortcut({
   name: 'Déployer une version/MEP',
   type: 'global',
   callback_id: 'deploy-release',
-  description: 'Lance le déploiement d\'une version sur l\'environnement de production'
+  description: "Lance le déploiement d'une version sur l'environnement de production",
 });
 
 manifest.addInteractivity({

--- a/run/routes/applications.js
+++ b/run/routes/applications.js
@@ -5,6 +5,5 @@ module.exports = [
     method: 'POST',
     path: '/applications/{name}/cdn-cache-invalidations',
     handler: applicationController.invalidateCdnCache,
-  }
+  },
 ];
-

--- a/run/routes/deploy-sites.js
+++ b/run/routes/deploy-sites.js
@@ -5,6 +5,5 @@ module.exports = [
     method: 'POST',
     path: '/deploy-sites',
     handler: deploySitesController.deploySites,
-  }
+  },
 ];
-

--- a/run/routes/manifest.js
+++ b/run/routes/manifest.js
@@ -5,6 +5,5 @@ module.exports = [
     method: 'GET',
     path: '/run/manifest',
     handler: manifestController.get,
-  }
+  },
 ];
-

--- a/run/services/cdn.js
+++ b/run/services/cdn.js
@@ -17,13 +17,17 @@ async function _getNamespaceKey(application) {
     headers: {
       'X-Api-Key': config.baleen.pat,
       'Content-type': 'application/json',
-    }
+    },
   });
 
   const namespaces = config.baleen.appNamespaces;
-  const namespace = _.find(namespaces, (v, k) => { return k === application; });
+  const namespace = _.find(namespaces, (v, k) => {
+    return k === application;
+  });
 
-  const namespaceKey = _.findKey(accountDetails.data.namespaces, (v) => { return v === namespace; });
+  const namespaceKey = _.findKey(accountDetails.data.namespaces, (v) => {
+    return v === namespace;
+  });
 
   if (!namespaceKey) {
     throw new NamespaceNotFoundError(application);
@@ -36,20 +40,24 @@ async function invalidateCdnCache(application) {
   const namespaceKey = await _getNamespaceKey(application);
   const urlForInvalidate = `${CDN_URL}/cache/invalidations`;
 
-  await axios.post(urlForInvalidate, {
-    patterns: [ '.' ]
-  }, {
-    headers: {
-      'X-Api-Key': config.baleen.pat,
-      'Content-type': 'application/json',
-      'Cookie': `baleen-namespace=${namespaceKey}`,
+  await axios.post(
+    urlForInvalidate,
+    {
+      patterns: ['.'],
+    },
+    {
+      headers: {
+        'X-Api-Key': config.baleen.pat,
+        'Content-type': 'application/json',
+        Cookie: `baleen-namespace=${namespaceKey}`,
+      },
     }
-  });
+  );
 
   return `Cache CDN invalidé pour l‘application ${application}.`;
 }
 
 module.exports = {
   invalidateCdnCache,
-  NamespaceNotFoundError
+  NamespaceNotFoundError,
 };

--- a/run/services/deploy.js
+++ b/run/services/deploy.js
@@ -4,7 +4,9 @@ const releasesService = require('../../common/services/releases');
 async function deploy(repoName, appNamesList) {
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
   const environment = 'production';
-  await Promise.all(appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment)));
+  await Promise.all(
+    appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment))
+  );
   return releaseTag;
 }
 

--- a/run/services/sendinblue-report.js
+++ b/run/services/sendinblue-report.js
@@ -29,12 +29,7 @@ function _getColor(percentage) {
   return color;
 }
 
-function _generateAndReturnFilledSlackBlocks({
-  requestEmails,
-  usagePercentage,
-  startDate,
-  endDate
-}) {
+function _generateAndReturnFilledSlackBlocks({ requestEmails, usagePercentage, startDate, endDate }) {
   const emoji = _getEmoji(usagePercentage);
   const color = _getColor(usagePercentage);
 
@@ -50,16 +45,16 @@ function _generateAndReturnFilledSlackBlocks({
           {
             title: 'Nombre d‘e-mails envoyés :',
             value: `${requestEmails}`,
-            short: true
+            short: true,
           },
           {
             title: 'Quota utilisé :',
             value: `${usagePercentage}% ${emoji}`,
-            short: true
+            short: true,
           },
         ],
-      }
-    ]
+      },
+    ],
   };
 }
 
@@ -76,7 +71,7 @@ async function getReport() {
 
   const requestEmails = response.requests;
   const mailingQuota = config.sendInBlue.mailingQuota;
-  const usagePercentage = (requestEmails/mailingQuota * 100).toFixed();
+  const usagePercentage = ((requestEmails / mailingQuota) * 100).toFixed();
   const blocks = _generateAndReturnFilledSlackBlocks({
     requestEmails: requestEmails.toLocaleString(),
     usagePercentage,
@@ -87,8 +82,6 @@ async function getReport() {
   return axios.post(config.slack.webhookUrlForReporting, blocks, { headers: { 'content-type': 'application/json' } });
 }
 
-
 module.exports = {
-  getReport
+  getReport,
 };
-

--- a/run/services/slack/app-status-from-scalingo.js
+++ b/run/services/slack/app-status-from-scalingo.js
@@ -2,25 +2,23 @@ const ScalingoClient = require('../../../common/services/scalingo-client');
 
 async function getAppStatusFromScalingo(appName) {
   if (!appName) {
-    return { text: 'Un nom d\'application est attendu en paramètre (ex: pix-app-production)' } ;
+    return { text: "Un nom d'application est attendu en paramètre (ex: pix-app-production)" };
   }
 
   const environment = _getEnvironmentFrom({ appName });
 
   try {
     const client = await ScalingoClient.getInstance(environment);
-    const appInfos = await client.getAppInfo(
-      appName
-    );
+    const appInfos = await client.getAppInfo(appName);
 
     const blocks = appInfos.map((appInfo) => {
       const appStatus = appInfo.isUp ? '💚' : '🛑';
       const lastVersionDisplayed = environment === 'integration' ? '' : ` - ${appInfo.lastDeployedVersion}`;
       return {
-        'type': 'section',
-        'text': {
-          'type': 'mrkdwn',
-          'text': `*${appInfo.name}* ${appStatus}${lastVersionDisplayed}\n${appInfo.lastDeployementAt}`,
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${appInfo.name}* ${appStatus}${lastVersionDisplayed}\n${appInfo.lastDeployementAt}`,
         },
       };
     });
@@ -30,7 +28,7 @@ async function getAppStatusFromScalingo(appName) {
       blocks,
     };
   } catch (error) {
-    return { text: `Une erreur est survenue : "${error.message}"` } ;
+    return { text: `Une erreur est survenue : "${error.message}"` };
   }
 }
 

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -26,13 +26,14 @@ const axios = require('axios');
 const postSlackMessage = require('../../../common/services/slack/surfaces/messages/post-message');
 
 function sendResponse(responseUrl, text) {
-  axios.post(responseUrl,
+  axios.post(
+    responseUrl,
     { text },
     {
       headers: {
         'content-type': 'application/json',
       },
-    },
+    }
   );
 }
 
@@ -57,8 +58,12 @@ function _isReleaseTypeInvalid(releaseType) {
 }
 async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
-    postSlackMessage('Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".');
-    throw new Error('Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".');
+    postSlackMessage(
+      'Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".'
+    );
+    throw new Error(
+      'Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".'
+    );
   }
   const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.publishPixRepo(repoName, releaseType);
@@ -74,8 +79,12 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
 
 async function publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
-    postSlackMessage('Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".');
-    throw new Error('Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".');
+    postSlackMessage(
+      'Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".'
+    );
+    throw new Error(
+      'Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".'
+    );
   }
   const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.publishPixRepo(repoName, releaseType);
@@ -137,19 +146,16 @@ async function getAndDeployLastVersion({ appName }) {
 function _isAppFromPixRepo({ appName }) {
   const appNameParts = appName.split('-');
 
-  if(appNameParts.length != 3) {
+  if (appNameParts.length != 3) {
     return false;
   }
 
   const [appNamePrefix, shortAppName, environment] = appName.split('-');
 
-  return appNamePrefix === 'pix'
-    && PIX_APPS.includes(shortAppName)
-    && PIX_APPS_ENVIRONMENTS.includes(environment);
+  return appNamePrefix === 'pix' && PIX_APPS.includes(shortAppName) && PIX_APPS_ENVIRONMENTS.includes(environment);
 }
 
 module.exports = {
-
   async createAndDeployPixLCMS(payload) {
     await publishAndDeployRelease(PIX_LCMS_REPO_NAME, [PIX_LCMS_APP_NAME], payload.text, payload.response_url);
   },
@@ -167,7 +173,12 @@ module.exports = {
   },
 
   async createAndDeployPixDatawarehouse(payload) {
-    await publishAndDeployRelease(PIX_DATAWAREHOUSE_REPO_NAME, PIX_DATAWAREHOUSE_APPS_NAME, payload.text, payload.response_url);
+    await publishAndDeployRelease(
+      PIX_DATAWAREHOUSE_REPO_NAME,
+      PIX_DATAWAREHOUSE_APPS_NAME,
+      payload.text,
+      payload.response_url
+    );
   },
 
   async createAndDeployPixBotRelease(payload) {
@@ -192,5 +203,5 @@ module.exports = {
 
   async createAndDeployPixTutosRelease(payload) {
     await publishAndDeployRelease(PIX_TUTOS_REPO_NAME, [PIX_TUTOS_APP_NAME], payload.text, payload.response_url);
-  }
+  },
 };

--- a/run/services/slack/shortcuts.js
+++ b/run/services/slack/shortcuts.js
@@ -11,10 +11,10 @@ module.exports = {
       url: 'https://slack.com/api/views.open',
       headers: {
         'content-type': 'application/json',
-        'authorization': `Bearer ${config.slack.botToken}`
+        authorization: `Bearer ${config.slack.botToken}`,
       },
-      data: deployReleaseTagSelectionModal(payload.trigger_id)
+      data: deployReleaseTagSelectionModal(payload.trigger_id),
     };
     return axios(options);
-  }
+  },
 };

--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -8,23 +8,25 @@ function modal(releaseTag, hasConfigFileChanged) {
     callbackId,
     privateMetaData: releaseTag,
     submit: '🚀 Go !',
-    close: 'Annuler'
+    close: 'Annuler',
   }).blocks([
-    ...hasConfigFileChanged ? [
-      Blocks.Section({
-        text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
-      })
-    ] : [],
+    ...(hasConfigFileChanged
+      ? [
+          Blocks.Section({
+            text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo PRODUCTION*.",
+          }),
+        ]
+      : []),
     Blocks.Section({
-      text: `Vous vous apprêtez à déployer la version *${releaseTag}* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?`
-    })
+      text: `Vous vous apprêtez à déployer la version *${releaseTag}* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?`,
+    }),
   ]);
 }
 
 module.exports = (releaseTag, hasConfigFileChanged) => {
   return {
     response_action: 'push',
-    view: modal(releaseTag, hasConfigFileChanged).buildToObject()
+    view: modal(releaseTag, hasConfigFileChanged).buildToObject(),
   };
 };
 

--- a/run/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-tag-selection.js
@@ -7,22 +7,24 @@ function modal() {
     title: 'Déployer une release',
     callbackId,
     submit: 'Déployer',
-    close: 'Annuler'
+    close: 'Annuler',
   }).blocks([
     Blocks.Input({
       blockId: 'deploy-release-tag',
       label: 'Numéro de release',
-    }).element(Elements.TextInput({
-      actionId: 'release-tag-value',
-      placeholder: 'Ex : v2.130.0'
-    }))
+    }).element(
+      Elements.TextInput({
+        actionId: 'release-tag-value',
+        placeholder: 'Ex : v2.130.0',
+      })
+    ),
   ]);
 }
 
 module.exports = (triggerId) => {
   return {
     trigger_id: triggerId,
-    view: modal().buildToObject()
+    view: modal().buildToObject(),
   };
 };
 

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -20,7 +20,7 @@ module.exports = {
       deploy(environments.production, releaseTag);
     }
     return {
-      'response_action': 'clear'
+      response_action: 'clear',
     };
-  }
+  },
 };

--- a/test/acceptance/build/manifest_test.js
+++ b/test/acceptance/build/manifest_test.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai');
 const server = require('../../../server');
 
-describe('Acceptance | Build | Manifest', function() {
-  describe('GET /build/manifest', function() {
-    it('responds with 200 and returns the manifest', async () => {
+describe('Acceptance | Build | Manifest', function () {
+  describe('GET /build/manifest', function () {
+    it('responds with 200 and returns the manifest', async function () {
       const res = await server.inject({
         method: 'GET',
         url: '/build/manifest',
@@ -12,77 +12,73 @@ describe('Acceptance | Build | Manifest', function() {
       expect(res.statusCode).to.equal(200);
       expect(res.result).to.deep.equal({
         display_information: {
-          name: 'Pix Bot Build'
+          name: 'Pix Bot Build',
         },
         features: {
           bot_user: {
             display_name: 'Pix Bot Build',
-            always_online: false
+            always_online: false,
           },
           shortcuts: [
             {
               name: 'Publier une version/MER',
               type: 'global',
               callback_id: 'publish-release',
-              description: 'Publie une nouvelle version et la déploie sur l\'environnement de recette'
-            }
+              description: "Publie une nouvelle version et la déploie sur l'environnement de recette",
+            },
           ],
           slash_commands: [
             {
               command: '/pr-pix',
               url: `http://${hostname}/slack/commands/pull-requests`,
-              description: 'Afficher les PR à review de l\'application Pix',
+              description: "Afficher les PR à review de l'application Pix",
               usage_hint: '[cross-team|team-acces|team-evaluation|team-certif|team-prescription]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/tips-a11y',
               url: `http://${hostname}/slack/commands/accessibility-tip`,
-              description: 'Je veux un tips sur l\'accessibilité !',
+              description: "Je veux un tips sur l'accessibilité !",
               usage_hint: undefined,
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/changelog',
               url: `http://${hostname}/slack/commands/changelog`,
               description: 'Afficher le changelog depuis la dernière release',
               usage_hint: undefined,
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/hotfix',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-hotfix`,
-              description: 'Créer une version patch à partir d\'une branche et la déployer en recette',
+              description: "Créer une version patch à partir d'une branche et la déployer en recette",
               usage_hint: '[branch-name]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/mob',
               url: `http://${hostname}/slack/commands/mob`,
-              description: 'Afficher des couples pilote/co-pilote à partir d\'une liste de participants',
-              usage_hint: '[@quelqu\'un @quelqu\'une]',
-              should_escape: false
-            }
+              description: "Afficher des couples pilote/co-pilote à partir d'une liste de participants",
+              usage_hint: "[@quelqu'un @quelqu'une]",
+              should_escape: false,
+            },
           ],
         },
         oauth_config: {
           scopes: {
-            bot: [
-              'commands',
-              'incoming-webhook',
-              'workflow.steps:execute'
-            ]
-          }
+            bot: ['commands', 'incoming-webhook', 'workflow.steps:execute'],
+          },
         },
         settings: {
           interactivity: {
             is_enabled: true,
-            request_url: `http://${hostname}/build/slack/interactive-endpoint`
+            request_url: `http://${hostname}/build/slack/interactive-endpoint`,
           },
           org_deploy_enabled: false,
           socket_mode_enabled: false,
-          token_rotation_enabled: false
-        }
+          token_rotation_enabled: false,
+        },
       });
     });
   });

--- a/test/acceptance/build/slack_test.js
+++ b/test/acceptance/build/slack_test.js
@@ -1,11 +1,17 @@
-const { expect, nock, createSlackWebhookSignatureHeaders, nockGithubWithNoConfigChanges, nockGithubWithConfigChanges } = require('../../test-helper');
+const {
+  expect,
+  nock,
+  createSlackWebhookSignatureHeaders,
+  nockGithubWithNoConfigChanges,
+  nockGithubWithConfigChanges,
+} = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | Build | Slack', function() {
-  describe('POST /build/slack/interactive-endpoint', function() {
-    it('responds with 204', async () => {
+describe('Acceptance | Build | Slack', function () {
+  describe('POST /build/slack/interactive-endpoint', function () {
+    it('responds with 204', async function () {
       const body = {
-        type: 'view_closed'
+        type: 'view_closed',
       };
       const res = await server.inject({
         method: 'POST',
@@ -16,9 +22,9 @@ describe('Acceptance | Build | Slack', function() {
       expect(res.statusCode).to.equal(204);
     });
 
-    it('responds with 401', async () => {
+    it('responds with 401', async function () {
       const body = {
-        type: 'view_closed'
+        type: 'view_closed',
       };
       const res = await server.inject({
         method: 'POST',
@@ -28,91 +34,91 @@ describe('Acceptance | Build | Slack', function() {
       expect(res.statusCode).to.equal(401);
     });
 
-    describe('when using the shortcut publish-release', function() {
-      it('calls slack with the tag selection modal', async function() {
+    describe('when using the shortcut publish-release', function () {
+      it('calls slack with the tag selection modal', async function () {
         const slackCall = nock('https://slack.com')
           .post('/api/views.open', {
-            'trigger_id': 'trigger id',
-            'view': {
-              'type': 'modal',
-              'callback_id': 'release-type-selection',
-              'title': {
-                'type': 'plain_text',
-                'text': 'Publier une release',
+            trigger_id: 'trigger id',
+            view: {
+              type: 'modal',
+              callback_id: 'release-type-selection',
+              title: {
+                type: 'plain_text',
+                text: 'Publier une release',
               },
-              'submit': {
-                'type': 'plain_text',
-                'text': 'Publier',
+              submit: {
+                type: 'plain_text',
+                text: 'Publier',
               },
-              'close': {
-                'type': 'plain_text',
-                'text': 'Annuler',
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
               },
-              'blocks': [
+              blocks: [
                 {
-                  'type': 'section',
-                  'text': {
-                    'type': 'mrkdwn',
-                    'text': 'Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d\'architecture'
-                  }
-                },
-                {
-                  'type': 'divider'
-                },
-                {
-                  'type': 'input',
-                  'block_id': 'publish-release-type',
-                  'label': {
-                    'type': 'plain_text',
-                    'text': 'Type de release',
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: "Pix utilise le format de gestion de versions _Semantic Versionning_ :\n- *patch* : contient exclusivement des correctif(s)\n- *minor* : contient au moins 1 évolution technique ou fonctionnelle\n- *major* : contient au moins 1 changement majeur d'architecture",
                   },
-                  'element': {
-                    'action_id': 'release-type-option',
-                    'type': 'static_select',
-                    'placeholder': {
-                      'type': 'plain_text',
-                      'text': 'Selectionnez un élément'
+                },
+                {
+                  type: 'divider',
+                },
+                {
+                  type: 'input',
+                  block_id: 'publish-release-type',
+                  label: {
+                    type: 'plain_text',
+                    text: 'Type de release',
+                  },
+                  element: {
+                    action_id: 'release-type-option',
+                    type: 'static_select',
+                    placeholder: {
+                      type: 'plain_text',
+                      text: 'Selectionnez un élément',
                     },
-                    'initial_option': {
-                      'text': {
-                        'type': 'plain_text',
-                        'text': 'Minor'
+                    initial_option: {
+                      text: {
+                        type: 'plain_text',
+                        text: 'Minor',
                       },
-                      'value': 'minor'
+                      value: 'minor',
                     },
-                    'options': [
+                    options: [
                       {
-                        'text': {
-                          'type': 'plain_text',
-                          'text': 'Minor'
+                        text: {
+                          type: 'plain_text',
+                          text: 'Minor',
                         },
-                        'value': 'minor'
+                        value: 'minor',
                       },
                       {
-                        'text': {
-                          'type': 'plain_text',
-                          'text': 'Patch'
+                        text: {
+                          type: 'plain_text',
+                          text: 'Patch',
                         },
-                        'value': 'patch'
+                        value: 'patch',
                       },
                       {
-                        'text': {
-                          'type': 'plain_text',
-                          'text': 'Major'
+                        text: {
+                          type: 'plain_text',
+                          text: 'Major',
                         },
-                        'value': 'major'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
+                        value: 'major',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
           })
           .reply(200);
         const body = {
           type: 'shortcut',
           callback_id: 'publish-release',
-          trigger_id: 'trigger id'
+          trigger_id: 'trigger id',
         };
         const res = await server.inject({
           method: 'POST',
@@ -124,8 +130,7 @@ describe('Acceptance | Build | Slack', function() {
         expect(slackCall.isDone()).to.be.true;
       });
 
-      describe('with the callback release-type-selection', function() {
-
+      describe('with the callback release-type-selection', function () {
         it('returns the confirmation modal', async function () {
           nockGithubWithNoConfigChanges();
 
@@ -138,8 +143,8 @@ describe('Acceptance | Build | Slack', function() {
                   'publish-release-type': {
                     'release-type-option': {
                       selected_option: {
-                        value: 'minor'
-                      }
+                        value: 'minor',
+                      },
                     },
                   },
                 },
@@ -196,8 +201,8 @@ describe('Acceptance | Build | Slack', function() {
                   'publish-release-type': {
                     'release-type-option': {
                       selected_option: {
-                        value: 'major'
-                      }
+                        value: 'major',
+                      },
                     },
                   },
                 },
@@ -235,8 +240,8 @@ describe('Acceptance | Build | Slack', function() {
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo RECETTE*.'
-                  }
+                    text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.",
+                  },
                 },
                 {
                   type: 'section',
@@ -251,7 +256,7 @@ describe('Acceptance | Build | Slack', function() {
         });
       });
 
-      describe('callback release-publication-confirmation', function() {
+      describe('callback release-publication-confirmation', function () {
         it('publish and deploy the app', async function () {
           const body = {
             type: 'view_submission',
@@ -268,7 +273,7 @@ describe('Acceptance | Build | Slack', function() {
           });
           expect(res.statusCode).to.equal(200);
           expect(JSON.parse(res.payload)).to.deep.equal({
-            response_action: 'clear'
+            response_action: 'clear',
           });
         });
       });

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -2,27 +2,27 @@ const { expect } = require('../../test-helper');
 const server = require('../../../server');
 const { version } = require('../../../package.json');
 
-describe('Acceptance | Common | Index', function() {
-  describe('GET /', function() {
-    it('responds with 200', async () => {
+describe('Acceptance | Common | Index', function () {
+  describe('GET /', function () {
+    it('responds with 200', async function () {
       const res = await server.inject({
         method: 'GET',
-        url: '/'
+        url: '/',
       });
       expect(res.statusCode).to.equal(200);
       expect(JSON.parse(res.payload)).to.deep.equal({
         name: 'pix-bot',
         version,
-        description: 'Pix Bot application'
+        description: 'Pix Bot application',
       });
     });
   });
 
-  describe('GET /slackviews', function() {
-    it('responds with 200', async () => {
+  describe('GET /slackviews', function () {
+    it('responds with 200', async function () {
       const res = await server.inject({
         method: 'GET',
-        url: '/slackviews'
+        url: '/slackviews',
       });
       expect(res.statusCode).to.equal(200);
     });

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai');
 const server = require('../../../server');
 
-describe('Acceptance | Run | Manifest', function() {
-  describe('GET /run/manifest', function() {
-    it('responds with 200 and returns the manifest', async () => {
+describe('Acceptance | Run | Manifest', function () {
+  describe('GET /run/manifest', function () {
+    it('responds with 200 and returns the manifest', async function () {
       const res = await server.inject({
         method: 'GET',
         url: '/run/manifest',
@@ -12,20 +12,20 @@ describe('Acceptance | Run | Manifest', function() {
       expect(res.statusCode).to.equal(200);
       expect(res.result).to.eql({
         display_information: {
-          name: 'Pix Bot Run'
+          name: 'Pix Bot Run',
         },
         features: {
           bot_user: {
             display_name: 'Pix Bot Run',
-            always_online: false
+            always_online: false,
           },
           shortcuts: [
             {
               name: 'Déployer une version/MEP',
               type: 'global',
               callback_id: 'deploy-release',
-              description: 'Lance le déploiement d\'une version sur l\'environnement de production'
-            }
+              description: "Lance le déploiement d'une version sur l'environnement de production",
+            },
           ],
           slash_commands: [
             {
@@ -33,98 +33,95 @@ describe('Acceptance | Run | Manifest', function() {
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-site-release`,
               description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',
               usage_hint: 'patch|minor|major (minor par défaut)',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/publish-pix-ui',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-ui-release`,
               description: 'Crée une release de Pix-UI et la déploie sur les Github pages !',
               usage_hint: '[patch, minor, major]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-pix-lcms',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-lcms-release`,
               description: 'Crée une release de Pix-LCMS et la déploie en production (https://lcms-api.pix.fr)',
               usage_hint: '[patch, minor, major]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-pix-datawarehouse',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-datawarehouse-release`,
-              description: 'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
+              description:
+                'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
               usage_hint: '[patch, minor, major]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-pix-bot',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-bot-release`,
               description: 'Releaser et déployer pix-bot-run et pix-bot-build',
               usage_hint: '[patch, minor, major]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/app-status',
               url: `http://${hostname}/slack/commands/app-status`,
               description: 'Returns the app status given the app name as parameter',
               usage_hint: '[pix-app-production, production]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-last-version',
               url: `http://${hostname}/slack/commands/deploy-last-version`,
               description: 'Deploy last version of an app',
               usage_hint: '[pix-admin-production]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-ember-testing-library',
               url: `http://${hostname}/slack/commands/create-and-deploy-ember-testing-library-release`,
               description: 'Crée une release de Ember-testing-library',
               usage_hint: '[patch, minor, major]',
-              should_escape: false
+              should_escape: false,
             },
             {
               command: '/deploy-db-stats',
               description: 'Crée une release de db stats',
               should_escape: false,
               url: `http://${hostname}/slack/commands/create-and-deploy-db-stats`,
-              usage_hint: '[patch, minor, major]'
+              usage_hint: '[patch, minor, major]',
             },
             {
               command: '/deploy-metabase',
               description: 'Déploie metabase',
               should_escape: false,
               url: `http://${hostname}/slack/commands/deploy-metabase`,
-              usage_hint: '/deploy-metabase'
+              usage_hint: '/deploy-metabase',
             },
             {
               command: '/deploy-pix-tutos',
               description: 'Crée une release de Pix Tutos',
               should_escape: false,
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-tutos-release`,
-              usage_hint: '[patch, minor, major]'
-            }
-          ]
+              usage_hint: '[patch, minor, major]',
+            },
+          ],
         },
         oauth_config: {
           scopes: {
-            bot: [
-              'commands',
-              'incoming-webhook',
-              'chat:write'
-            ]
-          }
+            bot: ['commands', 'incoming-webhook', 'chat:write'],
+          },
         },
         settings: {
           interactivity: {
             is_enabled: true,
-            request_url: `http://${hostname}/run/slack/interactive-endpoint`
+            request_url: `http://${hostname}/run/slack/interactive-endpoint`,
           },
           org_deploy_enabled: false,
           socket_mode_enabled: false,
-          token_rotation_enabled: false
-        }
+          token_rotation_enabled: false,
+        },
       });
     });
   });

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -1,12 +1,17 @@
-const { expect, nock, createSlackWebhookSignatureHeaders, nockGithubWithNoConfigChanges, nockGithubWithConfigChanges } = require('../../test-helper');
+const {
+  expect,
+  nock,
+  createSlackWebhookSignatureHeaders,
+  nockGithubWithNoConfigChanges,
+  nockGithubWithConfigChanges,
+} = require('../../test-helper');
 const server = require('../../../server');
 
-describe('Acceptance | Run | Slack', function() {
-  describe('POST /run/slack/interactive-endpoint', function() {
-
-    it('responds with 204', async () => {
+describe('Acceptance | Run | Slack', function () {
+  describe('POST /run/slack/interactive-endpoint', function () {
+    it('responds with 204', async function () {
       const body = {
-        type: 'view_closed'
+        type: 'view_closed',
       };
       const res = await server.inject({
         method: 'POST',
@@ -17,9 +22,9 @@ describe('Acceptance | Run | Slack', function() {
       expect(res.statusCode).to.equal(204);
     });
 
-    it('responds with 401', async () => {
+    it('responds with 401', async function () {
       const body = {
-        type: 'view_closed'
+        type: 'view_closed',
       };
       const res = await server.inject({
         method: 'POST',
@@ -29,51 +34,51 @@ describe('Acceptance | Run | Slack', function() {
       expect(res.statusCode).to.equal(401);
     });
 
-    describe('when using the shortcut deploy-release', function() {
-      it('calls slack with the tag selection modal', async function() {
+    describe('when using the shortcut deploy-release', function () {
+      it('calls slack with the tag selection modal', async function () {
         const slackCall = nock('https://slack.com')
           .post('/api/views.open', {
-            'trigger_id': 'payload id',
-            'view': {
-              'type': 'modal',
-              'callback_id': 'release-tag-selection',
-              'title': {
-                'type': 'plain_text',
-                'text': 'Déployer une release',
+            trigger_id: 'payload id',
+            view: {
+              type: 'modal',
+              callback_id: 'release-tag-selection',
+              title: {
+                type: 'plain_text',
+                text: 'Déployer une release',
               },
-              'submit': {
-                'type': 'plain_text',
-                'text': 'Déployer',
+              submit: {
+                type: 'plain_text',
+                text: 'Déployer',
               },
-              'close': {
-                'type': 'plain_text',
-                'text': 'Annuler',
+              close: {
+                type: 'plain_text',
+                text: 'Annuler',
               },
-              'blocks': [
+              blocks: [
                 {
-                  'type': 'input',
-                  'block_id': 'deploy-release-tag',
-                  'label': {
-                    'type': 'plain_text',
-                    'text': 'Numéro de release',
+                  type: 'input',
+                  block_id: 'deploy-release-tag',
+                  label: {
+                    type: 'plain_text',
+                    text: 'Numéro de release',
                   },
-                  'element': {
-                    'type': 'plain_text_input',
-                    'action_id': 'release-tag-value',
-                    'placeholder': {
-                      'type': 'plain_text',
-                      'text': 'Ex : v2.130.0',
-                    }
-                  }
+                  element: {
+                    type: 'plain_text_input',
+                    action_id: 'release-tag-value',
+                    placeholder: {
+                      type: 'plain_text',
+                      text: 'Ex : v2.130.0',
+                    },
+                  },
                 },
-              ]
-            }
+              ],
+            },
           })
           .reply(200);
         const body = {
           type: 'shortcut',
           callback_id: 'deploy-release',
-          trigger_id: 'payload id'
+          trigger_id: 'payload id',
         };
         const res = await server.inject({
           method: 'POST',
@@ -85,10 +90,8 @@ describe('Acceptance | Run | Slack', function() {
         expect(slackCall.isDone()).to.be.true;
       });
 
-      describe('with the callback release-tag-selection', function() {
-
+      describe('with the callback release-tag-selection', function () {
         it('returns the confirmation modal', async function () {
-
           nockGithubWithNoConfigChanges();
 
           const body = {
@@ -136,7 +139,7 @@ describe('Acceptance | Run | Slack', function() {
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
+                    text: "Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?",
                   },
                 },
               ],
@@ -192,14 +195,14 @@ describe('Acceptance | Run | Slack', function() {
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: ':warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d\'environnement sont bien à jour sur *Scalingo PRODUCTION*.'
-                  }
+                    text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo PRODUCTION*.",
+                  },
                 },
                 {
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: 'Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s\'agit d\'une opération critique. Êtes-vous sûr de vous ?',
+                    text: "Vous vous apprêtez à déployer la version *v2.130.0* en production. Il s'agit d'une opération critique. Êtes-vous sûr de vous ?",
                   },
                 },
               ],
@@ -208,7 +211,7 @@ describe('Acceptance | Run | Slack', function() {
         });
       });
 
-      describe('callback release-deployment-confirmation', function() {
+      describe('callback release-deployment-confirmation', function () {
         it('deploy the app', async function () {
           const body = {
             type: 'view_submission',
@@ -225,7 +228,7 @@ describe('Acceptance | Run | Slack', function() {
           });
           expect(res.statusCode).to.equal(200);
           expect(JSON.parse(res.payload)).to.deep.equal({
-            response_action: 'clear'
+            response_action: 'clear',
           });
         });
       });

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -17,22 +17,22 @@ const scriptName = 'publish.sh';
 // git clone --bare https://github.com/1024pix/pix-bot-publish-test data/clean_repository.git
 // Make sure that empty folders on the bare git repostory have a .gitkeep file
 // Have a nice day
-describe('Acceptance | Scripts | publish.sh', function() {
+describe('Acceptance | Scripts | publish.sh', function () {
   this.timeout(30000);
   let testRepositoryPath;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     const originRepositoryPath = path.join(__dirname, 'data', 'clean_repository.git');
     testRepositoryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'clean-repository'));
 
     await fs.copy(originRepositoryPath, testRepositoryPath);
   });
 
-  afterEach(async () => {
+  afterEach(async function () {
     await fs.rm(testRepositoryPath, { force: true, recursive: true });
   });
 
-  it('Update package version, generate changelog, commit, tag and push', async () => {
+  it('Update package version, generate changelog, commit, tag and push', async function () {
     // given
     const branchName = 'dev';
     const versionType = 'minor';
@@ -49,7 +49,11 @@ describe('Acceptance | Scripts | publish.sh', function() {
     };
 
     // when
-    const { stdout, stderr } = await runScriptWithArgument(scriptName, [versionType, 'file://' +testRepositoryPath, branchName], { env });
+    const { stdout, stderr } = await runScriptWithArgument(
+      scriptName,
+      [versionType, 'file://' + testRepositoryPath, branchName],
+      { env }
+    );
 
     // then
     const expectedStdout = [
@@ -78,13 +82,7 @@ describe('Acceptance | Scripts | publish.sh', function() {
       'v0.2.0',
       '',
     ];
-    const expectedStderr = [
-      /^Cloning into/,
-      /To (.+)/,
-      /dev -> dev/,
-      /v0.2.0 -> v0.2.0/,
-      ''
-    ];
+    const expectedStderr = [/^Cloning into/, /To (.+)/, /dev -> dev/, /v0.2.0 -> v0.2.0/, ''];
     expectLines(expectedStdout, stdout);
     expectLines(expectedStderr, stderr);
     const git = simpleGit(testRepositoryPath);

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -16,22 +16,22 @@ const scriptName = 'release-pix-repo.sh';
 // git clone --bare https://github.com/1024pix/pix-bot-publish-test data/clean_repository.git
 // Make sure that empty folders on the bare git repostory have a .gitkeep file
 // Have a nice day
-describe('Acceptance | Scripts | release-pix-repo.sh', function() {
+describe('Acceptance | Scripts | release-pix-repo.sh', function () {
   this.timeout(30000);
   let testRepositoryPath;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     const originRepositoryPath = path.join(__dirname, 'data', 'clean_repository.git');
     testRepositoryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'clean-repository'));
 
     await fs.copy(originRepositoryPath, testRepositoryPath);
   });
 
-  afterEach(async () => {
+  afterEach(async function () {
     await fs.rm(testRepositoryPath, { force: true, recursive: true });
   });
 
-  it('Update package version, generate changelog, commit, tag and push', async () => {
+  it('Update package version, generate changelog, commit, tag and push', async function () {
     // given
     const branchName = 'dev';
     const versionType = 'minor';
@@ -46,7 +46,11 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
     };
 
     // when
-    const { stdout, stderr } = await runScriptWithArgument(scriptName, [githubOwner, githubRepository, versionType, branchName, 'file://'+ testRepositoryPath], { env });
+    const { stdout, stderr } = await runScriptWithArgument(
+      scriptName,
+      [githubOwner, githubRepository, versionType, branchName, 'file://' + testRepositoryPath],
+      { env }
+    );
 
     // then
     const expectedStdout = [
@@ -74,13 +78,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function() {
       'Release publication for 1024pix/pix-bot-publish-test \x1B[1;32msucceeded\x1B[0m (minor).',
       '',
     ];
-    const expectedStderr = [
-      /^Cloning into/,
-      /To (.+)/,
-      /dev -> dev/,
-      /v0.2.0 -> v0.2.0/,
-      ''
-    ];
+    const expectedStderr = [/^Cloning into/, /To (.+)/, /dev -> dev/, /v0.2.0 -> v0.2.0/, ''];
     expectLines(expectedStdout, stdout);
     expectLines(expectedStderr, stderr);
     const git = simpleGit(testRepositoryPath);

--- a/test/acceptance/scripts/script-helpers.js
+++ b/test/acceptance/scripts/script-helpers.js
@@ -3,9 +3,9 @@ const path = require('path');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-async function runScriptWithArgument (scriptFileName, args=[], options={}) {
+async function runScriptWithArgument(scriptFileName, args = [], options = {}) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
-  const {stdout, stderr} = await exec(`${path.join(scriptsDirectory, scriptFileName)} ${args.join(' ')}`, options);
+  const { stdout, stderr } = await exec(`${path.join(scriptsDirectory, scriptFileName)} ${args.join(' ')}`, options);
   return { stdout: stdout.split('\n'), stderr: stderr.split('\n') };
 }
 

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -10,7 +10,7 @@ describe('Integration | Build | Scalingo', function () {
 
   describe('POST /build/scalingo/deploy-endpoint', function () {
     describe('when scalingo build status is "build-error" ', () => {
-      it('should send slack message and return 200', async () => {
+      it('should send slack message and return 200', async function () {
         // Given
         const body = {
           app_name: 'pix-github-actions-test',
@@ -50,7 +50,7 @@ describe('Integration | Build | Scalingo', function () {
                 fields: [
                   {
                     type: 'mrkdwn',
-                    text: '*Deployment failed*\nWith status \'build-error\'',
+                    text: "*Deployment failed*\nWith status 'build-error'",
                   },
                   {
                     type: 'mrkdwn',
@@ -86,7 +86,7 @@ describe('Integration | Build | Scalingo', function () {
     });
 
     describe('when scalingo build status is not "build-error" ', () => {
-      it('should not send slack message and return 200', async () => {
+      it('should not send slack message and return 200', async function () {
         // Given
         const body = {
           app_name: 'pix-github-actions-test',

--- a/test/integration/common/services/releases_test.js
+++ b/test/integration/common/services/releases_test.js
@@ -2,10 +2,9 @@ const { describe, it } = require('mocha');
 const { expect } = require('chai');
 const releasesService = require('../../../../common/services/releases');
 
-describe('releases', function() {
-
-  describe('#_runScriptWithArgument', async function() {
-    it('should execute and return last line of script output', async function() {
+describe('releases', function () {
+  describe('#_runScriptWithArgument', function () {
+    it('should execute and return last line of script output', async function () {
       // when
       const lastLine = await releasesService._runScriptWithArgument('dummy-script.sh');
 
@@ -14,5 +13,3 @@ describe('releases', function() {
     });
   });
 });
-
-

--- a/test/integration/run/controllers/applications_test.js
+++ b/test/integration/run/controllers/applications_test.js
@@ -11,7 +11,10 @@ describe('Integration | Run | Applications', () => {
       const badApiKey = 'bad-api-key';
 
       // when
-      const response = await server.inject({ method: 'POST', url: `/applications/test/cdn-cache-invalidations?apiKey=${badApiKey}` });
+      const response = await server.inject({
+        method: 'POST',
+        url: `/applications/test/cdn-cache-invalidations?apiKey=${badApiKey}`,
+      });
 
       // then
       expect(response.statusCode).to.equal(401);
@@ -26,7 +29,10 @@ describe('Integration | Run | Applications', () => {
         sinon.stub(axios, 'post').resolves();
 
         // when
-        const response = await server.inject({ method: 'POST', url: `/applications/Pix_Test/cdn-cache-invalidations?apiKey=${apiKey}` });
+        const response = await server.inject({
+          method: 'POST',
+          url: `/applications/Pix_Test/cdn-cache-invalidations?apiKey=${apiKey}`,
+        });
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -34,7 +40,7 @@ describe('Integration | Run | Applications', () => {
     });
 
     describe('Fail case', () => {
-      context('When application not have equivalent in namespace', () => {
+      context('When application not have equivalent in namespace', function () {
         it('should return a HTTP response with status code 400', async () => {
           // given
           const apiKey = config.openApi.authorizationToken;
@@ -44,7 +50,10 @@ describe('Integration | Run | Applications', () => {
           sinon.stub(axios, 'post').resolves();
 
           // when
-          const response = await server.inject({ method: 'POST', url: `/applications/${application}/cdn-cache-invalidations?apiKey=${apiKey}` });
+          const response = await server.inject({
+            method: 'POST',
+            url: `/applications/${application}/cdn-cache-invalidations?apiKey=${apiKey}`,
+          });
 
           // then
           expect(response.statusCode).to.equal(400);

--- a/test/integration/run/services/cdn_test.js
+++ b/test/integration/run/services/cdn_test.js
@@ -9,14 +9,14 @@ function _stubAccountDetails(namespace) {
     reqheaders: {
       'X-Api-Key': config.baleen.pat,
       'Content-type': 'application/json',
-    }
+    },
   })
     .get('/account')
     .reply(200, {
-      namespaces : {
+      namespaces: {
         'namespace-key2': 'Test2',
         'namespace-key1': namespace,
-      }
+      },
     });
 }
 
@@ -25,10 +25,10 @@ function _stubInvalidationCachePost(namespaceKey) {
     reqheaders: {
       'X-Api-Key': config.baleen.pat,
       'Content-type': 'application/json',
-      'Cookie': `baleen-namespace=${namespaceKey}`
-    }
+      Cookie: `baleen-namespace=${namespaceKey}`,
+    },
   })
-    .post('/cache/invalidations', { patterns: ['.']})
+    .post('/cache/invalidations', { patterns: ['.'] })
     .reply(200);
 }
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -140,6 +140,7 @@ function nockGithubWithConfigChanges() {
     .reply(200, [{}]);
 }
 
+// eslint-disable-next-line mocha/no-exports
 module.exports = {
   catchErr,
   expect,

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -7,7 +7,7 @@ const config = require('../config');
 
 chai.use(require('sinon-chai'));
 
-beforeEach(() => {
+beforeEach(function () {
   nock.disableNetConnect();
 });
 
@@ -32,7 +32,7 @@ function createGithubWebhookSignatureHeader(body) {
   hmac.update(body);
 
   return {
-    'x-hub-signature-256': 'sha256='+ hmac.digest('hex'),
+    'x-hub-signature-256': 'sha256=' + hmac.digest('hex'),
   };
 }
 
@@ -43,8 +43,8 @@ function createSlackWebhookSignatureHeaders(body) {
   hmac.update(`${version}:${timestamp}:${body}`);
 
   return {
-    'x-slack-signature': version +'='+ hmac.digest('hex'),
-    'x-slack-request-timestamp': timestamp
+    'x-slack-signature': version + '=' + hmac.digest('hex'),
+    'x-slack-request-timestamp': timestamp,
   };
 }
 
@@ -54,39 +54,42 @@ function nockGithubWithNoConfigChanges() {
     .twice()
     .reply(200, [
       {
-        'commit': {
-          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+        commit: {
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
         },
       },
       {
-        'commit': {
-          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/456',
+        commit: {
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/456',
         },
-      }
+      },
     ]);
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/1234')
     .reply(200, {
       commit: {
-        'committer': {
-          'date': '2021-04-14T12:40:50.326Z'
+        committer: {
+          date: '2021-04-14T12:40:50.326Z',
         },
-      }
+      },
     });
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/456')
     .reply(200, {
       commit: {
-        'committer': {
-          'date': '2021-04-10T12:40:50.326Z'
+        committer: {
+          date: '2021-04-10T12:40:50.326Z',
         },
-      }
+      },
     });
 
   nock('https://api.github.com')
-    .filteringPath(/since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g, 'since=XXXX&until=XXXX')
+    .filteringPath(
+      /since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g,
+      'since=XXXX&until=XXXX'
+    )
     .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, []);
 }
@@ -97,39 +100,42 @@ function nockGithubWithConfigChanges() {
     .twice()
     .reply(200, [
       {
-        'commit': {
-          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
+        commit: {
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/1234',
         },
       },
       {
-        'commit': {
-          'url': 'https://api.github.com/repos/github-owner/github-repository/commits/456',
+        commit: {
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/456',
         },
-      }
+      },
     ]);
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/1234')
     .reply(200, {
       commit: {
-        'committer': {
-          'date': '2021-04-14T12:40:50.326Z'
+        committer: {
+          date: '2021-04-14T12:40:50.326Z',
         },
-      }
+      },
     });
 
   nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/456')
     .reply(200, {
       commit: {
-        'committer': {
-          'date': '2021-04-10T12:40:50.326Z'
+        committer: {
+          date: '2021-04-10T12:40:50.326Z',
         },
-      }
+      },
     });
 
   nock('https://api.github.com')
-    .filteringPath(/since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g, 'since=XXXX&until=XXXX')
+    .filteringPath(
+      /since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g,
+      'since=XXXX&until=XXXX'
+    )
     .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, [{}]);
 }

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -3,33 +3,43 @@ const { expect } = require('chai');
 const { nock, createGithubWebhookSignatureHeader, sinon } = require('../../../test-helper');
 const githubService = require('../../../../common/services/github');
 
-describe('#getPullRequests', function() {
-
-  it('should return the response for slack', async function() {
+describe('#getPullRequests', function () {
+  it('should return the response for slack', async function () {
     // given
     const items = [
-      { html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [ { name: 'team certif'} ]},
-      { html_url: 'http://test2.fr', number: 1, title: 'PR2', labels: [ { name: ':construction: toto'}, { name: ':idea: team certif'}] },
+      { html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [{ name: 'team certif' }] },
+      {
+        html_url: 'http://test2.fr',
+        number: 1,
+        title: 'PR2',
+        labels: [{ name: ':construction: toto' }, { name: ':idea: team certif' }],
+      },
     ];
 
     nock('https://api.github.com')
-      .get('/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3Ateam-certif&sort=updated&order=desc')
-      .reply(200, {items});
+      .get(
+        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3Ateam-certif&sort=updated&order=desc'
+      )
+      .reply(200, { items });
 
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/pulls/0/reviews')
-      .reply(200, [{state: 'COMMENTED'}, {state: 'APPROVED'}]);
+      .reply(200, [{ state: 'COMMENTED' }, { state: 'APPROVED' }]);
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/pulls/1/reviews')
-      .reply(200, [{state: 'CHANGES_REQUESTED'}]);
+      .reply(200, [{ state: 'CHANGES_REQUESTED' }]);
 
     const expectedResponse = {
       response_type: 'in_channel',
       text: 'PRs à review pour team-certif',
       attachments: [
         { color: '#B7CEF5', pretext: '', fields: [{ value: '💬x1 ✅x1 | <http://test1.fr|PR1>', short: false }] },
-        { color: '#B7CEF5', pretext: '', fields: [{ value: '❌x1 | :construction: :idea: | <http://test2.fr|PR2>', short: false }] },
-      ]
+        {
+          color: '#B7CEF5',
+          pretext: '',
+          fields: [{ value: '❌x1 | :construction: :idea: | <http://test2.fr|PR2>', short: false }],
+        },
+      ],
     };
 
     // when
@@ -39,15 +49,15 @@ describe('#getPullRequests', function() {
     expect(response).to.deep.equal(expectedResponse);
   });
 
-  it('should call the Github API with the label without space', async function() {
+  it('should call the Github API with the label without space', async function () {
     // given
     let scopePr, scopeReview;
-    const items = [
-      { html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [ { name: 'team certif'} ]},
-    ];
+    const items = [{ html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [{ name: 'team certif' }] }];
     scopePr = nock('https://api.github.com')
-      .get('/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3ATech%2520Review%2520Needed&sort=updated&order=desc')
-      .reply(200, {items});
+      .get(
+        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3ATech%2520Review%2520Needed&sort=updated&order=desc'
+      )
+      .reply(200, { items });
 
     scopeReview = nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/pulls/0/reviews')
@@ -60,19 +70,14 @@ describe('#getPullRequests', function() {
     expect(scopePr.isDone());
     expect(scopeReview.isDone());
   });
-
 });
 
 describe('#getLatestReleaseTag', () => {
-
   it('should call GitHub "Tags" API', async () => {
     // given
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/tags')
-      .reply(200, [
-        { 'name': 'v2.171.0', },
-        { 'name': 'v2.170.0', },
-      ]);
+      .reply(200, [{ name: 'v2.171.0' }, { name: 'v2.170.0' }]);
 
     // when
     const response = await githubService.getLatestReleaseTag();
@@ -85,10 +90,7 @@ describe('#getLatestReleaseTag', () => {
     // given
     nock('https://api.github.com')
       .get('/repos/github-owner/given-repository/tags')
-      .reply(200, [
-        { 'name': 'v2.171.0', },
-        { 'name': 'v2.170.0', },
-      ]);
+      .reply(200, [{ name: 'v2.171.0' }, { name: 'v2.170.0' }]);
 
     // when
     const response = await githubService.getLatestReleaseTag('given-repository');
@@ -96,11 +98,9 @@ describe('#getLatestReleaseTag', () => {
     // then
     expect(response).to.equal('v2.171.0');
   });
-
 });
 
 describe('#getChangelogSinceLatestRelease', () => {
-
   it('should return the list of PR titles since latest release', async () => {
     // given
     const latestTagDate = new Date('2020-04-01T15:29:51Z');
@@ -112,16 +112,16 @@ describe('#getChangelogSinceLatestRelease', () => {
     nock('https://api.github.com')
       .get(`/repos/${repoOwner}/${repoName}/tags`)
       .reply(200, [
-        {commit: {url: '/latest_tag_commit_url'},},
-        {commit: {url: '/some_tag_commit_url'},},
-        {commit: {url: '/some_other_tag_commit_url'},},
+        { commit: { url: '/latest_tag_commit_url' } },
+        { commit: { url: '/some_tag_commit_url' } },
+        { commit: { url: '/some_other_tag_commit_url' } },
       ]);
     nock('https://api.github.com')
       .get('/latest_tag_commit_url')
-      .reply(200, {commit: {committer: {date: latestTagDate}}});
+      .reply(200, { commit: { committer: { date: latestTagDate } } });
     nock('https://api.github.com')
       .get(`/repos/${repoOwner}/${repoName}`)
-      .reply(200, {default_branch: 'my_default_branch'});
+      .reply(200, { default_branch: 'my_default_branch' });
     nock('https://api.github.com')
       .get(`/repos/${repoOwner}/${repoName}/pulls`)
       .query({
@@ -132,9 +132,9 @@ describe('#getChangelogSinceLatestRelease', () => {
         per_page: 100,
       })
       .reply(200, [
-        {merged_at: afterTag1Date, title: 'PR Protéines'},
-        {merged_at: afterTag2Date, title: 'PR Légumes'},
-        {merged_at: beforeTagDate, title: 'PR Fruit'},
+        { merged_at: afterTag1Date, title: 'PR Protéines' },
+        { merged_at: afterTag2Date, title: 'PR Légumes' },
+        { merged_at: beforeTagDate, title: 'PR Fruit' },
       ]);
 
     // when
@@ -143,26 +143,22 @@ describe('#getChangelogSinceLatestRelease', () => {
     // then
     expect(response).to.deep.equal(['PR Protéines', 'PR Légumes']);
   });
-
 });
 
 describe('#getMergedPullRequestsSortedByDescendingDate', () => {
-
   it('should call GitHub "Pulls" API', async () => {
     // given
-    const pullRequests = [
-      { merged_at: '2020-09-02T12:26:47Z' },
-      { merged_at: '2020-09-01T12:26:47Z' }
-    ];
-    nock('https://api.github.com')
-      .get('/repos/github-owner/github-repository')
-      .reply(200, { default_branch: 'dev' });
+    const pullRequests = [{ merged_at: '2020-09-02T12:26:47Z' }, { merged_at: '2020-09-01T12:26:47Z' }];
+    nock('https://api.github.com').get('/repos/github-owner/github-repository').reply(200, { default_branch: 'dev' });
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc&base=dev&per_page=100')
       .reply(200, pullRequests);
 
     // when
-    const response = await githubService.getMergedPullRequestsSortedByDescendingDate('github-owner', 'github-repository');
+    const response = await githubService.getMergedPullRequestsSortedByDescendingDate(
+      'github-owner',
+      'github-repository'
+    );
 
     // then
     expect(response).to.deep.equal(pullRequests);
@@ -170,44 +166,41 @@ describe('#getMergedPullRequestsSortedByDescendingDate', () => {
 
   it('should call GitHub "Pulls" API with given branch name', async () => {
     // given
-    const pullRequests = [
-      { merged_at: '2020-09-02T12:26:47Z' },
-      { merged_at: '2020-09-01T12:26:47Z' }
-    ];
+    const pullRequests = [{ merged_at: '2020-09-02T12:26:47Z' }, { merged_at: '2020-09-01T12:26:47Z' }];
     nock('https://api.github.com')
-      .get('/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc&base=toto&per_page=100')
+      .get(
+        '/repos/github-owner/github-repository/pulls?state=closed&sort=updated&direction=desc&base=toto&per_page=100'
+      )
       .reply(200, pullRequests);
 
     // when
-    const response = await githubService.getMergedPullRequestsSortedByDescendingDate('github-owner', 'github-repository', 'toto');
+    const response = await githubService.getMergedPullRequestsSortedByDescendingDate(
+      'github-owner',
+      'github-repository',
+      'toto'
+    );
 
     // then
     expect(response).to.deep.equal(pullRequests);
   });
-
 });
 
 describe('#getCommitAtURL', () => {
-
   it('should call Github "Request" API', async () => {
     // given
-    nock('https://commit-url.github.com')
-      .get('/')
-      .reply(200, {
-        commit: 'some data'
-      });
+    nock('https://commit-url.github.com').get('/').reply(200, {
+      commit: 'some data',
+    });
 
     // when
     const response = await githubService.getCommitAtURL('https://commit-url.github.com');
 
     // then
     expect(response).to.deep.equal('some data');
-
   });
 });
 
 describe('#isBuildStatusOK', () => {
-
   it('should call Github "branches" API', async () => {
     // given
     const branchName = 'branch-name';
@@ -215,13 +208,13 @@ describe('#isBuildStatusOK', () => {
       .get(`/repos/github-owner/github-repository/branches/${branchName}`)
       .reply(200, {
         commit: {
-          url: 'https://api.github.com/repos/github-owner/github-repository/commits/commitSHA1'
-        }
+          url: 'https://api.github.com/repos/github-owner/github-repository/commits/commitSHA1',
+        },
       });
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/commits/commitSHA1/check-runs')
       .reply(200, {
-        'check_runs': [{ name: 'build-test-and-deploy', status: 'completed', conclusion: 'success' }]
+        check_runs: [{ name: 'build-test-and-deploy', status: 'completed', conclusion: 'success' }],
       });
 
     // when
@@ -229,7 +222,6 @@ describe('#isBuildStatusOK', () => {
 
     // then
     expect(response).to.equal(true);
-
   });
 
   it('should call Github "tags" API', async () => {
@@ -237,21 +229,24 @@ describe('#isBuildStatusOK', () => {
     const tagName = 'v1.0.9';
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/tags')
-      .reply(200, [{
-        name: 'v1.0.10',
-        commit: {
-          url: 'https://api.github.com/repos/github-owner/github-repository/commits/v1.0.10SHA1'
+      .reply(200, [
+        {
+          name: 'v1.0.10',
+          commit: {
+            url: 'https://api.github.com/repos/github-owner/github-repository/commits/v1.0.10SHA1',
+          },
         },
-      }, {
-        name: 'v1.0.9',
-        commit: {
-          url: 'https://api.github.com/repos/github-owner/github-repository/commits/v1.0.9SHA1'
+        {
+          name: 'v1.0.9',
+          commit: {
+            url: 'https://api.github.com/repos/github-owner/github-repository/commits/v1.0.9SHA1',
+          },
         },
-      }]);
+      ]);
     nock('https://api.github.com')
       .get('/repos/github-owner/github-repository/commits/v1.0.9SHA1/check-runs')
       .reply(200, {
-        'check_runs': [{ name: 'build-test-and-deploy', status: 'completed', conclusion: 'success' }]
+        check_runs: [{ name: 'build-test-and-deploy', status: 'completed', conclusion: 'success' }],
       });
 
     // when
@@ -263,40 +258,40 @@ describe('#isBuildStatusOK', () => {
 });
 
 describe('#hasConfigFileChangedSinceLatestRelease', () => {
-  const latestReleaseDate= '2020-08-13T04:45:06Z';
+  const latestReleaseDate = '2020-08-13T04:45:06Z';
   const repoOwner = 'github-owner';
   const repoName = 'github-repository';
 
   let clock, now;
 
-  beforeEach(() => {
+  beforeEach(function () {
     now = new Date();
     clock = sinon.useFakeTimers(now);
   });
 
-  afterEach(() => {
+  afterEach(function () {
     clock.restore();
   });
 
-  context('should return true when config file has been changed', ()=> {
+  context('should return true when config file has been changed', function () {
     it('should call Github "commits list" API', async () => {
       // given
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: latestReleaseDate, until: now.toISOString(), path: 'api/lib/config.js' })
-        .reply(200,
-          [{
+        .reply(200, [
+          {
             sha: '5ec2f42',
-          }]
-        );
+          },
+        ]);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
-        .reply(200, [{commit: {url: '/latest_tag_commit_url',},}]);
+        .reply(200, [{ commit: { url: '/latest_tag_commit_url' } }]);
 
       nock('https://api.github.com')
         .get('/latest_tag_commit_url')
-        .reply(200, {commit: {committer: {date: latestReleaseDate}}});
+        .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       // when
       const response = await githubService.hasConfigFileChangedSinceLatestRelease(repoOwner, repoName);
@@ -305,23 +300,21 @@ describe('#hasConfigFileChangedSinceLatestRelease', () => {
     });
   });
 
-  context('should return false when config file did not changed changed', ()=> {
+  context('should return false when config file did not changed changed', function () {
     it('should call Github "commits list" API', async () => {
       // given
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: latestReleaseDate, until: now.toISOString(), path: 'api/lib/config.js' })
-        .reply(200,
-          []
-        );
+        .reply(200, []);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
-        .reply(200, [{commit: {url: '/latest_tag_commit_url',},}]);
+        .reply(200, [{ commit: { url: '/latest_tag_commit_url' } }]);
 
       nock('https://api.github.com')
         .get('/latest_tag_commit_url')
-        .reply(200, {commit: {committer: {date: latestReleaseDate}}});
+        .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       // when
       const response = await githubService.hasConfigFileChangedSinceLatestRelease(repoOwner, repoName);
@@ -332,22 +325,22 @@ describe('#hasConfigFileChangedSinceLatestRelease', () => {
 });
 
 describe('#hasConfigFileChangedInLatestRelease', () => {
-  const latestReleaseDate= '2020-08-13T04:45:06Z';
+  const latestReleaseDate = '2020-08-13T04:45:06Z';
   const secondToLastReleaseDate = '2020-08-10T12:45:06Z';
   const repoOwner = 'github-owner';
   const repoName = 'github-repository';
 
-  context('should return true when config file has been changed', ()=> {
+  context('should return true when config file has been changed', function () {
     it('should call Github "commits list" API', async () => {
       // given
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: secondToLastReleaseDate, until: latestReleaseDate, path: 'api/lib/config.js' })
-        .reply(200,
-          [{
+        .reply(200, [
+          {
             sha: '5ec2f42',
-          }]
-        );
+          },
+        ]);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -359,11 +352,11 @@ describe('#hasConfigFileChangedInLatestRelease', () => {
 
       nock('https://api.github.com')
         .get('/latest_tag_commit_url')
-        .reply(200, {commit: {committer: {date: latestReleaseDate}}});
+        .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       nock('https://api.github.com')
         .get('/second-to-last_tag_commit_url')
-        .reply(200, {commit: {committer: {date: secondToLastReleaseDate}}});
+        .reply(200, { commit: { committer: { date: secondToLastReleaseDate } } });
 
       // when
       const response = await githubService.hasConfigFileChangedInLatestRelease(repoOwner, repoName);
@@ -372,15 +365,13 @@ describe('#hasConfigFileChangedInLatestRelease', () => {
     });
   });
 
-  context('should return false when config file did not changed changed', ()=> {
+  context('should return false when config file did not changed changed', function () {
     it('should call Github "commits list" API', async () => {
       // given
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: secondToLastReleaseDate, until: latestReleaseDate, path: 'api/lib/config.js' })
-        .reply(200,
-          []
-        );
+        .reply(200, []);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -392,11 +383,11 @@ describe('#hasConfigFileChangedInLatestRelease', () => {
 
       nock('https://api.github.com')
         .get('/latest_tag_commit_url')
-        .reply(200, {commit: {committer: {date: latestReleaseDate}}});
+        .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       nock('https://api.github.com')
         .get('/second-to-last_tag_commit_url')
-        .reply(200, {commit: {committer: {date: secondToLastReleaseDate}}});
+        .reply(200, { commit: { committer: { date: secondToLastReleaseDate } } });
 
       // when
       const response = await githubService.hasConfigFileChangedInLatestRelease(repoOwner, repoName);
@@ -406,8 +397,8 @@ describe('#hasConfigFileChangedInLatestRelease', () => {
   });
 });
 
-describe('#verifyWebhookSignature', function() {
-  it('return true when the signature match', function() {
+describe('#verifyWebhookSignature', function () {
+  it('return true when the signature match', function () {
     const body = {};
     const request = {
       headers: createGithubWebhookSignatureHeader(JSON.stringify(body)),
@@ -416,17 +407,19 @@ describe('#verifyWebhookSignature', function() {
     expect(githubService.verifyWebhookSignature(request)).to.be.true;
   });
 
-  it('return error when the signature dont match', function() {
+  it('return error when the signature dont match', function () {
     const body = {};
     const request = {
       headers: { 'x-hub-signature-256': 'sha256=test' },
       payload: body,
     };
 
-    expect(githubService.verifyWebhookSignature(request).output.payload.message).to.eql('Github signature verification failed. Signature mismatch.');
+    expect(githubService.verifyWebhookSignature(request).output.payload.message).to.eql(
+      'Github signature verification failed. Signature mismatch.'
+    );
   });
 
-  it('return error when not signature is present', function() {
+  it('return error when not signature is present', function () {
     const body = {};
     const request = {
       headers: {},

--- a/test/unit/build/services/google-sheet_test.js
+++ b/test/unit/build/services/google-sheet_test.js
@@ -4,71 +4,63 @@ const { sinon } = require('../../../test-helper');
 const axios = require('axios');
 const googleSheet = require('../../../../build/services/google-sheet');
 
-describe('#getA11YTip', function() {
-  const data =
-        {
-          'range': 'tips!A1:E500',
-          'majorDimension': 'ROWS',
-          'values': [
-            [
-              'Titre',
-              'Sujet',
-              'Message',
-              'Lien',
-              'Tips Pix'
-            ],
-            [
-              'Traduire aussi le contenu masqué',
-              'Les langues',
-              'Il faut aussi penser à traduire : les attributs `alt`, les `aria-label`, les `title`, les `title` et `desc` des svg, etc.',
-              'https://www.accede-web.com/notices/html-css-javascript/3-langues/3-3-veiller-a-traduire-les-contenus-masques/'
-            ]
-          ]
-        }
-    ;
-  before(() => {
+describe('#getA11YTip', function () {
+  const data = {
+    range: 'tips!A1:E500',
+    majorDimension: 'ROWS',
+    values: [
+      ['Titre', 'Sujet', 'Message', 'Lien', 'Tips Pix'],
+      [
+        'Traduire aussi le contenu masqué',
+        'Les langues',
+        'Il faut aussi penser à traduire : les attributs `alt`, les `aria-label`, les `title`, les `title` et `desc` des svg, etc.',
+        'https://www.accede-web.com/notices/html-css-javascript/3-langues/3-3-veiller-a-traduire-les-contenus-masques/',
+      ],
+    ],
+  };
+  before(function () {
     sinon.stub(axios, 'get').resolves({ data });
   });
 
-  it('should return the response for slack', async function() {
+  it('should return the response for slack', async function () {
     // given
     const expectedResponse = {
       response_type: 'in_channel',
-      'blocks': [
+      blocks: [
         {
-          'type': 'divider'
+          type: 'divider',
         },
         {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': ':a11y: Tip A11Y :a11y:'
-          }
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: ':a11y: Tip A11Y :a11y:',
+          },
         },
         {
-          'type': 'divider'
+          type: 'divider',
         },
         {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': `:book: *${data.values[1][0].toUpperCase()}* :book: \n _${data.values[1][1]}_ `
-          }
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `:book: *${data.values[1][0].toUpperCase()}* :book: \n _${data.values[1][1]}_ `,
+          },
         },
         {
-          'type': 'divider'
+          type: 'divider',
         },
         {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': `${data.values[1][2]} \n :link: : ${data.values[1][3]} \n :pix_logo: : -`
-          }
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `${data.values[1][2]} \n :link: : ${data.values[1][3]} \n :pix_logo: : -`,
+          },
         },
         {
-          'type': 'divider'
-        }
-      ]
+          type: 'divider',
+        },
+      ],
     };
     // when
     const response = await googleSheet.getA11YTip('team-certif');
@@ -76,5 +68,4 @@ describe('#getA11YTip', function() {
     // then
     expect(response).to.deep.equal(expectedResponse);
   });
-
 });

--- a/test/unit/common/models/Manifest_test.js
+++ b/test/unit/common/models/Manifest_test.js
@@ -2,11 +2,9 @@ const { expect } = require('../../../test-helper');
 
 const { Manifest } = require('../../../../common/models/Manifest');
 
-describe('Unit | Common | Models | Manifest', () => {
-
-  describe('#constructor', () => {
-
-    it('should create an instance of manifest', () => {
+describe('Unit | Common | Models | Manifest', function () {
+  describe('#constructor', function () {
+    it('should create an instance of manifest', function () {
       // given
       const manifest = new Manifest('Pix Bot: The return');
 
@@ -18,8 +16,8 @@ describe('Unit | Common | Models | Manifest', () => {
     });
   });
 
-  describe('#registerSlashCommand', () => {
-    it('register a slash commands', () => {
+  describe('#registerSlashCommand', function () {
+    it('register a slash commands', function () {
       // given
       const manifest = new Manifest('Pix Bot: The return');
       const handler = () => {};
@@ -44,13 +42,13 @@ describe('Unit | Common | Models | Manifest', () => {
           usage_hint: 'this is a test',
           should_escape: false,
           handler,
-        }
+        },
       ]);
     });
   });
 
-  describe('#addInteractivity', () => {
-    it('add interactivity url', () => {
+  describe('#addInteractivity', function () {
+    it('add interactivity url', function () {
       // given
       const manifest = new Manifest('Pix Bot: The return');
       const handler = () => {};
@@ -58,25 +56,25 @@ describe('Unit | Common | Models | Manifest', () => {
       // when
       manifest.addInteractivity({
         path: '/test-url',
-        handler
+        handler,
       });
 
       // then
       expect(manifest.interactivity).to.eql({
         path: '/test-url',
-        handler
+        handler,
       });
     });
   });
 
-  describe('#getRoutes', () => {
+  describe('#getRoutes', function () {
     let manifest;
 
-    beforeEach(() => {
+    beforeEach(function () {
       manifest = new Manifest('Pix Bot: The return');
     });
 
-    it('returns the hapi routes for slash commands', () => {
+    it('returns the hapi routes for slash commands', function () {
       // given
       const handler = () => {};
 
@@ -97,11 +95,11 @@ describe('Unit | Common | Models | Manifest', () => {
           method: 'POST',
           path: '/command/test',
           handler,
-        }
+        },
       ]);
     });
 
-    it('returns the hapi routes for interactivity', () => {
+    it('returns the hapi routes for interactivity', function () {
       // given
       const handler = () => {};
 
@@ -118,11 +116,11 @@ describe('Unit | Common | Models | Manifest', () => {
           method: 'POST',
           path: '/command/interactivity',
           handler,
-        }
+        },
       ]);
     });
 
-    it('returns the hapi routes for slash commands and interactivity', () => {
+    it('returns the hapi routes for slash commands and interactivity', function () {
       // given
       const handler = () => {};
 
@@ -145,8 +143,8 @@ describe('Unit | Common | Models | Manifest', () => {
     });
   });
 
-  describe('#registerShortcut', () => {
-    it('register a shortcut', () => {
+  describe('#registerShortcut', function () {
+    it('register a shortcut', function () {
       // given
       const manifest = new Manifest('Pix Bot: The return');
       // when
@@ -154,7 +152,7 @@ describe('Unit | Common | Models | Manifest', () => {
         name: 'Test shortcut',
         type: 'global',
         callback_id: 'test-shortcut',
-        description: 'Test description'
+        description: 'Test description',
       });
 
       // then
@@ -164,8 +162,8 @@ describe('Unit | Common | Models | Manifest', () => {
           name: 'Test shortcut',
           type: 'global',
           callback_id: 'test-shortcut',
-          description: 'Test description'
-        }
+          description: 'Test description',
+        },
       ]);
     });
   });

--- a/test/unit/common/models/PartialChangeLogGenerator_test.js
+++ b/test/unit/common/models/PartialChangeLogGenerator_test.js
@@ -5,11 +5,9 @@ const PullRequest = require('../../../../common/models/PullRequest');
 const PullRequestGroup = require('../../../../common/models/PullRequestGroup');
 const PartialChangeLogGenerator = require('../../../../common/models/PartialChangeLogGenerator');
 
-describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
-
-  describe('#constructor', () => {
-
-    it('should create an instance of PartialChangeLogGenerator', () => {
+describe('Unit | Common | Models | PartialChangeLogGenerator', function () {
+  describe('#constructor', function () {
+    it('should create an instance of PartialChangeLogGenerator', function () {
       // given
       const headOfChangelogTitle = '## v3.99.0 (10/09/2021)';
       const pullRequestGroups = [
@@ -36,9 +34,8 @@ describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
     });
   });
 
-  describe('#grabPullRequestsByTag', () => {
-
-    it('should return an empty array if all Pull Requests are grabbed', () => {
+  describe('#grabPullRequestsByTag', function () {
+    it('should return an empty array if all Pull Requests are grabbed', function () {
       // given
       const featurePullRequestGroup = new PullRequestGroup({
         tagToGrab: Tag.FEATURE,
@@ -66,7 +63,7 @@ describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
       expect(result).to.an('array').that.is.empty;
     });
 
-    it('should return the initial Pull Request array if no Pull Request is grabbed', () => {
+    it('should return the initial Pull Request array if no Pull Request is grabbed', function () {
       // given
       const featurePullRequestGroup = new PullRequestGroup({
         tagToGrab: Tag.FEATURE,
@@ -94,7 +91,7 @@ describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
       expect(result).to.deep.equal(initialPullRequests);
     });
 
-    it('should return the initial Pull Request array minus all Pull Requests grabbed', () => {
+    it('should return the initial Pull Request array minus all Pull Requests grabbed', function () {
       // given
       const featurePullRequestGroup = new PullRequestGroup({
         tagToGrab: Tag.FEATURE,
@@ -126,9 +123,8 @@ describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
     });
   });
 
-  describe('#getLinesToDisplay', () => {
-
-    it('should return empty array if if no Pull Request is grabbed', () => {
+  describe('#getLinesToDisplay', function () {
+    it('should return empty array if if no Pull Request is grabbed', function () {
       // given
       const featurePullRequestGroup = new PullRequestGroup({
         tagToGrab: Tag.FEATURE,
@@ -152,7 +148,7 @@ describe('Unit | Common | Models | PartialChangeLogGenerator', () => {
       expect(result).to.an('array').that.is.empty;
     });
 
-    it('should return head of Changelog title and list of Pull Requests grabbed', () => {
+    it('should return head of Changelog title and list of Pull Requests grabbed', function () {
       // given
       const headOfChangelogTitle = '## v3.99.0 (10/09/2021)';
 

--- a/test/unit/common/models/PullRequestGroupFactory_test.js
+++ b/test/unit/common/models/PullRequestGroupFactory_test.js
@@ -5,11 +5,9 @@ const { Tag } = require('../../../../common/models/Tags');
 
 const PullRequestGroupFactory = require('../../../../common/models/PullRequestGroupFactory');
 
-describe('Unit | Common | Models | PullRequestGroupFactory', () => {
-
-  describe('#build', () => {
-
-    it('should return an array of Pull Request Groups', () => {
+describe('Unit | Common | Models | PullRequestGroupFactory', function () {
+  describe('#build', function () {
+    it('should return an array of Pull Request Groups', function () {
       // given
       const expectedPullRequestGroups = [
         new PullRequestGroup({
@@ -38,5 +36,4 @@ describe('Unit | Common | Models | PullRequestGroupFactory', () => {
       expect(result).to.deep.equal(expectedPullRequestGroups);
     });
   });
-
 });

--- a/test/unit/common/models/PullRequestGroup_test.js
+++ b/test/unit/common/models/PullRequestGroup_test.js
@@ -5,11 +5,9 @@ const { Tag } = require('../../../../common/models/Tags');
 
 const PullRequestGroup = require('../../../../common/models/PullRequestGroup');
 
-describe('Unit | Common | Models | PullRequestGroup', () => {
-
-  describe('#constructor', () => {
-
-    it('should not create an instance if parameter tag to grab is not valid', () => {
+describe('Unit | Common | Models | PullRequestGroup', function () {
+  describe('#constructor', function () {
+    it('should not create an instance if parameter tag to grab is not valid', function () {
       // given
       const wrongTag = 'wrongTag';
       const groupTitle = '### :bug: Correction';
@@ -21,7 +19,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       expect(instantiate).to.throw(TypeError);
     });
 
-    it('should create an instance if parameter tag is valid', () => {
+    it('should create an instance if parameter tag is valid', function () {
       // given
       const validTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -37,9 +35,8 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
     });
   });
 
-  describe('#grabPullRequestsByTag', () => {
-
-    it('should return the initial Pull Request array if no Pull Request is grabbed', () => {
+  describe('#grabPullRequestsByTag', function () {
+    it('should return the initial Pull Request array if no Pull Request is grabbed', function () {
       // given
       const featureTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -54,7 +51,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       expect(pullRequestGroup.grabbedPullRequests).to.an('array').that.is.empty;
     });
 
-    it('should return an empty array if all Pull Requests are grabbed', () => {
+    it('should return an empty array if all Pull Requests are grabbed', function () {
       // given
       const featureTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -62,7 +59,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
 
       const initialPullRequests = [
         new PullRequest({ title: '[FEATURE] PIX-1' }),
-        new PullRequest({ title: '[FEATURE] PIX-2' })
+        new PullRequest({ title: '[FEATURE] PIX-2' }),
       ];
 
       // when
@@ -73,7 +70,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       expect(pullRequestGroup.grabbedPullRequests).to.deep.equal(initialPullRequests);
     });
 
-    it('should return the initial Pull Requests array minus Pull Requests grabbed', () => {
+    it('should return the initial Pull Requests array minus Pull Requests grabbed', function () {
       // given
       const featureTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -95,9 +92,8 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
     });
   });
 
-  describe('#getLinesToDisplay', () => {
-
-    it('should return empty array if if no Pull Request is grabbed', () => {
+  describe('#getLinesToDisplay', function () {
+    it('should return empty array if if no Pull Request is grabbed', function () {
       // given
       const featureTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -110,7 +106,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       expect(result).to.an('array').that.is.empty;
     });
 
-    it('should return group title and list of Pull Requests grabbed', () => {
+    it('should return group title and list of Pull Requests grabbed', function () {
       // given
       const featureTag = Tag.FEATURE;
       const groupTitle = '### :rocket: Amélioration';
@@ -125,11 +121,7 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       const initialPullRequests = [featurePullRequest, techPullRequest];
       pullRequestGroup.grabPullRequestsByTag(initialPullRequests);
 
-      const expectedLinesToDisplay = [
-        groupTitle,
-        featurePullRequest.toString(),
-        '',
-      ];
+      const expectedLinesToDisplay = [groupTitle, featurePullRequest.toString(), ''];
 
       // when
       const result = pullRequestGroup.getLinesToDisplay();
@@ -138,5 +130,4 @@ describe('Unit | Common | Models | PullRequestGroup', () => {
       expect(result).to.deep.equal(expectedLinesToDisplay);
     });
   });
-
 });

--- a/test/unit/common/models/PullRequest_test.js
+++ b/test/unit/common/models/PullRequest_test.js
@@ -3,11 +3,9 @@ const { expect, sinon } = require('../../../test-helper');
 const { Tag, Tags } = require('../../../../common/models/Tags');
 const PullRequest = require('../../../../common/models/PullRequest');
 
-describe('Unit | Common | Models | PullRequest', () => {
-
-  describe('#constructor', () => {
-
-    it('should create an instance of PullRequest', () => {
+describe('Unit | Common | Models | PullRequest', function () {
+  describe('#constructor', function () {
+    it('should create an instance of PullRequest', function () {
       // given
       const properties = {
         html_url: 'url',
@@ -22,7 +20,7 @@ describe('Unit | Common | Models | PullRequest', () => {
       expect(createdInstance).to.be.an.instanceOf(PullRequest);
     });
 
-    it('should have title, number and htmlUrl properties', () => {
+    it('should have title, number and htmlUrl properties', function () {
       // given
       const properties = {
         html_url: 'url',
@@ -39,7 +37,7 @@ describe('Unit | Common | Models | PullRequest', () => {
       expect(createdInstance.title).to.equal(properties.title);
     });
 
-    it('should call Tag.getTagByTitle to set tag property', () => {
+    it('should call Tag.getTagByTitle to set tag property', function () {
       // given
       sinon.spy(Tags, 'getTagByTitle');
       const properties = {
@@ -55,7 +53,7 @@ describe('Unit | Common | Models | PullRequest', () => {
       expect(Tags.getTagByTitle).to.have.calledWith(properties.title);
     });
 
-    it('should have a tag property', () => {
+    it('should have a tag property', function () {
       // given
       const properties = {
         html_url: 'url',
@@ -71,9 +69,8 @@ describe('Unit | Common | Models | PullRequest', () => {
     });
   });
 
-  describe('#toString', () => {
-
-    it('should return a string with properties', () => {
+  describe('#toString', function () {
+    it('should return a string with properties', function () {
       // given
       const html_url = 'https://github.com/1024pix/pix/pull/2971';
       const number = 2971;

--- a/test/unit/common/models/Tags_test.js
+++ b/test/unit/common/models/Tags_test.js
@@ -2,15 +2,13 @@ const { expect } = require('../../../test-helper');
 
 const { Tag, Tags } = require('../../../../common/models/Tags');
 
-describe('Unit | Common | Models | Tags', () => {
-
-  describe('#getTagByTitle', () => {
-
+describe('Unit | Common | Models | Tags', function () {
+  describe('#getTagByTitle', function () {
     [
       {
         testTitle: 'Tag.BUGFIX if title include [BUGFIX]',
         pullRequestTitle: '[BUGFIX] Pull Request Title',
-        expectedTag: Symbol.for('bugfix')
+        expectedTag: Symbol.for('bugfix'),
       },
       {
         testTitle: 'Tag.FEATURE if title include [FEATURE]',
@@ -32,9 +30,8 @@ describe('Unit | Common | Models | Tags', () => {
         pullRequestTitle: '[TECH] Pull Request Title',
         expectedTag: Symbol.for('tech'),
       },
-
     ].forEach((testCase) => {
-      it(`should return ${testCase.testTitle}`, () => {
+      it(`should return ${testCase.testTitle}`, function () {
         // when
         const tag = Tags.getTagByTitle(testCase.pullRequestTitle);
 
@@ -44,9 +41,8 @@ describe('Unit | Common | Models | Tags', () => {
     });
   });
 
-  describe('#isValidTag', () => {
-
-    it('should return false if parameter is not a valid Tag', () => {
+  describe('#isValidTag', function () {
+    it('should return false if parameter is not a valid Tag', function () {
       // given
       const wrongTag = 'wrongTag';
 
@@ -57,7 +53,7 @@ describe('Unit | Common | Models | Tags', () => {
       expect(result).to.be.false;
     });
 
-    it('should return true if parameter is a valid Tag', () => {
+    it('should return true if parameter is a valid Tag', function () {
       // given
       const validTag = Tag.FEATURE;
 

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -12,19 +12,17 @@ const {
   orderPr,
 } = require('../../../../common/services/changelog');
 
-describe('Unit | Common | Services | Changelog', () => {
-
-  describe('#displayPullRequest', () => {
-
-
-    it('should return a line with correct format from correct PR name', () => {
+describe('Unit | Common | Services | Changelog', function () {
+  describe('#displayPullRequest', function () {
+    it('should return a line with correct format from correct PR name', function () {
       // given
       const pullRequest = {
         title: '[BUGFIX] Résolution du problème de surestimation du niveau (US-389).',
         number: 111,
-        html_url: 'http://git/111'
+        html_url: 'http://git/111',
       };
-      const expectedLine = '- [#111](http://git/111) [BUGFIX] Résolution du problème de surestimation du niveau (US-389).';
+      const expectedLine =
+        '- [#111](http://git/111) [BUGFIX] Résolution du problème de surestimation du niveau (US-389).';
 
       // when
       const result = displayPullRequest(pullRequest);
@@ -34,45 +32,51 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#filterPullRequest', () => {
-
-    it('should return only merged PR since last MEP', () => {
+  describe('#filterPullRequest', function () {
+    it('should return only merged PR since last MEP', function () {
       // given
       const date = '2019-01-18T15:29:51Z';
-      const pullRequests = [{
-        'id': 1,
-        'number': 315,
-        'state': 'closed',
-        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
-        'created_at': '2019-01-11T15:47:26Z',
-        'updated_at': '2019-01-23T13:37:47Z',
-        'closed_at': '2019-01-23T13:37:37Z',
-        'merged_at': '2019-01-23T13:37:37Z',
-        'assignee': null,
-        'milestone': null,
-      }, {
-        'id': 2,
-        'number': 316,
-        'state': 'closed',
-        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
-        'created_at': '2018-01-11T15:47:26Z',
-        'updated_at': '2018-01-23T13:37:47Z',
-        'closed_at': '2018-01-23T13:37:37Z',
-        'merged_at': '2018-01-23T13:37:37Z',
-        'assignee': null,
-        'milestone': null,
-      }, {
-        'id': 3,
-        'number': 317,
-        'state': 'closed',
-        'title': '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
-        'created_at': '2019-01-11T15:47:26Z',
-        'updated_at': '2019-01-23T13:37:47Z',
-        'closed_at': '2019-01-23T13:37:37Z',
-        'merged_at': null,
-        'assignee': null,
-        'milestone': null,
-      }];
+      const pullRequests = [
+        {
+          id: 1,
+          number: 315,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2019-01-11T15:47:26Z',
+          updated_at: '2019-01-23T13:37:47Z',
+          closed_at: '2019-01-23T13:37:37Z',
+          merged_at: '2019-01-23T13:37:37Z',
+          assignee: null,
+          milestone: null,
+        },
+        {
+          id: 2,
+          number: 316,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2018-01-11T15:47:26Z',
+          updated_at: '2018-01-23T13:37:47Z',
+          closed_at: '2018-01-23T13:37:37Z',
+          merged_at: '2018-01-23T13:37:37Z',
+          assignee: null,
+          milestone: null,
+        },
+        {
+          id: 3,
+          number: 317,
+          state: 'closed',
+          title:
+            '[BUGFIX] Retenter une compétence doit créer une nouvelle évaluation sur la compétence (et non en reprendre une ancienne) (PF-484).',
+          created_at: '2019-01-11T15:47:26Z',
+          updated_at: '2019-01-23T13:37:47Z',
+          closed_at: '2019-01-23T13:37:37Z',
+          merged_at: null,
+          assignee: null,
+          milestone: null,
+        },
+      ];
 
       // when
       const result = filterPullRequest(pullRequests, date);
@@ -83,9 +87,8 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getHeadOfChangelog', () => {
-
-    it('should return the head of changelog in correct value', () => {
+  describe('#getHeadOfChangelog', function () {
+    it('should return the head of changelog in correct value', function () {
       // given
       sinon.useFakeTimers();
       const headChangelog = '## v2.0.0 (01/01/1970)\n';
@@ -99,9 +102,8 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#orderPr', () => {
-
-    it('should order PR by type', () => {
+  describe('#orderPr', function () {
+    it('should order PR by type', function () {
       // given
       const pullRequests = [
         { title: '[BUGFIX] TEST' },
@@ -123,23 +125,28 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getTagReleaseDate', () => {
-
+  describe('#getTagReleaseDate', function () {
     const repoOwner = '1024pix';
     const repoName = 'pix';
     const tagName = 'v3.193.1';
 
-    beforeEach(() => {
-      sinon.stub(github, 'getLastCommitUrl')
+    beforeEach(function () {
+      sinon
+        .stub(github, 'getLastCommitUrl')
         .withArgs({ owner: repoOwner, repo: repoName, tagName })
-        .resolves(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`);
+        .resolves(
+          `https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`
+        );
 
-      sinon.stub(github, 'getCommitAtURL')
-        .withArgs(`https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`)
+      sinon
+        .stub(github, 'getCommitAtURL')
+        .withArgs(
+          `https://api.github.com/repos/${repoOwner}/${repoName}/commits/4c3ad3d377c37023e835ad674578cf06fcb4de7a`
+        )
         .resolves({ committer: { date: '2019-01-18T15:29:51Z' } });
     });
 
-    it('should return the date of the last MEP commit', async () => {
+    it('should return the date of the last MEP commit', async function () {
       // given
       const expectedDate = '2019-01-18T15:29:51Z';
 
@@ -151,26 +158,24 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#generateChangeLogContent', () => {
-
-    context('when changelog does not exist', () => {
-
-      it('should create it ', () => {
+  describe('#generateChangeLogContent', function () {
+    context('when changelog does not exist', function () {
+      it('should create it ', function () {
         // given
         const currentChangelogContent = [];
         const changes = [
           '## v3.55.0 (12/05/2021)',
           '',
-          '- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l\'utilisateur dans Pix Orga (PIX-2354).',
-          '- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l\'ajout de l\'index en base de donnée (PIX-2552).',
+          "- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l'utilisateur dans Pix Orga (PIX-2354).",
+          "- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l'ajout de l'index en base de donnée (PIX-2552).",
         ];
         const expectedChangelog = [
           '# PIX Changelog\n',
           '\n',
           '## v3.55.0 (12/05/2021)',
           '',
-          '- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l\'utilisateur dans Pix Orga (PIX-2354).',
-          '- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l\'ajout de l\'index en base de donnée (PIX-2552).',
+          "- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l'utilisateur dans Pix Orga (PIX-2354).",
+          "- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l'ajout de l'index en base de donnée (PIX-2552).",
         ];
 
         // when
@@ -181,9 +186,8 @@ describe('Unit | Common | Services | Changelog', () => {
       });
     });
 
-    context('when changelog exists', () => {
-
-      it('should update it ', () => {
+    context('when changelog exists', function () {
+      it('should update it ', function () {
         // given
         const currentChangelogContent = [
           '# PIX Changelog',
@@ -191,27 +195,27 @@ describe('Unit | Common | Services | Changelog', () => {
           '## v3.54.0 (11/05/2021)',
           '',
           '- [#2971](https://github.com/1024pix/pix/pull/2971) [FEATURE] Passer les sessions assignées comme sessions "à traiter" (PIX-2571)',
-          '- [#2972](https://github.com/1024pix/pix/pull/2972) [FEATURE] Affichage des macarons Pix+Droit sur le certificat utilisateur sur PixApp (PIX-2369)'
+          '- [#2972](https://github.com/1024pix/pix/pull/2972) [FEATURE] Affichage des macarons Pix+Droit sur le certificat utilisateur sur PixApp (PIX-2369)',
         ];
         const changes = [
           '## v3.55.0 (12/05/2021)',
           '',
-          '- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l\'utilisateur dans Pix Orga (PIX-2354).',
-          '- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l\'ajout de l\'index en base de donnée (PIX-2552).',
-          ''
+          "- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l'utilisateur dans Pix Orga (PIX-2354).",
+          "- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l'ajout de l'index en base de donnée (PIX-2552).",
+          '',
         ];
         const expectedChangelog = [
           '# PIX Changelog',
           '',
           '## v3.55.0 (12/05/2021)',
           '',
-          '- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l\'utilisateur dans Pix Orga (PIX-2354).',
-          '- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l\'ajout de l\'index en base de donnée (PIX-2552).',
+          "- [#2950](https://github.com/1024pix/pix/pull/2950) [FEATURE] Afficher les CGUs suivant la langue de l'utilisateur dans Pix Orga (PIX-2354).",
+          "- [#2988](https://github.com/1024pix/pix/pull/2988) [FEATURE] Ré-afficher les colonnes supprimées suite à l'ajout de l'index en base de donnée (PIX-2552).",
           '',
           '## v3.54.0 (11/05/2021)',
           '',
           '- [#2971](https://github.com/1024pix/pix/pull/2971) [FEATURE] Passer les sessions assignées comme sessions "à traiter" (PIX-2571)',
-          '- [#2972](https://github.com/1024pix/pix/pull/2972) [FEATURE] Affichage des macarons Pix+Droit sur le certificat utilisateur sur PixApp (PIX-2369)'
+          '- [#2972](https://github.com/1024pix/pix/pull/2972) [FEATURE] Affichage des macarons Pix+Droit sur le certificat utilisateur sur PixApp (PIX-2369)',
         ];
 
         // when
@@ -223,9 +227,8 @@ describe('Unit | Common | Services | Changelog', () => {
     });
   });
 
-  describe('#getNewChangeLogLines', () => {
-
-    it('should return head of Changelog title and corresponding lines of pull requests grouped by type', () => {
+  describe('#getNewChangeLogLines', function () {
+    it('should return head of Changelog title and corresponding lines of pull requests grouped by type', function () {
       // given
       const headOfChangelogTitle = '## v3.55.0 (12/05/2021)';
 
@@ -249,7 +252,7 @@ describe('Unit | Common | Services | Changelog', () => {
           html_url: 'https://github.com/foo/foo/pull/104',
           number: 104,
           title: 'Foo PIX-4',
-        }
+        },
       ];
 
       const expectedNewChangeLogLines = [

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -51,7 +51,7 @@ describe('releases', function () {
       expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK']);
     });
 
-    it('should trigger deployments of managed applications', async () => {
+    it('should throw an error when an application deployment fails', async () => {
       // given
       const scalingoClient = new ScalingoClient(null, 'production');
       scalingoClient.deployFromArchive = sinon.stub();

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -1,24 +1,24 @@
 const { describe, it } = require('mocha');
 const sinon = require('sinon');
-const proxyquire =  require('proxyquire');
+const proxyquire = require('proxyquire');
 const { expect } = require('chai');
 const ScalingoClient = require('../../../../common/services/scalingo-client');
 const github = require('../../../../common/services/github');
 
-describe('releases', function() {
+describe('releases', function () {
   let exec;
   let releasesService;
 
-  beforeEach(() => {
-    exec = sinon.stub().callsFake(async () => Promise.resolve({stdout: 'some heavy logs\n3.14.0\n', stderr: ''}));
+  beforeEach(function () {
+    exec = sinon.stub().callsFake(async () => Promise.resolve({ stdout: 'some heavy logs\n3.14.0\n', stderr: '' }));
     releasesService = proxyquire('../../../../common/services/releases', {
-      'child_process': {exec},
-      util: {promisify: fn => fn}
+      child_process: { exec },
+      util: { promisify: (fn) => fn },
     });
   });
 
-  describe('#deployPixRepo', async function() {
-    it('should deploy the pix site', async function() {
+  describe('#deployPixRepo', function () {
+    it('should deploy the pix site', async function () {
       // given
       const scalingoClient = new ScalingoClient(null, 'production');
       scalingoClient.deployFromArchive = sinon.stub();
@@ -33,7 +33,7 @@ describe('releases', function() {
     });
   });
 
-  describe('#deploy', async function () {
+  describe('#deploy', function () {
     it('should trigger deployments of managed applications', async () => {
       // given
       const scalingoClient = new ScalingoClient(null, 'production');
@@ -67,13 +67,18 @@ describe('releases', function() {
     });
   });
 
-  describe('#publish', async function () {
+  describe('#publish', function () {
     it('should call the publish script', async function () {
       //when
       await releasesService.publish('minor');
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/publish.sh minor https://undefined@github.com/github-owner/github-repository.git )$')));
+      sinon.assert.calledWith(
+        exec,
+        sinon.match(
+          new RegExp('.*(/scripts/publish.sh minor https://undefined@github.com/github-owner/github-repository.git )$')
+        )
+      );
     });
 
     it('should call the publish script with the branch name', async function () {
@@ -81,7 +86,14 @@ describe('releases', function() {
       await releasesService.publish('minor', 'hotfix');
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/publish.sh minor https://undefined@github.com/github-owner/github-repository.git hotfix)$')));
+      sinon.assert.calledWith(
+        exec,
+        sinon.match(
+          new RegExp(
+            '.*(/scripts/publish.sh minor https://undefined@github.com/github-owner/github-repository.git hotfix)$'
+          )
+        )
+      );
     });
 
     it('should retrieve new package version', async function () {
@@ -93,8 +105,8 @@ describe('releases', function() {
     });
   });
 
-  describe('#publishPixRepo', async function () {
-    it('should call the release pix script with \'minor\'', async function () {
+  describe('#publishPixRepo', function () {
+    it("should call the release pix script with 'minor'", async function () {
       // given
       sinon.stub(github, 'getDefaultBranch').resolves('dev');
 
@@ -102,8 +114,14 @@ describe('releases', function() {
       await releasesService.publishPixRepo('pix-site', 'minor');
 
       // then
-      sinon.assert.calledWith(exec, sinon.match(new RegExp('.*(/scripts/release-pix-repo.sh) github-owner pix-site minor dev https://undefined@github.com/github-owner/pix-site.git$')));
+      sinon.assert.calledWith(
+        exec,
+        sinon.match(
+          new RegExp(
+            '.*(/scripts/release-pix-repo.sh) github-owner pix-site minor dev https://undefined@github.com/github-owner/pix-site.git$'
+          )
+        )
+      );
     });
   });
-
 });

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -8,19 +8,19 @@ const ScalingoClient = require('../../../../common/services/scalingo-client');
 const { expect } = require('chai');
 
 describe('Scalingo client', () => {
-  beforeEach(() => {
+  beforeEach(function () {
     config.github.token = 'github-personal-access-token';
   });
 
-  afterEach(() => {
+  afterEach(function () {
     config.github.token = null;
   });
 
   describe('#ScalingoClient.getInstance', () => {
-
     it('should return the Scalingo client instance for recette', async () => {
       // given
-      sinon.stub(scalingo, 'clientFromToken')
+      sinon
+        .stub(scalingo, 'clientFromToken')
         .withArgs('tk-us-scalingo-token-recette', { apiUrl: 'https://scalingo.recette' })
         .resolves({ apiClient: () => {} });
       // when
@@ -32,7 +32,8 @@ describe('Scalingo client', () => {
 
     it('should return the Scalingo client instance for production', async () => {
       // given
-      sinon.stub(scalingo, 'clientFromToken')
+      sinon
+        .stub(scalingo, 'clientFromToken')
         .withArgs('tk-us-scalingo-token-production', { apiUrl: 'https://scalingo.production' })
         .resolves({ apiClient: () => {} });
       // when
@@ -61,10 +62,9 @@ describe('Scalingo client', () => {
     let createDeploymentStub;
     let scalingoClient;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       createDeploymentStub = sinon.stub();
-      sinon.stub(scalingo, 'clientFromToken')
-        .resolves({ Deployments: { create: createDeploymentStub } });
+      sinon.stub(scalingo, 'clientFromToken').resolves({ Deployments: { create: createDeploymentStub } });
 
       scalingoClient = await ScalingoClient.getInstance('production');
     });
@@ -92,14 +92,11 @@ describe('Scalingo client', () => {
       // when
       const result = await scalingoClient.deployFromArchive('pix-app', 'v1.0');
       // then
-      sinon.assert.calledWithExactly(
-        createDeploymentStub,
-        'pix-app-production',
-        {
-          git_ref: 'v1.0',
-          source_url: 'https://github-personal-access-token@github.com/github-owner/github-repository/archive/v1.0.tar.gz'
-        }
-      );
+      sinon.assert.calledWithExactly(createDeploymentStub, 'pix-app-production', {
+        git_ref: 'v1.0',
+        source_url:
+          'https://github-personal-access-token@github.com/github-owner/github-repository/archive/v1.0.tar.gz',
+      });
       expect(result).to.be.equal('Deployed pix-app-production v1.0');
     });
 
@@ -116,14 +113,10 @@ describe('Scalingo client', () => {
       // when
       const result = await scalingoClient.deployFromArchive('pix-app', 'v1.0', 'given-repository');
       // then
-      sinon.assert.calledWithExactly(
-        createDeploymentStub,
-        'pix-app-production',
-        {
-          git_ref: 'v1.0',
-          source_url: 'https://github-personal-access-token@github.com/github-owner/given-repository/archive/v1.0.tar.gz'
-        }
-      );
+      sinon.assert.calledWithExactly(createDeploymentStub, 'pix-app-production', {
+        git_ref: 'v1.0',
+        source_url: 'https://github-personal-access-token@github.com/github-owner/given-repository/archive/v1.0.tar.gz',
+      });
       expect(result).to.be.equal('Deployed pix-app-production v1.0');
     });
 
@@ -147,7 +140,7 @@ describe('Scalingo client', () => {
     let scalingoClient;
     let axiosGet;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       clientAppsFind = sinon.stub();
       clientDeploymentsFind = sinon.stub();
       sinon.stub(scalingo, 'clientFromToken').resolves({
@@ -170,7 +163,6 @@ describe('Scalingo client', () => {
         last_deployment_id: 'deployment-id-1',
       });
       clientDeploymentsFind.withArgs('pix-app-production', 'deployment-id-1').resolves({ pusher: {} });
-
 
       // when
       const appInfos = await scalingoClient.getAppInfo('pix-app-production');
@@ -362,12 +354,12 @@ describe('Scalingo client', () => {
     let manualReviewApp;
     let scalingoClient;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       manualReviewApp = sinon.stub();
       sinon.stub(scalingo, 'clientFromToken').resolves({
         SCMRepoLinks: {
-          manualReviewApp
-        }
+          manualReviewApp,
+        },
       });
 
       scalingoClient = await ScalingoClient.getInstance('reviewApps');

--- a/test/unit/run/services/sendinblue-report_test.js
+++ b/test/unit/run/services/sendinblue-report_test.js
@@ -18,10 +18,10 @@ describe('Unit | SendInBlue Report', () => {
     let getAggregatedSmtpReportStub;
     let axiosStub;
 
-    beforeEach(() => {
+    beforeEach(function () {
       getAggregatedSmtpReportStub = sinon.stub();
       sinon.stub(SibApiV3Sdk, 'TransactionalEmailsApi').returns({
-        getAggregatedSmtpReport: getAggregatedSmtpReportStub
+        getAggregatedSmtpReport: getAggregatedSmtpReportStub,
       });
       axiosStub = sinon.stub(axios, 'post');
       config.sendInBlue.apiKey = 'SendInBlueApiKey';
@@ -30,7 +30,7 @@ describe('Unit | SendInBlue Report', () => {
       clock = sinon.useFakeTimers(date.getTime());
     });
 
-    afterEach(() => {
+    afterEach(function () {
       clock.restore();
     });
 
@@ -45,14 +45,35 @@ describe('Unit | SendInBlue Report', () => {
       // then
       sinon.assert.calledWithExactly(getAggregatedSmtpReportStub, {
         startDate: expectedStartDate,
-        endDate: expectedEndDate
+        endDate: expectedEndDate,
       });
     });
 
     const cases = [
-      { when: 'usagePercentage < 50', expectedEmoji: ':vertical_traffic_light:', expectedColor: '#5bc0de', mailingRatio: 4, requestsMails: 1, percentage: 25 },
-      { when: 'usagePercentage >= 50 and < 70', expectedEmoji: ':warning:', expectedColor: '#f0ad4e', mailingRatio: 4, requestsMails: 2, percentage: 50 },
-      { when: 'usagePercentage >= 70', expectedEmoji: ':rotating_light:', expectedColor: '#d9534f', mailingRatio: 1000000, requestsMails: 700000, percentage: 70 },
+      {
+        when: 'usagePercentage < 50',
+        expectedEmoji: ':vertical_traffic_light:',
+        expectedColor: '#5bc0de',
+        mailingRatio: 4,
+        requestsMails: 1,
+        percentage: 25,
+      },
+      {
+        when: 'usagePercentage >= 50 and < 70',
+        expectedEmoji: ':warning:',
+        expectedColor: '#f0ad4e',
+        mailingRatio: 4,
+        requestsMails: 2,
+        percentage: 50,
+      },
+      {
+        when: 'usagePercentage >= 70',
+        expectedEmoji: ':rotating_light:',
+        expectedColor: '#d9534f',
+        mailingRatio: 1000000,
+        requestsMails: 700000,
+        percentage: 70,
+      },
     ];
 
     cases.forEach((testCase) => {
@@ -74,23 +95,25 @@ describe('Unit | SendInBlue Report', () => {
                 {
                   title: 'Nombre d‘e-mails envoyés :',
                   value: `${testCase.requestsMails.toLocaleString()}`,
-                  short: true
+                  short: true,
                 },
                 {
                   title: 'Quota utilisé :',
                   value: `${testCase.percentage}% ${testCase.expectedEmoji}`,
-                  short: true
+                  short: true,
                 },
               ],
-            }
-          ]
+            },
+          ],
         };
 
         // when
         await sendinblueReport.getReport();
 
         // then
-        sinon.assert.calledWithExactly(axiosStub, expectedWebHookUrl, expectedBlocks, { headers: { 'content-type': 'application/json' }});
+        sinon.assert.calledWithExactly(axiosStub, expectedWebHookUrl, expectedBlocks, {
+          headers: { 'content-type': 'application/json' },
+        });
       });
     });
   });

--- a/test/unit/run/services/slack/app-status-from-scalingo_test.js
+++ b/test/unit/run/services/slack/app-status-from-scalingo_test.js
@@ -6,25 +6,26 @@ const { getAppStatusFromScalingo } = require('../../../../../run/services/slack/
 const ScalingoClient = require('../../../../../common/services/scalingo-client');
 
 describe('#getAppStatusFromScalingo', () => {
-
   it('returns a message when no app is specified in command line', async () => {
     // when
     const response = await getAppStatusFromScalingo();
 
     // then
-    expect(response.text).equals('Un nom d\'application est attendu en paramètre (ex: pix-app-production)');
+    expect(response.text).equals("Un nom d'application est attendu en paramètre (ex: pix-app-production)");
   });
 
   it('returns a production app status for slack', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves([{
-      name: 'pix-app-production',
-      url: 'https://app.pix.fr',
-      isUp: true,
-      lastDeployementAt: '2021-03-24T08:37:18.611Z',
-      lastDeployedBy: 'Bob',
-      lastDeployedVersion: 'v1.0.0',
-    }]);
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-production',
+        url: 'https://app.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+    ]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
 
     // when
@@ -32,29 +33,31 @@ describe('#getAppStatusFromScalingo', () => {
 
     // then
     expect(response).to.deep.equal({
-      'response_type': 'in_channel',
-      'blocks': [
+      response_type: 'in_channel',
+      blocks: [
         {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
-          }
-        }
-      ]
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
+          },
+        },
+      ],
     });
   });
 
   it('returns a recette app status for slack', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves([{
-      name: 'pix-app-recette',
-      url: 'https://app.recette.pix.fr',
-      isUp: true,
-      lastDeployementAt: '2021-03-24T08:37:18.611Z',
-      lastDeployedBy: 'Bob',
-      lastDeployedVersion: 'v1.0.0',
-    }]);
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-recette',
+        url: 'https://app.recette.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+    ]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('recette').resolves({ getAppInfo });
 
     // when
@@ -66,14 +69,16 @@ describe('#getAppStatusFromScalingo', () => {
 
   it('returns an integration app status for slack', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves([{
-      name: 'pix-app-integration',
-      url: 'https://app.recette.pix.fr',
-      isUp: true,
-      lastDeployementAt: '2021-03-24T08:37:18.611Z',
-      lastDeployedBy: 'Bob',
-      lastDeployedVersion: 'v1.0.0',
-    }]);
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-integration',
+        url: 'https://app.recette.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+    ]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('integration').resolves({ getAppInfo });
 
     // when
@@ -81,20 +86,18 @@ describe('#getAppStatusFromScalingo', () => {
 
     // then
     expect(response.blocks).is.not.empty;
-    expect(response).to.deep.equal(
-      {
-        'response_type': 'in_channel',
-        'blocks': [
-          {
-            'type': 'section',
-            'text': {
-              'type': 'mrkdwn',
-              'text': '*pix-app-integration* 💚\n2021-03-24T08:37:18.611Z',
-            }
-          }
-        ]
-      }
-    );
+    expect(response).to.deep.equal({
+      response_type: 'in_channel',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*pix-app-integration* 💚\n2021-03-24T08:37:18.611Z',
+          },
+        },
+      ],
+    });
   });
 
   it('returns status for all production apps for slack', async () => {
@@ -115,7 +118,7 @@ describe('#getAppStatusFromScalingo', () => {
         lastDeployementAt: '2021-03-25T08:37:18.611Z',
         lastDeployedBy: 'Bob',
         lastDeployedVersion: 'v1.1.0',
-      }
+      },
     ]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
 
@@ -123,38 +126,39 @@ describe('#getAppStatusFromScalingo', () => {
     const response = await getAppStatusFromScalingo('production');
 
     // then
-    expect(response).to.deep.equal(
-      {
-        'response_type': 'in_channel',
-        'blocks': [
-          {
-            'type': 'section',
-            'text': {
-              'type': 'mrkdwn',
-              'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
-            }
-          }, {
-            'type': 'section',
-            'text': {
-              'type': 'mrkdwn',
-              'text': '*pix-api-production* 💚 - v1.1.0\n2021-03-25T08:37:18.611Z',
-            }
-          }
-        ]
-      }
-    );
+    expect(response).to.deep.equal({
+      response_type: 'in_channel',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*pix-api-production* 💚 - v1.1.0\n2021-03-25T08:37:18.611Z',
+          },
+        },
+      ],
+    });
   });
 
   it('returns a different status message when app is down', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves([{
-      name: 'pix-app-recette',
-      url: 'https://app.recette.pix.fr',
-      isUp: false,
-      lastDeployementAt: '2021-03-24T08:37:18.611Z',
-      lastDeployedBy: 'Bob',
-      lastDeployedVersion: 'v1.0.0',
-    }]);
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-recette',
+        url: 'https://app.recette.pix.fr',
+        isUp: false,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+    ]);
     sinon.stub(ScalingoClient, 'getInstance').withArgs('recette').resolves({ getAppInfo });
 
     // when
@@ -178,14 +182,16 @@ describe('#getAppStatusFromScalingo', () => {
 
   it('returns a production app status when the appName is not the full app name', async () => {
     // given
-    const getAppInfo = sinon.stub().resolves([{
-      name: 'pix-app-production',
-      url: 'https://app.pix.fr',
-      isUp: true,
-      lastDeployementAt: '2021-03-24T08:37:18.611Z',
-      lastDeployedBy: 'Bob',
-      lastDeployedVersion: 'v1.0.0',
-    }]);
+    const getAppInfo = sinon.stub().resolves([
+      {
+        name: 'pix-app-production',
+        url: 'https://app.pix.fr',
+        isUp: true,
+        lastDeployementAt: '2021-03-24T08:37:18.611Z',
+        lastDeployedBy: 'Bob',
+        lastDeployedVersion: 'v1.0.0',
+      },
+    ]);
     const scalingoClientSpy = sinon.stub(ScalingoClient, 'getInstance').withArgs('production').resolves({ getAppInfo });
 
     // when
@@ -194,17 +200,16 @@ describe('#getAppStatusFromScalingo', () => {
     // then
     expect(scalingoClientSpy.called).to.equal(true);
     expect(response).to.deep.equal({
-      'response_type': 'in_channel',
-      'blocks': [
+      response_type: 'in_channel',
+      blocks: [
         {
-          'type': 'section',
-          'text': {
-            'type': 'mrkdwn',
-            'text': '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z'
-          }
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*pix-app-production* 💚 - v1.0.0\n2021-03-24T08:37:18.611Z',
+          },
         },
-      ]
+      ],
     });
   });
-
 });

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -19,7 +19,7 @@ const githubServices = require('../../../../../common/services/github');
 const ScalingoClient = require('../../../../../common/services/scalingo-client');
 
 describe('Services | Slack | Commands', () => {
-  beforeEach(() => {
+  beforeEach(function () {
     // given
     sinon.stub(axios, 'post');
     sinon.stub(releasesServices, 'deployPixRepo').resolves();
@@ -29,7 +29,7 @@ describe('Services | Slack | Commands', () => {
 
   describe('#createAndDeployPixSiteRelease', () => {
     describe('when releaseType is set to minor', () => {
-      beforeEach(async () => {
+      beforeEach(async function () {
         // given
         const payload = { text: 'minor', response_url: 'http://example.net/callback' };
         // when
@@ -53,7 +53,9 @@ describe('Services | Slack | Commands', () => {
       });
 
       it('should inform the user of the progress', () => {
-        sinon.assert.calledWith(axios.post, 'http://example.net/callback', { text: 'Le script de déploiement de la release \'v1.0.0\' pour pix-site, pix-pro en production s\'est déroulé avec succès. En attente de l\'installation des applications sur Scalingo…' });
+        sinon.assert.calledWith(axios.post, 'http://example.net/callback', {
+          text: "Le script de déploiement de la release 'v1.0.0' pour pix-site, pix-pro en production s'est déroulé avec succès. En attente de l'installation des applications sur Scalingo…",
+        });
       });
     });
 
@@ -76,13 +78,14 @@ describe('Services | Slack | Commands', () => {
         // when
         await createAndDeployPixSiteRelease(payload);
         // then
-        sinon.assert.calledWith(axios.post, 'http://example.net/callback', { text: 'Erreur lors du déploiement de pix-site, pix-pro en production.' });
+        sinon.assert.calledWith(axios.post, 'http://example.net/callback', {
+          text: 'Erreur lors du déploiement de pix-site, pix-pro en production.',
+        });
       });
     });
   });
 
   describe('#createAndDeployPixUI', () => {
-
     it('should publish a new release', async () => {
       // given
       const payload = { text: 'minor' };
@@ -118,7 +121,6 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployEmberTestingLibrary', () => {
-
     it('should publish a new release', async () => {
       // given
       const payload = { text: 'minor' };
@@ -154,7 +156,7 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployPixLCMS', () => {
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       const payload = { text: 'minor' };
       // when
@@ -179,7 +181,7 @@ describe('Services | Slack | Commands', () => {
 
   describe('#createAndDeployPixBotRelease', () => {
     let client;
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       client = { deployFromArchive: sinon.spy() };
       sinon.stub(ScalingoClient, 'getInstance').resolves(client);
@@ -210,7 +212,7 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployPixDatawarehouse', () => {
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       const payload = { text: 'minor' };
       // when
@@ -269,7 +271,7 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployDbStats', () => {
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       const payload = { text: 'minor' };
       // when
@@ -293,8 +295,7 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployPixTutosRelease', () => {
-
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       const payload = { text: 'minor' };
       // when
@@ -320,7 +321,7 @@ describe('Services | Slack | Commands', () => {
   describe('#deployMetabase', () => {
     let client;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       client = { deployFromArchive: sinon.spy() };
       sinon.stub(ScalingoClient, 'getInstance').resolves(client);
@@ -330,8 +331,12 @@ describe('Services | Slack | Commands', () => {
 
     it('should deploy the release', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-metabase-production', 'master', 'metabase-deploy', { withEnvSuffix: false });
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-data-metabase-dev', 'master', 'metabase-deploy', { withEnvSuffix: false });
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-metabase-production', 'master', 'metabase-deploy', {
+        withEnvSuffix: false,
+      });
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-data-metabase-dev', 'master', 'metabase-deploy', {
+        withEnvSuffix: false,
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les règles de lint de pix-bot sont différentes de celles de https://github.com/1024pix/pix.

## :robot: Solution
Utiliser les mêmes règles de lint que https://github.com/1024pix/pix.

## :rainbow: Remarques
J'ai désactivé globalement la règle `mocha/no-setup-in-describe` comme c'est [recommandé dans la doc](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md).

J'ai aussi désactivé la règle `mocha/no-exports` nous permettant de mettre à disposition nos utilitaires de tests. Peut-être qu'il y a mieux à faire ?

Il reste deux warnings sur ce même fichier car on utilise `beforeEach` et `afterEach` globalement en dehors d'une suite de test.

## :100: Pour tester
Vérifier que le lint passe toujours.
