### PR TITLE
[TECH] Déployer Airflow en production depuis Slack

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -39,6 +39,17 @@ class ScalingoClient {
     return `Deployed ${scalingoApp} ${releaseTag}`;
   }
 
+  async deployFromSCM(scalingoApp, releaseTag) {
+    try {
+      await this.client.SCMRepoLinks.manualDeploy(scalingoApp, releaseTag);
+    } catch (e) {
+      console.error(e);
+      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`);
+    }
+
+    return `Deployement of ${scalingoApp} ${releaseTag} has been requested`;
+  }
+
   async getAppInfo(target) {
     if (['production', 'integration', 'recette'].includes(target)) {
       return await this._getAllAppsInfo(target);

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -33,18 +33,18 @@ class ScalingoClient {
       });
     } catch (e) {
       console.error(e);
-      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`);
+      throw new Error(`Unable to deploy ${scalingoApp} ${releaseTag}`);
     }
 
-    return `Deployed ${scalingoApp} ${releaseTag}`;
+    return `${scalingoApp} ${releaseTag} has been deployed`;
   }
 
-  async deployFromSCM(scalingoApp, releaseTag) {
+  async deployUsingSCM(scalingoApp, releaseTag) {
     try {
       await this.client.SCMRepoLinks.manualDeploy(scalingoApp, releaseTag);
     } catch (e) {
       console.error(e);
-      throw new Error(`Impossible to deploy ${scalingoApp} ${releaseTag}`);
+      throw new Error(`Unable to deploy ${scalingoApp} ${releaseTag}`);
     }
 
     return `Deployement of ${scalingoApp} ${releaseTag} has been requested`;

--- a/config.js
+++ b/config.js
@@ -118,6 +118,7 @@ module.exports = (function () {
       'pix-gravitee-apim-console-ui-production',
       'pix-gravitee-apim-rest-api-production',
     ],
+    PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -18,6 +18,15 @@ module.exports = {
     };
   },
 
+  deployAirflow(request) {
+    const payload = request.pre.payload;
+    commands.deployAirflow(payload);
+
+    return {
+      text: _getDeployStartedMessage(payload.text, 'Airflow'),
+    };
+  },
+
   createAndDeployPixSiteRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixSiteRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -111,6 +111,15 @@ manifest.registerSlashCommand({
   handler: slackbotController.deployGraviteeAPIM,
 });
 
+manifest.registerSlashCommand({
+  command: '/deploy-airflow',
+  path: '/slack/commands/deploy-airflow',
+  description: 'Déploie la version précisée de Airflow en production',
+  usage_hint: '/deploy-airflow $version',
+  should_escape: false,
+  handler: slackbotController.deployAirflow,
+});
+
 manifest.registerShortcut({
   name: 'MEP/Déployer une version',
   type: 'global',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -171,7 +171,7 @@ async function deployTagUsingSCM(appNames, tag) {
   const client = await ScalingoClient.getInstance('production');
   return Promise.all(
     appNames.map((appName) => {
-      return client.deployFromSCM(appName, tag);
+      return client.deployUsingSCM(appName, tag);
     })
   );
 }

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -20,6 +20,7 @@ const {
   PIX_TUTOS_APP_NAME,
   PIX_GRAVITEE_APIM_REPO_NAME,
   PIX_GRAVITEE_APIM_APPS_NAME,
+  PIX_AIRFLOW_APP_NAME,
 } = require('../../../config');
 const releasesService = require('../../../common/services/releases');
 const ScalingoClient = require('../../../common/services/scalingo-client');
@@ -166,7 +167,21 @@ async function deployFromBranch(repoName, appNames, branch) {
   );
 }
 
+async function deployTagUsingSCM(appNames, tag) {
+  const client = await ScalingoClient.getInstance('production');
+  return Promise.all(
+    appNames.map((appName) => {
+      return client.deployFromSCM(appName, tag);
+    })
+  );
+}
+
 module.exports = {
+  async deployAirflow(payload) {
+    const version = payload.text;
+    await deployTagUsingSCM([PIX_AIRFLOW_APP_NAME], version);
+  },
+
   async deployGraviteeAPIM() {
     await deployFromBranch(PIX_GRAVITEE_APIM_REPO_NAME, PIX_GRAVITEE_APIM_APPS_NAME, 'main');
   },

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -119,6 +119,13 @@ describe('Acceptance | Run | Manifest', function () {
               url: `http://${hostname}/slack/commands/deploy-gravitee-apim`,
               usage_hint: undefined,
             },
+            {
+              command: '/deploy-airflow',
+              description: 'Déploie la version précisée de Airflow en production',
+              should_escape: false,
+              url: `http://${hostname}/slack/commands/deploy-airflow`,
+              usage_hint: '/deploy-airflow $version',
+            },
           ],
         },
         oauth_config: {

--- a/test/acceptance/run/slashcommand_test.js
+++ b/test/acceptance/run/slashcommand_test.js
@@ -1,4 +1,4 @@
-const { expect, createSlackWebhookSignatureHeaders } = require('../../test-helper');
+const { expect, createSlackWebhookSignatureHeaders, nock } = require('../../test-helper');
 const server = require('../../../server');
 
 describe('Acceptance | Run | SlashCommand', function () {
@@ -27,6 +27,45 @@ describe('Acceptance | Run | SlashCommand', function () {
       });
       expect(res.statusCode).to.equal(200);
       expect(res.result.text).to.equal('Commande de déploiement de Gravitee APIM en production bien reçue.');
+    });
+  });
+
+  describe('POST /slack/commands/deploy-airflow', function () {
+    it('responds with 200 and deploys pix-airflow-production', async function () {
+      const body = {
+        text: 'v0.0.1',
+      };
+      const res = await server.inject({
+        method: 'POST',
+        url: '/slack/commands/deploy-airflow',
+        headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
+        payload: body,
+      });
+      expect(res.statusCode).to.equal(200);
+      expect(res.result.text).to.equal(
+        'Commande de déploiement de la release "v0.0.1" pour Airflow en production bien reçue.'
+      );
+    });
+
+    it('should call Scalingo SCM', function (done) {
+      const body = {
+        text: 'v0.0.1',
+      };
+      nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
+      const scalingo = nock('https://scalingo.production')
+        .post(`/v1/apps/pix-airflow-production/scm_repo_link/manual_deploy`, { branch: 'v0.0.1' })
+        .reply(200, {});
+
+      server.inject({
+        method: 'POST',
+        url: '/slack/commands/deploy-airflow',
+        headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
+        payload: body,
+      });
+
+      scalingo.on('replied', () => {
+        done();
+      });
     });
   });
 });

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -56,4 +56,26 @@ describe('Integration | Run | Services | Slack | Commands', function () {
       });
     });
   });
+  describe('#deployAirflow', function () {
+    it('should call Scalingo API to deploy a specified tag', async function () {
+      const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
+      const airflowVersion = 'v0.0.1';
+      const deploymentPayload = {
+        branch: airflowVersion,
+      };
+
+      const commandPayload = {
+        text: airflowVersion,
+      };
+
+      const nockCall = nock('https://scalingo.production')
+        .post(`/v1/apps/pix-airflow-production/scm_repo_link/manual_deploy`, deploymentPayload)
+        .reply(200, {});
+
+      await commands.deployAirflow(commandPayload);
+
+      expect(scalingoTokenNock.isDone()).to.be.true;
+      expect(nockCall.isDone()).to.be.true;
+    });
+  });
 });

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -134,6 +134,36 @@ describe('Scalingo client', () => {
     });
   });
 
+  describe('#ScalingoClient.deployFromSCM', () => {
+    let manualDeployStub;
+    let scalingoClient;
+
+    beforeEach(async function () {
+      manualDeployStub = sinon.stub();
+      sinon.stub(scalingo, 'clientFromToken').resolves({ SCMRepoLinks: { manualDeploy: manualDeployStub } });
+
+      scalingoClient = await ScalingoClient.getInstance('production');
+    });
+
+    it('should deploy an application for a given tag', async () => {
+      await scalingoClient.deployFromSCM('pix-app-production', 'v1.0');
+      expect(manualDeployStub).to.have.been.calledOnceWithExactly('pix-app-production', 'v1.0');
+    });
+
+    it('should failed when application does not exists', async () => {
+      // given
+      sinon.stub(console, 'error');
+      manualDeployStub.rejects(new Error());
+      // when
+      try {
+        await scalingoClient.deployFromSCM('unknown-app-production', 'v1.0');
+        expect.fail('Should throw an error when application doesnt exists');
+      } catch (e) {
+        expect(e.message).to.equal('Impossible to deploy unknown-app-production v1.0');
+      }
+    });
+  });
+
   describe('#Scalingo.getAppInfo', () => {
     let clientAppsFind;
     let clientDeploymentsFind;

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -97,7 +97,7 @@ describe('Scalingo client', () => {
         source_url:
           'https://github-personal-access-token@github.com/github-owner/github-repository/archive/v1.0.tar.gz',
       });
-      expect(result).to.be.equal('Deployed pix-app-production v1.0');
+      expect(result).to.be.equal('pix-app-production v1.0 has been deployed');
     });
 
     it('should deploy an application without the environment suffix', async () => {
@@ -105,7 +105,7 @@ describe('Scalingo client', () => {
       // when
       const result = await scalingoClient.deployFromArchive('pix-app', 'v1.0', undefined, { withEnvSuffix: false });
       // then
-      expect(result).to.be.equal('Deployed pix-app v1.0');
+      expect(result).to.be.equal('pix-app v1.0 has been deployed');
     });
 
     it('should deploy an application for a given repository', async () => {
@@ -117,10 +117,10 @@ describe('Scalingo client', () => {
         git_ref: 'v1.0',
         source_url: 'https://github-personal-access-token@github.com/github-owner/given-repository/archive/v1.0.tar.gz',
       });
-      expect(result).to.be.equal('Deployed pix-app-production v1.0');
+      expect(result).to.be.equal('pix-app-production v1.0 has been deployed');
     });
 
-    it('should failed when application does not exists', async () => {
+    it('should fail when application does not exists', async () => {
       // given
       sinon.stub(console, 'error');
       createDeploymentStub.rejects(new Error());
@@ -129,12 +129,12 @@ describe('Scalingo client', () => {
         await scalingoClient.deployFromArchive('unknown-app', 'v1.0');
         expect.fail('Should throw an error when application doesnt exists');
       } catch (e) {
-        expect(e.message).to.equal('Impossible to deploy unknown-app-production v1.0');
+        expect(e.message).to.equal('Unable to deploy unknown-app-production v1.0');
       }
     });
   });
 
-  describe('#ScalingoClient.deployFromSCM', () => {
+  describe('#ScalingoClient.deployUsingSCM', () => {
     let manualDeployStub;
     let scalingoClient;
 
@@ -146,20 +146,20 @@ describe('Scalingo client', () => {
     });
 
     it('should deploy an application for a given tag', async () => {
-      await scalingoClient.deployFromSCM('pix-app-production', 'v1.0');
+      await scalingoClient.deployUsingSCM('pix-app-production', 'v1.0');
       expect(manualDeployStub).to.have.been.calledOnceWithExactly('pix-app-production', 'v1.0');
     });
 
-    it('should failed when application does not exists', async () => {
+    it('should fail when application does not exists', async () => {
       // given
       sinon.stub(console, 'error');
       manualDeployStub.rejects(new Error());
       // when
       try {
-        await scalingoClient.deployFromSCM('unknown-app-production', 'v1.0');
+        await scalingoClient.deployUsingSCM('unknown-app-production', 'v1.0');
         expect.fail('Should throw an error when application doesnt exists');
       } catch (e) {
-        expect(e.message).to.equal('Impossible to deploy unknown-app-production v1.0');
+        expect(e.message).to.equal('Unable to deploy unknown-app-production v1.0');
       }
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Le déploiement de Airflow en production nécessite de se connecter sur Scalingo, et ne peut être lancé que depuis une branche

## :robot: Solution
Brancher le déploiement sur Slack via une slash command

## :rainbow: Remarques
Comme le repo est privé et qu'il est linké à Github via SCM, on peut utiliser l'API Scalingo correspondante pour déployer sans avoir à gérer d'authentification.

## :100: Pour tester
Lancer les tests, merger, déployer Pix-bot et déployer la version actuelle d'Airflow via Slack + Pix-bot