### PR TITLE
[BUGFIX]

### DIFF
--- a/config.js
+++ b/config.js
@@ -105,7 +105,7 @@ module.exports = (function () {
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex'],
 
     PIX_METABASE_REPO_NAME: 'metabase-deploy',
-    PIX_METABASE_APPS_NAME: ['pix-metabase-production', 'pix-data-metabase-dev'],
+    PIX_METABASE_APPS_NAME: ['pix-metabase-production', 'pix-data-metabase-production'],
 
     PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api'],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -16,7 +16,7 @@ describe('Integration | Run | Services | Slack | Commands', function () {
         .post('/v1/apps/pix-metabase-production/deployments', deploymentPayload)
         .reply(200, {});
       const scalingoDeployMetabaseDataNock = nock('https://scalingo.production')
-        .post('/v1/apps/pix-data-metabase-dev/deployments', deploymentPayload)
+        .post('/v1/apps/pix-data-metabase-production/deployments', deploymentPayload)
         .reply(200, {});
 
       await commands.deployMetabase();

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -334,7 +334,7 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(client.deployFromArchive, 'pix-metabase-production', 'master', 'metabase-deploy', {
         withEnvSuffix: false,
       });
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-data-metabase-dev', 'master', 'metabase-deploy', {
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-data-metabase-production', 'master', 'metabase-deploy', {
         withEnvSuffix: false,
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Le nom de l'application pix-data-metabase-dev a été renommé en pix-data-metabase-production sur scalingo.

## :robot: Solution
Faire le changement sur pix-bot
