### PR TITLE
[BUGFIX] Corrige les crashs liés aux déploiements de Review Apps Scalingo

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -32,11 +32,15 @@ module.exports = {
       if (labelsList.some((label) => label.name == 'no-review-app')) {
         return 'RA disabled for this PR';
       }
-      const client = await ScalingoClient.getInstance('reviewApps');
-      for (const appName of reviewApps) {
-        await client.deployReviewApp(appName, prId);
+      try {
+        const client = await ScalingoClient.getInstance('reviewApps');
+        for (const appName of reviewApps) {
+          await client.deployReviewApp(appName, prId);
+        }
+        return `Created RA on app ${reviewApps.join(', ')} with pr ${prId}`;
+      } catch (error) {
+        throw new Error(`Scalingo APIError: ${error.message}`);
       }
-      return `Created RA on app ${reviewApps.join(', ')} with pr ${prId}`;
     } else {
       return `Ignoring ${eventName} event`;
     }

--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -2,8 +2,7 @@ const { scalingo } = require('../config');
 
 function handleErrors(request, h) {
   const response = request.response;
-  const expectedStatusCodes = [401, 400];
-
+  const expectedStatusCodes = [404, 401, 400];
   if (response instanceof Error) {
     const statusCode = response?.output?.statusCode;
     if (!expectedStatusCodes.includes(statusCode)) {

--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -1,19 +1,7 @@
-const { scalingo } = require('../config');
-
 function handleErrors(request, h) {
-  const response = request.response;
-  const expectedStatusCodes = [404, 401, 400];
-  if (response instanceof Error) {
-    const statusCode = response?.output?.statusCode;
-    if (!expectedStatusCodes.includes(statusCode)) {
-      {
-        const message = response.stack.slice(0, scalingo.maxLogLength);
-        console.error(message);
-        return h.response('An error occurred, please try again later').code(500);
-      }
-    }
+  if (request.response.isBoom) {
+    console.error({ level: 'ERROR', message: request.response.message, stack: request.response.stack });
   }
-
   return h.continue;
 }
 

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -1,5 +1,4 @@
-const { expect } = require('chai');
-const { createGithubWebhookSignatureHeader, nock } = require('../../test-helper');
+const { expect, StatusCodes, createGithubWebhookSignatureHeader, nock } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Build | Github', function () {
@@ -161,6 +160,33 @@ describe('Acceptance | Build | Github', function () {
         payload: body,
       });
       expect(res.statusCode).to.equal(401);
+    });
+    context('when Scalingo API client throws an error', function () {
+      it('responds with 500 internal error', async function () {
+        const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(500, {
+          error: "Internal error occured, we're on it!",
+        });
+
+        const body = {
+          action: 'opened',
+          text: 'app-1',
+          pull_request: { labels: [], head: { repo: { name: 'pix-bot' } } },
+        };
+
+        const response = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+
+        expect(scalingoTokenNock.isDone()).to.be.true;
+        expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+        expect(response.result.message).to.equal('An internal server error occurred');
+      });
     });
   });
 });

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -1,4 +1,5 @@
-const { expect, StatusCodes } = require('../../test-helper');
+const { expect, StatusCodes, nock,
+  createGithubWebhookSignatureHeader } = require('../../test-helper');
 const server = require('../../../server');
 const { version } = require('../../../package.json');
 
@@ -22,6 +23,31 @@ describe('Acceptance | Common | Index', function () {
         });
         expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
         expect(response.result).to.not.equal('Some developer-oriented diagnostic message');
+        expect(response.result).to.equal('An error occurred, please try again later');
+      });
+
+      it('should not make Boom crash on a Scalingo APIError', async function () {
+        const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(500, {
+          error: "Internal error occured, we're on it!",
+        });
+        const body = {
+          action: 'opened',
+          text: 'app-1',
+          pull_request: { labels: [], head: { repo: { name: 'pix-bot' } } },
+        };
+
+        const response = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            "x-github-event": "pull_request"
+          },
+          payload: body,
+        });
+
+        expect(scalingoTokenNock.isDone()).to.be.true;
+        expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
         expect(response.result).to.equal('An error occurred, please try again later');
       });
     });

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -1,12 +1,11 @@
-const { expect, StatusCodes, nock,
-  createGithubWebhookSignatureHeader } = require('../../test-helper');
+const { expect, StatusCodes, nock, createGithubWebhookSignatureHeader } = require('../../test-helper');
 const server = require('../../../server');
 const { version } = require('../../../package.json');
 
 describe('Acceptance | Common | Index', function () {
   describe('on every route', function () {
     context('when an error is thrown', function () {
-      it('should respond an INTERNAL_SERVER_ERROR (500) and a high-level message', async function () {
+      it('should respond an INTERNAL_SERVER_ERROR (500)', async function () {
         // given
         server.route([
           {
@@ -22,8 +21,7 @@ describe('Acceptance | Common | Index', function () {
           url: '/throw-error',
         });
         expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
-        expect(response.result).to.not.equal('Some developer-oriented diagnostic message');
-        expect(response.result).to.equal('An error occurred, please try again later');
+        expect(response.result.message).to.equal('An internal server error occurred');
       });
 
       it('should not make Boom crash on a Scalingo APIError', async function () {
@@ -41,14 +39,14 @@ describe('Acceptance | Common | Index', function () {
           url: '/github/webhook',
           headers: {
             ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-            "x-github-event": "pull_request"
+            'x-github-event': 'pull_request',
           },
           payload: body,
         });
 
         expect(scalingoTokenNock.isDone()).to.be.true;
         expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
-        expect(response.result).to.equal('An error occurred, please try again later');
+        expect(response.result.message).to.equal('An internal server error occurred');
       });
     });
   });

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -53,6 +53,14 @@ describe('Acceptance | Common | Index', function () {
     });
   });
 
+  it('responds with 404', async function () {
+    const res = await server.inject({
+      method: 'GET',
+      url: '/should-not-exist',
+    });
+    expect(res.statusCode).to.equal(404);
+  });
+
   describe('GET /', function () {
     it('responds with 200', async function () {
       const res = await server.inject({

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -1,4 +1,4 @@
-const { expect, StatusCodes, nock, createGithubWebhookSignatureHeader } = require('../../test-helper');
+const { expect, StatusCodes } = require('../../test-helper');
 const server = require('../../../server');
 const { version } = require('../../../package.json');
 
@@ -20,31 +20,6 @@ describe('Acceptance | Common | Index', function () {
           method: 'GET',
           url: '/throw-error',
         });
-        expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
-        expect(response.result.message).to.equal('An internal server error occurred');
-      });
-
-      it('should not make Boom crash on a Scalingo APIError', async function () {
-        const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(500, {
-          error: "Internal error occured, we're on it!",
-        });
-        const body = {
-          action: 'opened',
-          text: 'app-1',
-          pull_request: { labels: [], head: { repo: { name: 'pix-bot' } } },
-        };
-
-        const response = await server.inject({
-          method: 'POST',
-          url: '/github/webhook',
-          headers: {
-            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-            'x-github-event': 'pull_request',
-          },
-          payload: body,
-        });
-
-        expect(scalingoTokenNock.isDone()).to.be.true;
         expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
         expect(response.result.message).to.equal('An internal server error occurred');
       });

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -51,12 +51,12 @@ describe('Acceptance | Common | Index', function () {
     });
   });
 
-  it('responds with 404', async function () {
-    const res = await server.inject({
+  it('should respond NOT_FOUND (404)', async function () {
+    const { statusCode } = await server.inject({
       method: 'GET',
       url: '/should-not-exist',
     });
-    expect(res.statusCode).to.equal(404);
+    expect(statusCode).to.equal(StatusCodes.NOT_FOUND);
   });
 
   describe('GET /', function () {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le client Scalingo renvoie une APIError, le code de Boom tente de modifier le champ data, qui n'a pas de setter. 
Cette tentative provoque un crash de l'application.

## :robot: Solution
Catcher l'erreur sur la creation des RA et la renvoyer dans un format exploitable par Boom.

## :rainbow: Remarques
J'en ai profité pour simplifier le gestionnaire d'erreurs qui remplaçait ce que Boom fait déjà, et remplaçait les codes de retours par des 500, ce qui rendait les logs inexacts mais ne permettait pas d'empêcher les crash.

## :100: Pour tester

Lancer les tests