### PR TITLE
[TECH]  Ajout d'une commande slash pour créer une application sur scalingo

### DIFF
--- a/build/manifest.js
+++ b/build/manifest.js
@@ -47,6 +47,15 @@ manifest.registerSlashCommand({
   handler: slackbotController.startMobRoles,
 });
 
+manifest.registerSlashCommand({
+  command: '/scalingo-create-app',
+  path: '/slack/commands/scalingo-create-app',
+  description: "Création d'application sur scalingo",
+  usage_hint: '[app-name environment]',
+  should_escape: false,
+  handler: slackbotController.createAppOnScalingo,
+});
+
 manifest.registerShortcut({
   name: 'Publier une version/MER',
   type: 'global',

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -83,6 +83,19 @@ class ScalingoClient {
       throw err;
     }
   }
+
+  async inviteCollaborator(appId, email) {
+    const { invitation_link } = await this.client.Collaborators.invite(appId, email);
+    return invitation_link;
+  }
+
+  async createApp(appName) {
+    const app = {
+      name: appName,
+    };
+    const { id } = await this.client.Apps.create(app);
+    return id;
+  }
 }
 
 async function _isUrlReachable(url) {

--- a/common/services/slack/surfaces/user-infos/get-user-infos.js
+++ b/common/services/slack/surfaces/user-infos/get-user-infos.js
@@ -1,0 +1,21 @@
+const axios = require('axios');
+const config = require('../../../../../config');
+
+module.exports = {
+  async getUserEmail(userId) {
+    const options = {
+      method: 'GET',
+      url: `https://slack.com/api/users.info?user=${userId}`,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${config.slack.botToken}`,
+      },
+    };
+    const response = await axios(options);
+    if (!response.data.ok) {
+      console.error(response.data);
+      throw new Error('Slack error received');
+    }
+    return response.data.user.profile.email;
+  },
+};

--- a/test/acceptance/build/manifest_test.js
+++ b/test/acceptance/build/manifest_test.js
@@ -63,6 +63,13 @@ describe('Acceptance | Build | Manifest', function () {
               usage_hint: "[@quelqu'un @quelqu'une]",
               should_escape: false,
             },
+            {
+              command: '/scalingo-create-app',
+              url: `http://${hostname}/slack/commands/scalingo-create-app`,
+              description: "Création d'application sur scalingo",
+              usage_hint: '[app-name environment]',
+              should_escape: false,
+            },
           ],
         },
         oauth_config: {


### PR DESCRIPTION
## :unicorn: Problème
L'ajout d'une app sur Scalingo demande de se connecter 2 fois pour la créer et l'assigner sur son compte perso.

## :robot: Solution
Ajouter une commande slack pour créer l'app et ajouter automatiquement l'utilisateur.

## :rainbow: Remarques
Penser à ajouter les droits [users:read](https://api.slack.com/scopes/users:read) et  [users:read.email](https://api.slack.com/scopes/users:read.email) sur le bot slack