### PR TITLE
Adding pix-datawarehouse-data to pix-db-replication app

### DIFF
--- a/config.js
+++ b/config.js
@@ -102,7 +102,7 @@ module.exports = (function () {
     PIX_SITE_REPO_NAME: 'pix-site',
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
-    PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex'],
+    PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex', 'pix-datawarehouse-data'],
 
     PIX_METABASE_REPO_NAME: 'metabase-deploy',
     PIX_METABASE_APPS_NAME: ['pix-metabase-production', 'pix-data-metabase-production'],


### PR DESCRIPTION
## :unicorn: Problème
pix-datawarehouse-data vient d'être créé et n'est pas dans la liste des apps prise en charge pour la mise à jour de pix-db-replication

## :robot: Solution
l'ajouter

