### PR TITLE
[BUGFIX] Mise à jour de scalingo-review-app-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3177,9 +3177,9 @@
       }
     },
     "node_modules/scalingo-review-app-manager": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.4.tgz",
-      "integrity": "sha512-pIuZ0VTu+Oai++aax8AoCPHsTpvKTS2oW9LtICdfkggWGsITFAkLn5r7sXujHXfqY4XZpDvdU2SK6Fdyl7/r8Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.5.tgz",
+      "integrity": "sha512-XB34JatiqYCKRuNFocwlGzWWcvchLHdMEF7pImV3fT61jivodX2ct9c3MuA+UaYGgYGr0EmtC4l4WVip0aIF4Q==",
       "dependencies": {
         "cron": "^2.1.0",
         "scalingo": "^0.7.0"
@@ -6218,9 +6218,9 @@
       }
     },
     "scalingo-review-app-manager": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.4.tgz",
-      "integrity": "sha512-pIuZ0VTu+Oai++aax8AoCPHsTpvKTS2oW9LtICdfkggWGsITFAkLn5r7sXujHXfqY4XZpDvdU2SK6Fdyl7/r8Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/scalingo-review-app-manager/-/scalingo-review-app-manager-1.0.5.tgz",
+      "integrity": "sha512-XB34JatiqYCKRuNFocwlGzWWcvchLHdMEF7pImV3fT61jivodX2ct9c3MuA+UaYGgYGr0EmtC4l4WVip0aIF4Q==",
       "requires": {
         "cron": "^2.1.0",
         "scalingo": "^0.7.0"


### PR DESCRIPTION
## :unicorn: Problème
Nous avions une régression sur scalingo-review-app-manager pour traiter les cas de non scaling des containers. La régression a été fixé dans la version 1.0.5 du package.

## :robot: Solution
Mettre à jour a la version 1.0.5
