### PR TITLE
[TECH] ajout d'un filtre dans le titre d'une PR pour ne pas déployer de RA

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -28,6 +28,10 @@ module.exports = {
       if (!reviewApps) {
         return 'No RA configured for this repository';
       }
+      const titleLc = payload.pull_request.title.toLowerCase();
+      if (/\[nora\]/.test(titleLc)) {
+        return `RA disabled for this PR`;
+      }
       const client = await ScalingoClient.getInstance('reviewApps');
       for (const appName of reviewApps) {
         await client.deployReviewApp(appName, prId);

--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -28,8 +28,19 @@ function orderPr(listPR) {
   });
 }
 
+function cleanPrTitle(pullrequest) {
+  const reg = /\[NORA\]/i;
+  const newTitle = pullrequest.title.replace(reg, '');
+  pullrequest.title = newTitle;
+  return pullrequest;
+}
+
 function filterPullRequest(pullrequests, dateOfLastMEP) {
-  return pullrequests.filter((PR) => PR.merged_at > dateOfLastMEP);
+  pullrequests = pullrequests.filter((PR) => PR.merged_at > dateOfLastMEP);
+  pullrequests.forEach((pullrequest) => {
+    cleanPrTitle(pullrequest);
+  });
+  return pullrequests;
 }
 
 function getHeadOfChangelog(tagVersion) {
@@ -61,6 +72,7 @@ function getNewChangeLogLines({ headOfChangelogTitle, pullRequests }) {
 
 module.exports = {
   displayPullRequest,
+  cleanPrTitle,
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -11,6 +11,7 @@ describe('Acceptance | Build | Github', function () {
         action: 'opened',
         number: 2,
         pull_request: {
+          title: '[TECH] Pr n2',
           head: {
             repo: {
               name: 'pix',
@@ -92,6 +93,21 @@ describe('Acceptance | Build | Github', function () {
       });
       expect(res.statusCode).to.equal(200);
       expect(res.result).to.eql('Ignoring edited action');
+    });
+
+    it('responds with 200 and do nothing for a pr with nora in title', async function () {
+      body.pull_request.title = '[TECH][NORA] Pr n2';
+      const res = await server.inject({
+        method: 'POST',
+        url: '/github/webhook',
+        headers: {
+          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+          'x-github-event': 'pull_request',
+        },
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql('RA disabled for this PR');
     });
 
     it('responds with 200 and do nothing for other event', async function () {

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -4,6 +4,7 @@ const github = require('../../../../common/services/github');
 
 const {
   displayPullRequest,
+  cleanPrTitle,
   filterPullRequest,
   generateChangeLogContent,
   getHeadOfChangelog,
@@ -29,6 +30,26 @@ describe('Unit | Common | Services | Changelog', function () {
 
       // then
       expect(result).to.equal(expectedLine);
+    });
+  });
+
+  describe('#cleanPrTitle', function () {
+    it('should remove uc NORA from PR title when defined', function () {
+      const pullRequest = { title: '[TECH] [NORA] pr 1' };
+      console.log(pullRequest.title);
+      const result = cleanPrTitle(pullRequest);
+      console.log(result.title);
+      expect(result.title).to.equal('[TECH]  pr 1');
+    });
+    it('should remove lc nora from PR title when defined', function () {
+      const pullRequest = { title: '[TECH] [nora] pr 1' };
+      const result = cleanPrTitle(pullRequest);
+      expect(result.title).to.equal('[TECH]  pr 1');
+    });
+    it('should do nothing when there is no nora in title', function () {
+      const pullRequest = { title: '[TECH] pr 1' };
+      const result = cleanPrTitle(pullRequest);
+      expect(result.title).to.equal(pullRequest.title);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Une PR déploie systématiquement une RA même pour des changements de CI ou de config qui ne peuvent pas être testés via une RA

## :robot: Solution
Ajout d'un filtre sur le titre d'une PR pour ignorer le déploiement d'une RA 
 

## :100: Pour tester
Ajouter [NORA] dans le titre de la PR