### PR TITLE
[TECH] Créer une application Scalingo depuis Slack

### DIFF
--- a/common/controllers/index.js
+++ b/common/controllers/index.js
@@ -6,11 +6,17 @@ const {
   sampleView: releaseTagSelection,
 } = require('../../run/services/slack/surfaces/modals/deploy-release/release-tag-selection');
 const {
+  sampleView: createAppOnScalingoSelection,
+} = require('../../run/services/slack/surfaces/modals/scalingo-apps/application-creation');
+const {
   sampleView: releaseDeploymentConfirmation,
 } = require('../../run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation');
 const {
   sampleView: releasePublicationConfirmation,
 } = require('../../build/services/slack/surfaces/modals/publish-release/release-publication-confirmation');
+const {
+  sampleView: submitApplicationNameSelection,
+} = require('../../run/services/slack/surfaces/modals/scalingo-apps/application-creation-confirmation');
 
 module.exports = {
   getApiInfo() {
@@ -25,8 +31,10 @@ module.exports = {
     const views = [
       { name: 'release-type-selection', view: releaseTypeSelection() },
       { name: 'release-tag-selection', view: releaseTagSelection() },
+      { name: 'create-app-on-scalingo', view: createAppOnScalingoSelection() },
       { name: 'release-deployment-confirmation', view: releaseDeploymentConfirmation() },
       { name: 'release-publication-confirmation', view: releasePublicationConfirmation() },
+      { name: 'application-creation-confirmation', view: submitApplicationNameSelection() },
     ];
     return views
       .map(({ name, view }) => {

--- a/common/models/ScalingoAppName.js
+++ b/common/models/ScalingoAppName.js
@@ -1,0 +1,18 @@
+//TODO use EnvVars
+const config = require('../../config');
+const alphanumericAndDashOnly = /^([a-zA-Z0-9]+-)+[a-zA-Z0-9]+$/;
+const prefix = 'pix-';
+class ScalingoAppName {
+  static isApplicationNameValid(applicationName) {
+    const suffix = config.scalingo.validAppSuffix;
+    const appNameMatchesRegex = applicationName.search(alphanumericAndDashOnly) >= 0;
+    const appNameHasCorrectLength = applicationName.length >= 6 && applicationName.length <= 46;
+    const appNameStartsWithPix = applicationName.startsWith(prefix);
+    const appNameEndsWithCorrectSuffix = suffix.includes(applicationName.split('-').slice(-1)[0]);
+    return appNameMatchesRegex && appNameHasCorrectLength && appNameStartsWithPix && appNameEndsWithCorrectSuffix;
+  }
+}
+
+module.exports = {
+  ScalingoAppName,
+};

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -83,6 +83,28 @@ class ScalingoClient {
       throw err;
     }
   }
+  async inviteCollaborator(applicationId, collaboratorEmail) {
+    try {
+      const { invitation_link } = await this.client.Collaborators.invite(applicationId, collaboratorEmail);
+      return invitation_link;
+    } catch (e) {
+      console.error(JSON.stringify(e));
+      throw new Error(`Impossible to invite ${collaboratorEmail} on ${applicationId}`);
+    }
+  }
+
+  async createApplication(name) {
+    const app = {
+      name: name,
+    };
+    try {
+      const { id } = await this.client.Apps.create(app);
+      return id;
+    } catch (e) {
+      console.error(JSON.stringify(e));
+      throw new Error(`Impossible to create ${app.name}, ${e.name}`);
+    }
+  }
 }
 
 async function _isUrlReachable(url) {

--- a/common/services/slack/surfaces/user-infos/get-user-infos.js
+++ b/common/services/slack/surfaces/user-infos/get-user-infos.js
@@ -2,27 +2,20 @@ const axios = require('axios');
 const config = require('../../../../../config');
 
 module.exports = {
-  async postMessage(message, attachments, channel = '#tech-releases') {
+  async getUserEmail(userId) {
     const options = {
-      method: 'POST',
-      url: 'https://slack.com/api/chat.postMessage',
+      method: 'GET',
+      url: `https://slack.com/api/users.info?user=${userId}`,
       headers: {
         'content-type': 'application/json',
         authorization: `Bearer ${config.slack.botToken}`,
       },
-      data: {
-        channel: channel,
-        text: message,
-        attachments: attachments,
-      },
     };
-
     const response = await axios(options);
     if (!response.data.ok) {
       console.error(response.data);
       throw new Error('Slack error received');
     }
-
-    return response;
+    return response.data.user.profile.email;
   },
 };

--- a/config.js
+++ b/config.js
@@ -46,7 +46,9 @@ module.exports = (function() {
       production: {
         token: process.env.SCALINGO_TOKEN_PRODUCTION,
         apiUrl: process.env.SCALINGO_API_URL_PRODUCTION,
-      }
+      },
+      validAppSuffix: _getJSON(process.env.SCALINGO_VALID_APP_SUFFIX) ||
+        ["production","review","integration","recette","sandbox","dev","router","test"]
     },
 
     openApi: {

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -116,13 +116,22 @@ module.exports = {
         if (payload.callback_id === 'deploy-release') {
           shortcuts.openViewDeployReleaseTagSelection(payload);
         }
+        if (payload.callback_id === 'scalingo-app-creation') {
+          shortcuts.openViewCreateAppOnScalingoSelection(payload);
+        }
         return null;
       case 'view_submission':
         if (payload.view.callback_id === shortcuts.openViewDeployReleaseTagSelectionCallbackId) {
           return viewSubmissions.submitReleaseTagSelection(payload);
         }
+        if (payload.view.callback_id === shortcuts.openViewCreateAppOnScalingoSelectionCallbackId) {
+          return viewSubmissions.submitApplicationNameSelection(payload);
+        }
         if (payload.view.callback_id === viewSubmissions.submitReleaseTagSelectionCallbackId) {
           return viewSubmissions.submitReleaseDeploymentConfirmation(payload);
+        }
+        if (payload.view.callback_id === viewSubmissions.submitApplicationNameSelectionCallbackId) {
+          return viewSubmissions.submitCreateAppOnScalingoConfirmation(payload);
         }
         return null;
       case 'view_closed':

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -110,6 +110,13 @@ manifest.registerShortcut({
   description: "Lance le déploiement d'une version sur l'environnement de production",
 });
 
+manifest.registerShortcut({
+  name: 'Créer une application sur Scalingo',
+  type: 'global',
+  callback_id: 'scalingo-app-creation',
+  description: "Lance la création d'une application sur Scalingo",
+});
+
 manifest.addInteractivity({
   path: '/run/slack/interactive-endpoint',
   handler: slackbotController.interactiveEndpoint,

--- a/run/services/slack/shortcuts.js
+++ b/run/services/slack/shortcuts.js
@@ -1,19 +1,36 @@
 const axios = require('axios');
 const deployReleaseTagSelectionModal = require('./surfaces/modals/deploy-release/release-tag-selection');
+const createAppOnScalingoModal = require('./surfaces/modals/scalingo-apps/application-creation');
 const config = require('../../../config');
+const openViewUrl = 'https://slack.com/api/views.open';
 
 module.exports = {
   openViewDeployReleaseTagSelectionCallbackId: deployReleaseTagSelectionModal.callbackId,
 
+  openViewCreateAppOnScalingoSelectionCallbackId: createAppOnScalingoModal.callbackId,
+
   openViewDeployReleaseTagSelection(payload) {
     const options = {
       method: 'POST',
-      url: 'https://slack.com/api/views.open',
+      url: openViewUrl,
       headers: {
         'content-type': 'application/json',
         authorization: `Bearer ${config.slack.botToken}`,
       },
       data: deployReleaseTagSelectionModal(payload.trigger_id),
+    };
+    return axios(options);
+  },
+
+  openViewCreateAppOnScalingoSelection(payload) {
+    const options = {
+      method: 'POST',
+      url: openViewUrl,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${config.slack.botToken}`,
+      },
+      data: createAppOnScalingoModal(payload.trigger_id),
     };
     return axios(options);
   },

--- a/run/services/slack/surfaces/modals/scalingo-apps/application-creation-confirmation.js
+++ b/run/services/slack/surfaces/modals/scalingo-apps/application-creation-confirmation.js
@@ -1,0 +1,34 @@
+const { Modal, Blocks } = require('slack-block-builder');
+
+const callbackId = 'application-creation-confirmation';
+
+function modal(applicationName, applicationEnvironment, applicationEnvironmentName, userEmail) {
+  return Modal({
+    title: 'Confirmation',
+    callbackId,
+    privateMetaData: JSON.stringify({
+      applicationName: applicationName,
+      applicationEnvironment: applicationEnvironment,
+      userEmail: userEmail,
+    }),
+    submit: '🚀 Go !',
+    close: 'Annuler',
+  }).blocks([
+    Blocks.Section({
+      text: `Vous vous apprêtez à créer l'application *${applicationName}* dans la région : *${applicationEnvironmentName}* et à inviter cet adesse email en tant que collaborateur : *${userEmail}*`,
+    }),
+  ]);
+}
+
+module.exports = (applicationName, applicationEnvironment, applicationEnvironmentName, userEmail) => {
+  return {
+    response_action: 'push',
+    view: modal(applicationName, applicationEnvironment, applicationEnvironmentName, userEmail).buildToObject(),
+  };
+};
+
+module.exports.sampleView = () => {
+  return modal('pix-application-name-recette', 'recette', 'Paris - SecNumCloud - Outscale', 'john.doe@pix.fr');
+};
+
+module.exports.callbackId = callbackId;

--- a/run/services/slack/surfaces/modals/scalingo-apps/application-creation.js
+++ b/run/services/slack/surfaces/modals/scalingo-apps/application-creation.js
@@ -1,0 +1,44 @@
+const { Modal, Blocks, Elements, Bits } = require('slack-block-builder');
+const regions = [
+  { id: 'production', name: 'Paris - SecNumCloud - Outscale' },
+  { id: 'recette', name: 'Paris - Outscale' },
+];
+const callbackId = 'application-name-selection';
+
+function modal() {
+  return Modal({
+    title: 'Créer une application',
+    callbackId,
+    submit: 'Créer',
+    close: 'Annuler',
+  }).blocks([
+    Blocks.Input({
+      blockId: 'create-app-name',
+      label: "Nom de l'application",
+    }).element(
+      Elements.TextInput({
+        actionId: 'scalingo-app-name',
+        placeholder: 'application-name',
+        initialValue: 'pix-super-application-recette',
+      })
+    ),
+    Blocks.Input({ blockId: 'application-env', label: 'Quelle région ?' }).element(
+      Elements.StaticSelect({ placeholder: 'Choisis la région' })
+        .actionId('item')
+        .options(regions.map((item) => Bits.Option({ text: item.name, value: item.id })))
+    ),
+  ]);
+}
+
+module.exports = (triggerId) => {
+  return {
+    trigger_id: triggerId,
+    view: modal(regions).buildToObject(),
+  };
+};
+
+module.exports.sampleView = () => {
+  return modal(regions);
+};
+
+module.exports.callbackId = callbackId;

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -1,7 +1,11 @@
 const openModalReleaseDeploymentConfirmation = require('./surfaces/modals/deploy-release/release-deployment-confirmation');
+const openModalApplicationCreationConfirmation = require('./surfaces/modals/scalingo-apps/application-creation-confirmation');
 const { environments, deploy } = require('../../../common/services/releases');
 const githubService = require('../../../common/services/github');
 const slackPostMessageService = require('../../../common/services/slack/surfaces/messages/post-message');
+const slackGetUserInfos = require('../../../common/services/slack/surfaces/user-infos/get-user-infos');
+const ScalingoClient = require('../../../common/services/scalingo-client');
+const { ScalingoAppName } = require('../../../common/models/ScalingoAppName');
 
 module.exports = {
   async submitReleaseTagSelection(payload) {
@@ -10,7 +14,26 @@ module.exports = {
     return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
   },
 
+  async submitApplicationNameSelection(payload) {
+    const applicationName = payload.view.state.values['create-app-name']['scalingo-app-name'].value;
+    const applicationEnvironment = payload.view.state.values['application-env']['item']['selected_option'].value;
+    const applicationEnvironmentName =
+      payload.view.state.values['application-env']['item']['selected_option']['text']['text'];
+    const userEmail = await slackGetUserInfos.getUserEmail(payload.user.id);
+    if (!ScalingoAppName.isApplicationNameValid(applicationName)) {
+      return `${applicationName} is incorrect`;
+    }
+    return openModalApplicationCreationConfirmation(
+      applicationName,
+      applicationEnvironment,
+      applicationEnvironmentName,
+      userEmail
+    );
+  },
+
   submitReleaseTagSelectionCallbackId: openModalReleaseDeploymentConfirmation.callbackId,
+
+  submitApplicationNameSelectionCallbackId: openModalApplicationCreationConfirmation.callbackId,
 
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
@@ -19,6 +42,19 @@ module.exports = {
     } else {
       deploy(environments.production, releaseTag);
     }
+    return {
+      response_action: 'clear',
+    };
+  },
+
+  async submitCreateAppOnScalingoConfirmation(payload) {
+    const { applicationName, applicationEnvironment, userEmail } = JSON.parse(payload.view.private_metadata);
+    const client = await ScalingoClient.getInstance(applicationEnvironment);
+    const appId = await client.createApplication(applicationName);
+    const invitationLink = await client.inviteCollaborator(appId, userEmail);
+    const message = `app ${applicationName} created <${invitationLink}|invitation link>`;
+    const channel = `@${payload.user.id}`;
+    slackPostMessageService.postMessage(message, null, channel);
     return {
       response_action: 'clear',
     };

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -26,6 +26,12 @@ describe('Acceptance | Run | Manifest', function () {
               callback_id: 'deploy-release',
               description: "Lance le déploiement d'une version sur l'environnement de production",
             },
+            {
+              name: 'Créer une application sur Scalingo',
+              type: 'global',
+              callback_id: 'scalingo-app-creation',
+              description: "Lance la création d'une application sur Scalingo",
+            },
           ],
           slash_commands: [
             {

--- a/test/unit/common/models/ScalingoAppName_test.js
+++ b/test/unit/common/models/ScalingoAppName_test.js
@@ -1,0 +1,70 @@
+const { expect } = require('../../../test-helper');
+
+const { ScalingoAppName } = require('../../../../common/models/ScalingoAppName');
+
+describe('Unit | Common | Models | ScalingoAppName', function () {
+  describe('#isApplicationNameValid', function () {
+    it('should return false if appName contains non alphanum or dash char', function () {
+      // given
+      const invalidAppName = 'pix#-application-nameat-production';
+
+      // when
+      const resultInvalidAppName = ScalingoAppName.isApplicationNameValid(invalidAppName);
+      console.log(resultInvalidAppName);
+      // then
+      expect(resultInvalidAppName, 'Invalid app name').to.be.false;
+    });
+
+    it('should return false if appName does not start with pix', function () {
+      // given
+      const doesNotStartWithPixAppName = 'app-name-format';
+
+      // when
+      const resultDoesNotStartWithPixAppName = ScalingoAppName.isApplicationNameValid(doesNotStartWithPixAppName);
+
+      // then
+      expect(resultDoesNotStartWithPixAppName, 'Does not start with pix app name').to.be.false;
+    });
+
+    it('should return false if appName is too short', function () {
+      // given
+      const tooShortAppName = 'pix-a';
+
+      // when
+      const resultTooShortAppName = ScalingoAppName.isApplicationNameValid(tooShortAppName);
+
+      // then
+      expect(resultTooShortAppName, 'Too short app name').to.be.false;
+    });
+    it('should return false if appName is too long', function () {
+      // given
+      const tooLongAppName = 'pix-application-with-a-long-name-that-does-not-fit-production';
+
+      // when
+      const resultTooLongAppName = ScalingoAppName.isApplicationNameValid(tooLongAppName);
+
+      // then
+      expect(resultTooLongAppName, 'Too long app name').to.be.false;
+    });
+    it('should return false if appName end with incorrect suffix', function () {
+      // given
+      const incorrectSuffixAppName = 'pix-coucou-app-name-mauvaissuffix';
+
+      // when
+      const resultIncorrectSuffixAppName = ScalingoAppName.isApplicationNameValid(incorrectSuffixAppName);
+
+      // then
+      expect(resultIncorrectSuffixAppName, 'Incorrect suffix app name').to.be.false;
+    });
+    it('should return true if parameter is a valid appName', function () {
+      // given
+      const validAppName = 'pix-super-application-recette';
+
+      // when
+      const result = ScalingoAppName.isApplicationNameValid(validAppName);
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'ajout d'une app sur Scalingo demande de se connecter 2 fois pour la créer et l'assigner sur son compte perso.

## :robot: Solution
Ajouter un raccourcis slack pour créer l'app et ajouter automatiquement l'utilisateur dans les collaborateurs.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Indiquer comment tester depuis le slack de test