### PR TITLE
[TECH] Empêcher le merge si un rebase est en cours

### DIFF
--- a/.github/workflows/prevent-fixup-commit.yaml
+++ b/.github/workflows/prevent-fixup-commit.yaml
@@ -1,0 +1,14 @@
+name: commits check
+on:
+  # eslint-disable-next-line yml/no-empty-mapping-value
+  pull_request:
+jobs:
+  block-autosquash-commits:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Block Autosquash Commits
+        uses: xt0rted/block-autosquash-commits-action@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :unicorn: Problème
Si un rebase est en cours, le nom du commit porte le nom de l'action (ex: fixup!)

## :robot: Solution
Utiliser une GHA pour empêcher le merge

## :100: Pour tester
Pousser un commit coupable et vérifier que le merge est désactivé