### PR TITLE
[TECH] Tracer le message d'erreur du CDN

### DIFF
--- a/run/services/cdn.js
+++ b/run/services/cdn.js
@@ -40,19 +40,25 @@ async function invalidateCdnCache(application) {
   const namespaceKey = await _getNamespaceKey(application);
   const urlForInvalidate = `${CDN_URL}/cache/invalidations`;
 
-  await axios.post(
-    urlForInvalidate,
-    {
-      patterns: ['.'],
-    },
-    {
-      headers: {
-        'X-Api-Key': config.baleen.pat,
-        'Content-type': 'application/json',
-        Cookie: `baleen-namespace=${namespaceKey}`,
+  try {
+    await axios.post(
+      urlForInvalidate,
+      {
+        patterns: ['.'],
       },
-    }
-  );
+      {
+        headers: {
+          'X-Api-Key': config.baleen.pat,
+          'Content-type': 'application/json',
+          Cookie: `baleen-namespace=${namespaceKey}`,
+        },
+      }
+    );
+  } catch (error) {
+    const cdnResponseMessage = JSON.stringify(error.response.data);
+    const message = `Request failed with status code ${error.response.status} and message ${cdnResponseMessage}`;
+    throw new Error(message);
+  }
 
   return `Cache CDN invalidé pour l‘application ${application}.`;
 }


### PR DESCRIPTION
## :unicorn: Problème
Si l'invalidation du cache échoue, on ne n'a pas le détail de la réponse

La réponse du CDN
```json
{
  "type" : "https://www.jhipster.tech/problem/problem-with-message",
  "title" : "Bad Request",
  "status" : 400,
  "detail" : "JSON parse error: Unexpected character (',' (code 44)): expected a value; nested exception is com.fasterxml.jackson.core.JsonParseException: Unexpected character (',' (code 44)): expected a value\n at [Source: (PushbackInputStream); line: 1, column: 12]",
  "path" : "/api/cache/invalidations",
  "message" : "error.http.400"
}
```

Ce qui est loggé
```
Request failed with status code 500
```


## :robot: Solution
Ajouter le message de réponse du CDN dans l'erreur

## :rainbow: Remarques
Pour obtenir le format de réponse de Baleen, j'ai invalidé le cache depuis l'UI et renvoyé un payload invalide

## :100: Pour tester
Vérifier que la CI passe