### PR TITLE
Mentionner MER/MEP au début du label de l'action de release

### DIFF
--- a/build/manifest.js
+++ b/build/manifest.js
@@ -48,7 +48,7 @@ manifest.registerSlashCommand({
 });
 
 manifest.registerShortcut({
-  name: 'Publier une version/MER',
+  name: 'MER/Publier une version',
   type: 'global',
   callback_id: 'publish-release',
   description: "Publie une nouvelle version et la déploie sur l'environnement de recette",

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -104,7 +104,7 @@ manifest.registerSlashCommand({
 });
 
 manifest.registerShortcut({
-  name: 'Déployer une version/MEP',
+  name: 'MEP/Déployer une version',
   type: 'global',
   callback_id: 'deploy-release',
   description: "Lance le déploiement d'une version sur l'environnement de production",

--- a/test/acceptance/build/manifest_test.js
+++ b/test/acceptance/build/manifest_test.js
@@ -21,7 +21,7 @@ describe('Acceptance | Build | Manifest', function () {
           },
           shortcuts: [
             {
-              name: 'Publier une version/MER',
+              name: 'MER/Publier une version',
               type: 'global',
               callback_id: 'publish-release',
               description: "Publie une nouvelle version et la déploie sur l'environnement de recette",

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -21,7 +21,7 @@ describe('Acceptance | Run | Manifest', function () {
           },
           shortcuts: [
             {
-              name: 'Déployer une version/MEP',
+              name: 'MEP/Déployer une version',
               type: 'global',
               callback_id: 'deploy-release',
               description: "Lance le déploiement d'une version sur l'environnement de production",


### PR DESCRIPTION
## :unicorn: Problème
Il y a de plus en plus d'actions possible dans les applications Slack Run et Build.
Les PO utilisant principalement les actions de MEP et de MEP, leur label n'est plus affiché dans son intégralité et ralenti le processus
![image](https://user-images.githubusercontent.com/56302715/188833909-83834a03-4f75-4562-9b56-e5c9d51d3e85.png)

## :robot: Solution
Faire démarrer le label par l'acronyme  MER ou MEP

## :rainbow: Remarques
Ca ne va pas tenir longtemps, l'ajout de nouvelles fonctionnalités va reléguer les MEP/MEP en fin de liste.
Une solution possible: isoler des actions dans une application dédiée.

## :100: Pour tester
Se rendre sur PixBot test, canal #tech-releases 
Vérifier que le libellé est correct (l'action va échouer, pas de déclenchement réel)