### PR TITLE
[BUGFIX] Mise a jour de scalingo-review-app-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3177,9 +3177,9 @@
       }
     },
     "node_modules/scalingo-review-app-manager": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.2.tgz",
-      "integrity": "sha512-4djHkgVHiP9JeLcT9sKb+pVh7aFb1ngDdD+SoMsz3FNkb3MEzOmyg5wwPFS3+jevHTzphW9/uwxKww67FUgEkg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.4.tgz",
+      "integrity": "sha512-pIuZ0VTu+Oai++aax8AoCPHsTpvKTS2oW9LtICdfkggWGsITFAkLn5r7sXujHXfqY4XZpDvdU2SK6Fdyl7/r8Q==",
       "dependencies": {
         "cron": "^2.1.0",
         "scalingo": "^0.7.0"
@@ -6218,9 +6218,9 @@
       }
     },
     "scalingo-review-app-manager": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.2.tgz",
-      "integrity": "sha512-4djHkgVHiP9JeLcT9sKb+pVh7aFb1ngDdD+SoMsz3FNkb3MEzOmyg5wwPFS3+jevHTzphW9/uwxKww67FUgEkg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.4.tgz",
+      "integrity": "sha512-pIuZ0VTu+Oai++aax8AoCPHsTpvKTS2oW9LtICdfkggWGsITFAkLn5r7sXujHXfqY4XZpDvdU2SK6Fdyl7/r8Q==",
       "requires": {
         "cron": "^2.1.0",
         "scalingo": "^0.7.0"


### PR DESCRIPTION
## :unicorn: Problème
Pix-bot crashe lorsque l'API de scalingo échoue a scaler un container.


## :robot: Solution
Pour ne pas envoyer d'exception en cas d'erreur, la dépendance `scalingo-review-app-manager` a été mise à jour. 
