### PR TITLE
[BUGFIX] Le nom du shortcut de création de l'application est trop long.

### DIFF
--- a/run/manifest.js
+++ b/run/manifest.js
@@ -111,7 +111,7 @@ manifest.registerShortcut({
 });
 
 manifest.registerShortcut({
-  name: 'Créer une application sur Scalingo',
+  name: 'Créer une appli Scalingo',
   type: 'global',
   callback_id: 'scalingo-app-creation',
   description: "Lance la création d'une application sur Scalingo",

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | Run | Manifest', function () {
               description: "Lance le déploiement d'une version sur l'environnement de production",
             },
             {
-              name: 'Créer une application sur Scalingo',
+              name: 'Créer une appli Scalingo',
               type: 'global',
               callback_id: 'scalingo-app-creation',
               description: "Lance la création d'une application sur Scalingo",


### PR DESCRIPTION
## :unicorn: Problème
La longueur maximale est de 25 caractères, or elle en fait 32

## :robot: Solution
La raboter

## :rainbow: Remarques
Serait-il possible d'avoir une validation dans la CI ?

## :100: Pour tester
Comparer le manifest avec celui de production (qui est lui valide)