### PR TITLE
[TECH] Gérer les erreurs inattendues

### DIFF
--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -1,8 +1,11 @@
+const { scalingo } = require('../config');
+
 function handleErrors(request, h) {
   const response = request.response;
 
   if (response instanceof Error && response.output.statusCode !== 401 && response.output.statusCode !== 400) {
-    console.log(response.stack);
+    const stacktrace = response.stack.slice(0, scalingo.maxLogLength);
+    console.error(stacktrace);
     return h.response('An error occurred, please try again later').code(500);
   }
 

--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -2,11 +2,17 @@ const { scalingo } = require('../config');
 
 function handleErrors(request, h) {
   const response = request.response;
+  const expectedStatusCodes = [401, 400];
 
-  if (response instanceof Error && response.output.statusCode !== 401 && response.output.statusCode !== 400) {
-    const stacktrace = response.stack.slice(0, scalingo.maxLogLength);
-    console.error(stacktrace);
-    return h.response('An error occurred, please try again later').code(500);
+  if (response instanceof Error) {
+    const statusCode = response?.output?.statusCode;
+    if (!expectedStatusCodes.includes(statusCode)) {
+      {
+        const message = response.stack.slice(0, scalingo.maxLogLength);
+        console.error(message);
+        return h.response('An error occurred, please try again later').code(500);
+      }
+    }
   }
 
   return h.continue;

--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -1,0 +1,14 @@
+function handleErrors(request, h) {
+  const response = request.response;
+
+  if (response instanceof Error) {
+    console.log(response.stack);
+    return h.response('An error occurred, please try again later').code(500);
+  }
+
+  return h.continue;
+}
+
+module.exports = {
+  handleErrors,
+};

--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -1,7 +1,7 @@
 function handleErrors(request, h) {
   const response = request.response;
 
-  if (response instanceof Error) {
+  if (response instanceof Error && response.output.statusCode !== 401 && response.output.statusCode !== 400) {
     console.log(response.stack);
     return h.response('An error occurred, please try again later').code(500);
   }

--- a/config.js
+++ b/config.js
@@ -49,6 +49,7 @@ module.exports = (function () {
         'router',
         'test',
       ],
+      maxLogLength: process.env.MAX_LOG_LENGTH || 1000,
     },
 
     openApi: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-plugin-prettier": "^4.2.1",
         "fs-extra": "^10.1.0",
+        "http-status-codes": "^2.2.0",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "mocha": "^9.2.2",
@@ -1914,6 +1915,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
     },
     "node_modules/human-signals": {
       "version": "3.0.1",
@@ -5278,6 +5285,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
       "dev": true
     },
     "human-signals": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "fs-extra": "^10.1.0",
+    "http-status-codes": "^2.2.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "mocha": "^9.2.2",

--- a/sample.env
+++ b/sample.env
@@ -339,3 +339,16 @@ SCALINGO_TOKEN_INTEGRATION=__CHANGE_ME__
 # type: String (URL)
 # default: "https://api.osc-fr1.scalingo.com"
 SCALINGO_API_URL_INTEGRATION=https://api.osc-fr1.scalingo.com
+
+# ======================
+# LOGGING
+# ======================
+
+# Maximum log length
+#
+# Truncate all logs to ensure it can be processed correctly in log ingester
+#
+# presence: optional
+# type: integer
+# default: 1000
+# MAX_LOG_LENGTH=100

--- a/server.js
+++ b/server.js
@@ -9,10 +9,17 @@ const runManifest = require('./run/manifest');
 const buildManifest = require('./build/manifest');
 const { slackConfig } = require('./common/config');
 const manifests = [runManifest, buildManifest];
+const preResponseHandler = require('./common/pre-response-handler');
+
+const setupErrorHandling = function (server) {
+  server.ext('onPreResponse', preResponseHandler.handleErrors);
+};
 
 const server = Hapi.server({
   port: config.port,
 });
+
+setupErrorHandling(server);
 
 ['/build', '/run', '/common'].forEach((subDir) => {
   const routesDir = path.join(__dirname, subDir, '/routes');

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -1,8 +1,32 @@
-const { expect } = require('../../test-helper');
+const { expect, StatusCodes } = require('../../test-helper');
 const server = require('../../../server');
 const { version } = require('../../../package.json');
 
 describe('Acceptance | Common | Index', function () {
+  describe('on every route', function () {
+    context('when an error is thrown', function () {
+      it('should respond an INTERNAL_SERVER_ERROR (500) and a high-level message', async function () {
+        // given
+        server.route([
+          {
+            method: 'GET',
+            path: '/throw-error',
+            handler: () => {
+              throw new Error('Some developer-oriented diagnostic message');
+            },
+          },
+        ]);
+        const response = await server.inject({
+          method: 'GET',
+          url: '/throw-error',
+        });
+        expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.result).to.not.equal('Some developer-oriented diagnostic message');
+        expect(response.result).to.equal('An error occurred, please try again later');
+      });
+    });
+  });
+
   describe('GET /', function () {
     it('responds with 200', async function () {
       const res = await server.inject({

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -9,10 +9,12 @@ const { StatusCodes } = require('http-status-codes');
 
 chai.use(require('sinon-chai'));
 
+// eslint-disable-next-line mocha/no-top-level-hooks
 beforeEach(function () {
   nock.disableNetConnect();
 });
 
+// eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(function () {
   sinon.restore();
   nock.cleanAll();

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -5,6 +5,8 @@ const nock = require('nock');
 const crypto = require('crypto');
 const config = require('../config');
 
+const { StatusCodes } = require('http-status-codes');
+
 chai.use(require('sinon-chai'));
 
 beforeEach(function () {
@@ -150,4 +152,5 @@ module.exports = {
   createSlackWebhookSignatureHeaders,
   nockGithubWithConfigChanges,
   nockGithubWithNoConfigChanges,
+  StatusCodes,
 };


### PR DESCRIPTION
## :unicorn: Problème
Si l'une des routes ne gère pas toutes les erreurs, le serveur Web sort en erreur.
De plus, la stacktrace affichée n'est pas lisible.

## :robot: Solution
Catcher toute erreur non interceptée.
Répondre 500 à l'utilisateur avec un message d'erreur générique.
Tracer la stracktrace complète (la tronquer suivant les possibilités de Scalingo).

## :rainbow: Remarques
Création d'une route de test comme dans le monorepo, mais qui peut être supprimée si besoin.
Discussion sur https://1024pix.slack.com/archives/C658LDBAQ/p1665732852955529

La gestion des erreurs "attendues" (401, 400) n'est pas aussi claire que dans le monorepo (`DomainErrors`).

## :100: Pour tester

Configurer le log

```shell
scalingo --region osc-fr1 --app pix-bot-review-pr156 env-set MAX_LOG_LENGTH=1500
scalingo --region osc-fr1 --app pix-bot-review-pr156 restart
```
Provoquer une erreur inattendue
``` shell
scalingo --region osc-fr1 --app pix-bot-review-pr156 env-set SCALINGO_TOKEN=foo
scalingo --region osc-fr1 --app pix-bot-review-pr156 restart
```

Brancher le slack `PixBotTest` à la PR et déclencher n'importe quelle action


Vérifier que:
- la stacktrace est tracée
- la réponse HTTP est 500
``` shell
scalingo --region osc-fr1 --app pix-bot-review-pr156 logs
```

Le message doit être de la forme suivante
```
Error: Some developer-oriented diagnostic message
    at throwError (/pix-bot/common/controllers/index.js:31:11)
    at exports.Manager.execute (/repo/pix-bot/node_modules/@hapi/hapi/lib/toolkit.js:57:29)
```