### PR TITLE
Mise à jour du nom des application Gravitee APIM

### DIFF
--- a/config.js
+++ b/config.js
@@ -113,10 +113,10 @@ module.exports = (function () {
     PIX_TUTOS_APP_NAME: 'pix-tutos',
     PIX_GRAVITEE_APIM_REPO_NAME: 'pix-gravitee-apim',
     PIX_GRAVITEE_APIM_APPS_NAME: [
-      'pix-apim-portal-ui-production',
-      'pix-apim-gateway-production',
-      'pix-apim-management-ui-production',
-      'pix-apim-rest-api-production',
+      'pix-gravitee-apim-portal-ui-production',
+      'pix-gravitee-apim-gateway-production',
+      'pix-gravitee-apim-console-ui-production',
+      'pix-gravitee-apim-rest-api-production',
     ],
   };
 

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -38,10 +38,10 @@ describe('Integration | Run | Services | Slack | Commands', function () {
         },
       };
       const nockDeploys = [
-        'pix-apim-portal-ui-production',
-        'pix-apim-gateway-production',
-        'pix-apim-management-ui-production',
-        'pix-apim-rest-api-production',
+        'pix-gravitee-apim-portal-ui-production',
+        'pix-gravitee-apim-gateway-production',
+        'pix-gravitee-apim-console-ui-production',
+        'pix-gravitee-apim-rest-api-production',
       ].map((app) => {
         return nock('https://scalingo.production')
           .post(`/v1/apps/${app}/deployments`, deploymentPayload)


### PR DESCRIPTION
## :unicorn: Problème
Le nom des applications Gravitee APIM de production ont changé.
On ne peut plus déployer via Pix-bot

## :robot: Solution
Mettre a jour le noms des applications.