### PR TITLE
[FEATURE] Filtrer les PR draft sur la commande Slack /pr-pix 

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -37,7 +37,7 @@ async function _getPullReviewsFromGithub(label) {
 
   try {
     const { data } = await octokit.search.issuesAndPullRequests({
-      q: `is:pr+is:open+archived:false+user:${owner}+label:${label}`,
+      q: `is:pr+is:open+archived:false+draft:false+user:${owner}+label:${label}`,
       sort: 'updated',
       order: 'desc',
     });

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -18,7 +18,7 @@ describe('#getPullRequests', function () {
 
     nock('https://api.github.com')
       .get(
-        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3Ateam-certif&sort=updated&order=desc'
+        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+draft%3Afalse+user%3Agithub-owner+label%3Ateam-certif&sort=updated&order=desc'
       )
       .reply(200, { items });
 
@@ -55,7 +55,7 @@ describe('#getPullRequests', function () {
     const items = [{ html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [{ name: 'team certif' }] }];
     scopePr = nock('https://api.github.com')
       .get(
-        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+user%3Agithub-owner+label%3ATech%2520Review%2520Needed&sort=updated&order=desc'
+        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+draft%3Afalse+user%3Agithub-owner+label%3ATech%2520Review%2520Needed&sort=updated&order=desc'
       )
       .reply(200, { items });
 

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -49,13 +49,13 @@ describe('#getPullRequests', function () {
     expect(response).to.deep.equal(expectedResponse);
   });
 
-  it('should call the Github API with the label without space', async function () {
+  it('should call the Github API with the label', async function () {
     // given
     let scopePr, scopeReview;
-    const items = [{ html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [{ name: 'team certif' }] }];
+    const items = [{ html_url: 'http://test1.fr', number: 0, title: 'PR1', labels: [{ name: 'cross-team' }] }];
     scopePr = nock('https://api.github.com')
       .get(
-        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+draft%3Afalse+user%3Agithub-owner+label%3ATech%2520Review%2520Needed&sort=updated&order=desc'
+        '/search/issues?q=is%3Apr+is%3Aopen+archived%3Afalse+draft%3Afalse+user%3Agithub-owner+label%3Across-team&sort=updated&order=desc'
       )
       .reply(200, { items });
 
@@ -64,7 +64,7 @@ describe('#getPullRequests', function () {
       .reply(200, []);
 
     // when
-    await githubService.getPullRequests('Tech Review Needed');
+    await githubService.getPullRequests('cross-team');
 
     // then
     expect(scopePr.isDone());


### PR DESCRIPTION
## :unicorn: Problème
Des PRs non prêtes à la review peuvent remonter lorsque l'on utilise la commande `/pr-pix` sur le Slack Pix.

## :robot: Solution
Filtrer les PRs draft pour ne pas les retourner.

## :rainbow: Remarques
Petite mise à jour de test en même temps.

## :100: Pour tester
Comparer le résultat de `/pr-pix cross-team` sur le Slack de test et de prod
