### PR TITLE
[FEATURE] Eviter de déployer une RA si la PR contient le label `no-review-app`. 

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -19,6 +19,7 @@ module.exports = {
       const repository = payload.pull_request.head.repo.name;
       const prId = payload.number;
       const reviewApps = repositoryToScalingoAppsReview[repository];
+      const labelsList = payload.pull_request.labels;
       if (payload.pull_request.head.repo.fork) {
         return 'No RA for a fork';
       }
@@ -27,6 +28,9 @@ module.exports = {
       }
       if (!reviewApps) {
         return 'No RA configured for this repository';
+      }
+      if (labelsList.some((label) => label.name == 'no-review-app')) {
+        return 'RA disabled for this PR';
       }
       const client = await ScalingoClient.getInstance('reviewApps');
       for (const appName of reviewApps) {

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -11,6 +11,7 @@ describe('Acceptance | Build | Github', function () {
         action: 'opened',
         number: 2,
         pull_request: {
+          labels: [{ name: 'test-label' }],
           head: {
             repo: {
               name: 'pix',
@@ -22,6 +23,32 @@ describe('Acceptance | Build | Github', function () {
     });
 
     it('responds with 200 and create the RA on scalingo', async function () {
+      const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
+      const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+        .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+        .reply(201);
+      const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+        .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+        .reply(201);
+
+      const res = await server.inject({
+        method: 'POST',
+        url: '/github/webhook',
+        headers: {
+          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+          'x-github-event': 'pull_request',
+        },
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql('Created RA on app pix-front-review, pix-api-review with pr 2');
+      expect(scalingoAuth.isDone()).to.be.true;
+      expect(scalingoDeploy1.isDone()).to.be.true;
+      expect(scalingoDeploy2.isDone()).to.be.true;
+    });
+
+    it('responds with 200 and create the RA on scalingo with no labels', async function () {
+      body.pull_request.labels = [];
       const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
       const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
         .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
@@ -92,6 +119,21 @@ describe('Acceptance | Build | Github', function () {
       });
       expect(res.statusCode).to.equal(200);
       expect(res.result).to.eql('Ignoring edited action');
+    });
+
+    it('responds with 200 and do nothing for a pr labelled with no-review-app', async function () {
+      body.pull_request.labels = [{ name: 'no-review-app' }];
+      const res = await server.inject({
+        method: 'POST',
+        url: '/github/webhook',
+        headers: {
+          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+          'x-github-event': 'pull_request',
+        },
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql('RA disabled for this PR');
     });
 
     it('responds with 200 and do nothing for other event', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Une PR déploie systématiquement une RA même pour des changements de CI ou de config qui ne peuvent pas être testés via une RA, ce qui peut engendrer des coûts supplémentaires inutiles.


## :robot: Solution
Ajout d'un filtre sur le label pour ingorer le déploiement d'une RA 

## :100: Pour tester
Ajouter no-review-app dans les labels au moment de la rédaction d'une PR