### PR TITLE
:art: Ecrire les logs d'erreurs sur une ligne

### DIFF
--- a/common/pre-response-handler.js
+++ b/common/pre-response-handler.js
@@ -1,6 +1,11 @@
 function handleErrors(request, h) {
   if (request.response.isBoom) {
-    console.error({ level: 'ERROR', message: request.response.message, stack: request.response.stack });
+    const errorLog = {
+      level: 'ERROR',
+      message: request.response.message,
+      stack: request.response.stack,
+    };
+    console.error(JSON.stringify(errorLog));
   }
   return h.continue;
 }


### PR DESCRIPTION
## :unicorn: Problème
Les logs d'erreurs sont écrites sur plusieurs lignes de la sortie standard, empêchant son parsing

## :robot: Solution
Stringify le log avant de l'envoyer

## :100: Pour tester
Lancer le test `test/acceptance/build/github_test.js` et vérifier que le log d'erreur est bien sur une seule ligne