### PR TITLE
[TECH] Linter l'ensemble des fichiers.

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{js,yml, yaml}": "eslint --fix server.js common/* run/* build/* bin/* test/*"
+  "*.{js,yml, yaml}": "eslint --fix"
 }

--- a/config.js
+++ b/config.js
@@ -3,13 +3,6 @@ function _getNumber(numberAsString, defaultIntNumber) {
   return isNaN(number) ? defaultIntNumber : number;
 }
 
-function _getCommaSeparatedValues(valuesAsString) {
-  if (!valuesAsString) {
-    return undefined;
-  }
-  return valuesAsString.split(',').map(v => v.trim());
-}
-
 function _getJSON(value) {
   if (!value) {
     return undefined;
@@ -18,11 +11,10 @@ function _getJSON(value) {
   return JSON.parse(value);
 }
 
-module.exports = (function() {
-
+module.exports = (function () {
   const config = {
     port: _getNumber(process.env.PORT, 3000),
-    environment: (process.env.NODE_ENV || 'development'),
+    environment: process.env.NODE_ENV || 'development',
 
     baleen: {
       pat: process.env.BALEEN_PERSONAL_ACCESS_TOKEN,
@@ -47,8 +39,16 @@ module.exports = (function() {
         token: process.env.SCALINGO_TOKEN_PRODUCTION,
         apiUrl: process.env.SCALINGO_API_URL_PRODUCTION,
       },
-      validAppSuffix: _getJSON(process.env.SCALINGO_VALID_APP_SUFFIX) ||
-        ["production","review","integration","recette","sandbox","dev","router","test"]
+      validAppSuffix: _getJSON(process.env.SCALINGO_VALID_APP_SUFFIX) || [
+        'production',
+        'review',
+        'integration',
+        'recette',
+        'sandbox',
+        'dev',
+        'router',
+        'test',
+      ],
     },
 
     openApi: {
@@ -70,7 +70,7 @@ module.exports = (function() {
 
     googleSheet: {
       key: process.env.GOOGLE_SHEET_API_KEY,
-      idA11Y: process.env.GOOGLE_SHEET_A11Y
+      idA11Y: process.env.GOOGLE_SHEET_A11Y,
     },
 
     sendInBlue: {
@@ -136,5 +136,4 @@ module.exports = (function() {
   }
 
   return config;
-
 })();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy:minor": "npm version minor && npm run deploy:tag",
     "deploy:patch": "npm version patch && npm run deploy:tag",
     "deploy:tag": "git push --tags && git push",
-    "lint": "eslint server.js common/* run/* build/* bin/* test/*",
+    "lint": "eslint .",
     "local:trigger-lint-on-commit": "husky install",
     "local:prevent-trigger-lint-on-commit": "git config --unset core.hooksPath",
     "start": "node bin/www",

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -32,9 +32,11 @@ async function main() {
       pullRequests = await github.getMergedPullRequestsSortedByDescendingDate(repoOwner, repoName, branchName);
     } else {
       try {
-        pullRequests = await pullRequestSinceLastRelease(repoOwner, repoName, lastTagNameOnBranch, branchName)
+        pullRequests = await pullRequestSinceLastRelease(repoOwner, repoName, lastTagNameOnBranch, branchName);
       } catch (e) {
-        console.error('Error while fetching the tag and pull-requests. If it\'s your first release, ensure that the version set is 0.0.0.');
+        console.error(
+          "Error while fetching the tag and pull-requests. If it's your first release, ensure that the version set is 0.0.0."
+        );
         throw e;
       }
     }
@@ -48,19 +50,19 @@ async function main() {
 
     try {
       currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
-    } catch(error) {
+    } catch (error) {
       console.log('Changelog file does not exist. It will be created.');
       currentChangeLog = [`# ${repoName} Changelog\n`, '\n'];
     }
 
     const changeLogContent = generateChangeLogContent({
       currentChangelogContent: currentChangeLog,
-      changes: newChangeLogLines
+      changes: newChangeLogLines,
     });
 
     console.log(`Writing to ${CHANGELOG_FILE}`);
     fs.writeFileSync(CHANGELOG_FILE, changeLogContent.join('\n'));
-  } catch(e) {
+  } catch (e) {
     console.log(e);
     process.exit(1);
   }


### PR DESCRIPTION
## :unicorn: Problème
La commande de lint cible des dossiers à la racine. 
Si un dossier est ajouté, il n'est pas linté.
Les fichiers à la racine ne sont pas lintés.

## :robot: Solution
Linter l'ensemble des descendants de la racine.

## :rainbow: Remarques
Suppression d'une fonction non utilisée.

## :100: Pour tester
Introduire une violation dans un nouveau fichier et vérifier que `npm run lint` renvoie une code retour `1`