### PR TITLE
Créer une application Scalingo avec une configuration valide via Slack

### DIFF
--- a/common/models/ScalingoAppName.js
+++ b/common/models/ScalingoAppName.js
@@ -1,12 +1,14 @@
 //TODO use EnvVars
 const config = require('../../config');
 const alphanumericAndDashOnly = /^([a-zA-Z0-9]+-)+[a-zA-Z0-9]+$/;
-const prefix = 'pix-';
+const prefix = config.scalingo.validAppPrefix;
 class ScalingoAppName {
   static isApplicationNameValid(applicationName) {
     const suffix = config.scalingo.validAppSuffix;
     const appNameMatchesRegex = applicationName.search(alphanumericAndDashOnly) >= 0;
-    const appNameHasCorrectLength = applicationName.length >= 6 && applicationName.length <= 46;
+    const appNameHasCorrectLength =
+      applicationName.length >= config.scalingo.validAppNbCharMin &&
+      applicationName.length <= config.scalingo.validAppNbCharMax;
     const appNameStartsWithPix = applicationName.startsWith(prefix);
     const appNameEndsWithCorrectSuffix = suffix.includes(applicationName.split('-').slice(-1)[0]);
     return appNameMatchesRegex && appNameHasCorrectLength && appNameStartsWithPix && appNameEndsWithCorrectSuffix;

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -108,8 +108,13 @@ class ScalingoClient {
     const app = {
       name: name,
     };
+    const appSettings = {
+      force_https: true,
+      router_logs: true,
+    };
     try {
       const { id } = await this.client.Apps.create(app);
+      await this.client.Apps.update(id, appSettings);
       return id;
     } catch (e) {
       console.error(JSON.stringify(e));

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -47,7 +47,7 @@ class ScalingoClient {
       throw new Error(`Unable to deploy ${scalingoApp} ${releaseTag}`);
     }
 
-    return `Deployement of ${scalingoApp} ${releaseTag} has been requested`;
+    return `Deployment of ${scalingoApp} ${releaseTag} has been requested`;
   }
 
   async getAppInfo(target) {

--- a/config.js
+++ b/config.js
@@ -49,6 +49,9 @@ module.exports = (function () {
         'router',
         'test',
       ],
+      validAppPrefix: 'pix',
+      validAppNbCharMax: 46,
+      validAppNbCharMin: 6,
       maxLogLength: process.env.MAX_LOG_LENGTH || 1000,
     },
 

--- a/run/services/slack/surfaces/modals/scalingo-apps/application-creation-confirmation.js
+++ b/run/services/slack/surfaces/modals/scalingo-apps/application-creation-confirmation.js
@@ -15,7 +15,7 @@ function modal(applicationName, applicationEnvironment, applicationEnvironmentNa
     close: 'Annuler',
   }).blocks([
     Blocks.Section({
-      text: `Vous vous apprêtez à créer l'application *${applicationName}* dans la région : *${applicationEnvironmentName}* et à inviter cet adesse email en tant que collaborateur : *${userEmail}*`,
+      text: `Vous vous apprêtez à créer l'application *${applicationName}* dans la région : *${applicationEnvironmentName}* et à inviter cet adresse email en tant que collaborateur : *${userEmail}*`,
     }),
   ]);
 }

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -6,6 +6,7 @@ const slackPostMessageService = require('../../../common/services/slack/surfaces
 const slackGetUserInfos = require('../../../common/services/slack/surfaces/user-infos/get-user-infos');
 const ScalingoClient = require('../../../common/services/scalingo-client');
 const { ScalingoAppName } = require('../../../common/models/ScalingoAppName');
+const config = require('../../../config');
 
 module.exports = {
   async submitReleaseTagSelection(payload) {
@@ -20,8 +21,14 @@ module.exports = {
     const applicationEnvironmentName =
       payload.view.state.values['application-env']['item']['selected_option']['text']['text'];
     const userEmail = await slackGetUserInfos.getUserEmail(payload.user.id);
+    const appSufixList = config.scalingo.validAppSuffix.toString();
     if (!ScalingoAppName.isApplicationNameValid(applicationName)) {
-      return `${applicationName} is incorrect`;
+      return {
+        response_action: 'errors',
+        errors: {
+          'create-app-name': `${applicationName} is incorrect, it should start with "${config.scalingo.validAppPrefix}-" and end with one of the following : ${appSufixList}. Also the length should be between ${config.scalingo.validAppNbCharMin} and ${config.scalingo.validAppNbCharMax} characters.`,
+        },
+      };
     }
     return openModalApplicationCreationConfirmation(
       applicationName,

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -397,7 +397,7 @@ describe('Acceptance | Run | Slack', function () {
                 {
                   text: {
                     type: 'mrkdwn',
-                    text: "Vous vous apprêtez à créer l'application *pix-application-de-folie-recette* dans la région : *recette* et à inviter cet adesse email en tant que collaborateur : *john.doe@pix.fr*",
+                    text: "Vous vous apprêtez à créer l'application *pix-application-de-folie-recette* dans la région : *recette* et à inviter cet adresse email en tant que collaborateur : *john.doe@pix.fr*",
                   },
                   type: 'section',
                 },

--- a/test/integration/common/services/slack/view-submissions_test.js
+++ b/test/integration/common/services/slack/view-submissions_test.js
@@ -1,0 +1,130 @@
+const { expect, sinon } = require('../../../../test-helper');
+const viewSubmissions = require('../../../../../run/services/slack/view-submissions');
+const slackGetUserInfos = require('../../../../../common/services/slack/surfaces/user-infos/get-user-infos');
+
+describe('view-submissions', function () {
+  describe('#submitApplicationNameSelection', function () {
+    context('when application name is invalid', function () {
+      it('should return error message', async function () {
+        // given
+        const applicationName = 'foo-bar-production';
+        const applicationEnvironment = 'production';
+        const applicationEnvironmentName = 'production';
+        const userId = 1;
+        const userEmail = 'john.doe@pix.fr';
+
+        const getUserEmailStub = sinon.stub(slackGetUserInfos, 'getUserEmail');
+        getUserEmailStub.resolves(userEmail);
+
+        const payload = {
+          view: {
+            state: {
+              values: {
+                'create-app-name': {
+                  'scalingo-app-name': {
+                    value: applicationName,
+                  },
+                },
+                'application-env': {
+                  item: {
+                    selected_option: {
+                      value: applicationEnvironment,
+                      text: {
+                        text: applicationEnvironmentName,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          user: { id: userId },
+        };
+
+        // when
+        const actual = await viewSubmissions.submitApplicationNameSelection(payload);
+
+        // then
+        expect(actual).to.deep.equal({
+          response_action: 'errors',
+          errors: {
+            'create-app-name': `foo-bar-production is incorrect, it should start with "pix-" and end with one of the following : production,review,integration,recette,sandbox,dev,router,test. Also the length should be between 6 and 46 characters.`,
+          },
+        });
+      });
+    });
+    context('when application name is valid', function () {
+      it('should return response', async function () {
+        // given
+        const applicationName = 'pix-foo-production';
+        const applicationEnvironment = 'production';
+        const applicationEnvironmentName = 'production';
+        const userId = 1;
+        const userEmail = 'john.doe@pix.fr';
+
+        const getUserEmailStub = sinon.stub(slackGetUserInfos, 'getUserEmail');
+        getUserEmailStub.resolves(userEmail);
+
+        const payload = {
+          view: {
+            state: {
+              values: {
+                'create-app-name': {
+                  'scalingo-app-name': {
+                    value: applicationName,
+                  },
+                },
+                'application-env': {
+                  item: {
+                    selected_option: {
+                      value: applicationEnvironment,
+                      text: {
+                        text: applicationEnvironmentName,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          user: { id: userId },
+        };
+
+        // when
+        const actual = await viewSubmissions.submitApplicationNameSelection(payload);
+
+        // then
+        expect(actual).to.deep.equal({
+          response_action: 'push',
+          view: {
+            blocks: [
+              {
+                text: {
+                  text: "Vous vous apprêtez à créer l'application *pix-foo-production* dans la région : *production* et à inviter cet adresse email en tant que collaborateur : *john.doe@pix.fr*",
+                  type: 'mrkdwn',
+                },
+                type: 'section',
+              },
+            ],
+            callback_id: 'application-creation-confirmation',
+            close: {
+              text: 'Annuler',
+              type: 'plain_text',
+            },
+            private_metadata:
+              '{"applicationName":"pix-foo-production","applicationEnvironment":"production","userEmail":"john.doe@pix.fr"}',
+            submit: {
+              text: '🚀 Go !',
+              type: 'plain_text',
+            },
+            title: {
+              text: 'Confirmation',
+              type: 'plain_text',
+            },
+            type: 'modal',
+          },
+        });
+      });
+    });
+  });
+});

--- a/test/integration/run/services/slack/view-submissions_test.js
+++ b/test/integration/run/services/slack/view-submissions_test.js
@@ -1,0 +1,56 @@
+const slackViewSubmissions = require('../../../../../run/services/slack/view-submissions');
+const { expect, nock, createScalingoTokenNock } = require('../../../../test-helper');
+
+describe('Integration | Run | Services | Slack | Commands', function () {
+  describe('#submitCreateAppOnScalingoConfirmation', function () {
+    it('creates a scalingo application', async function () {
+      const payload = {
+        user: { id: 'idslack' },
+        view: {
+          private_metadata:
+            '{"applicationName": "foobar","applicationEnvironment": "recette", "userEmail": "foo@bar.fr"}',
+        },
+      };
+      const expectedResponse = {
+        response_action: 'clear',
+      };
+
+      const expectedBody = { app: { name: 'foobar' } };
+      const expectedUpdateBody = {
+        app: {
+          force_https: true,
+          router_logs: true,
+        },
+      };
+      const expectedInviteCollaboratorBody = {
+        collaborator: { email: 'foo@bar.fr' },
+      };
+      createScalingoTokenNock();
+      nock(`https://scalingo.recette`)
+        .post('/v1/apps', JSON.stringify(expectedBody))
+        .reply(201, { app: { id: 1 } });
+      nock(`https://scalingo.recette`)
+        .patch('/v1/apps/1', JSON.stringify(expectedUpdateBody))
+        .reply(200, { app: { name: 'foobar' } });
+      nock(`https://scalingo.recette`)
+        .post('/v1/apps/1/collaborators', JSON.stringify(expectedInviteCollaboratorBody))
+        .reply(201, {
+          collaborator: [
+            {
+              email: 'collaborator@example.com',
+              id: '54101e25736f7563d5060000',
+              status: 'pending',
+              username: 'n/a',
+              invitation_link:
+                'https://my.scalingo.com/apps/collaboration?token=8415965b809c928c807dc99790e5745d97f05b8c',
+              app_id: '5343eccd646173000a140000',
+            },
+          ],
+        });
+
+      const response = await slackViewSubmissions.submitCreateAppOnScalingoConfirmation(payload);
+
+      expect(response).to.deep.equal(expectedResponse);
+    });
+  });
+});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -144,6 +144,9 @@ function nockGithubWithConfigChanges() {
     .reply(200, [{}]);
 }
 
+function createScalingoTokenNock() {
+  nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
+}
 // eslint-disable-next-line mocha/no-exports
 module.exports = {
   catchErr,
@@ -151,6 +154,7 @@ module.exports = {
   nock,
   sinon,
   createGithubWebhookSignatureHeader,
+  createScalingoTokenNock,
   createSlackWebhookSignatureHeaders,
   nockGithubWithConfigChanges,
   nockGithubWithNoConfigChanges,

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -411,8 +411,12 @@ describe('Scalingo client', () => {
     it('should return application identifier', async () => {
       // given
       const createApplicationStub = sinon.stub();
-      sinon.stub(scalingo, 'clientFromToken').resolves({ Apps: { create: createApplicationStub } });
+      const updateApplicationStub = sinon.stub();
+      sinon
+        .stub(scalingo, 'clientFromToken')
+        .resolves({ Apps: { create: createApplicationStub, update: updateApplicationStub } });
       createApplicationStub.resolves({ id: 1 });
+      updateApplicationStub.resolves();
       const scalingoClient = await ScalingoClient.getInstance('recette');
 
       // when
@@ -424,8 +428,12 @@ describe('Scalingo client', () => {
     it('should call create with application name', async () => {
       // given
       const createApplicationStub = sinon.stub();
-      sinon.stub(scalingo, 'clientFromToken').resolves({ Apps: { create: createApplicationStub } });
+      const updateApplicationStub = sinon.stub();
+      sinon
+        .stub(scalingo, 'clientFromToken')
+        .resolves({ Apps: { create: createApplicationStub, update: updateApplicationStub } });
       createApplicationStub.resolves({ id: 1 });
+      updateApplicationStub.resolves();
       const scalingoClient = await ScalingoClient.getInstance('recette');
 
       // when
@@ -433,6 +441,48 @@ describe('Scalingo client', () => {
 
       // then
       expect(createApplicationStub).to.have.been.calledOnceWithExactly({ name: 'pix-application-recette' });
+    });
+    it('should call update with valid options', async () => {
+      // given
+      const createApplicationStub = sinon.stub();
+      const updateApplicationStub = sinon.stub();
+      sinon
+        .stub(scalingo, 'clientFromToken')
+        .resolves({ Apps: { create: createApplicationStub, update: updateApplicationStub } });
+      createApplicationStub.resolves({ id: 1 });
+      updateApplicationStub.resolves();
+      const scalingoClient = await ScalingoClient.getInstance('recette');
+
+      // when
+      await scalingoClient.createApplication('pix-application-recette');
+
+      // then
+      expect(updateApplicationStub).to.have.been.calledOnceWithExactly(1, { force_https: true, router_logs: true });
+    });
+
+    it('should throw when scalingo client throw an error', async () => {
+      // given
+      const createApplicationStub = sinon.stub();
+      const updateApplicationStub = sinon.stub();
+      sinon
+        .stub(scalingo, 'clientFromToken')
+        .resolves({ Apps: { create: createApplicationStub, update: updateApplicationStub } });
+      createApplicationStub.resolves({ id: 1 });
+      updateApplicationStub.rejects({
+        name: 'foo',
+      });
+      const scalingoClient = await ScalingoClient.getInstance('recette');
+
+      // when
+      let actual;
+      try {
+        await scalingoClient.createApplication('pix-application-recette');
+      } catch (error) {
+        actual = error;
+      }
+
+      // then
+      expect(actual.message).to.equal('Impossible to create pix-application-recette, foo');
     });
   });
 });

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -406,4 +406,33 @@ describe('Scalingo client', () => {
       expect(manualReviewApp.called).to.be.true;
     });
   });
+
+  describe('#Scalingo.createApplication', () => {
+    it('should return application identifier', async () => {
+      // given
+      const createApplicationStub = sinon.stub();
+      sinon.stub(scalingo, 'clientFromToken').resolves({ Apps: { create: createApplicationStub } });
+      createApplicationStub.resolves({ id: 1 });
+      const scalingoClient = await ScalingoClient.getInstance('recette');
+
+      // when
+      const actual = await scalingoClient.createApplication('pix-application-recette');
+
+      // then
+      expect(actual).to.equal(1);
+    });
+    it('should call create with application name', async () => {
+      // given
+      const createApplicationStub = sinon.stub();
+      sinon.stub(scalingo, 'clientFromToken').resolves({ Apps: { create: createApplicationStub } });
+      createApplicationStub.resolves({ id: 1 });
+      const scalingoClient = await ScalingoClient.getInstance('recette');
+
+      // when
+      await scalingoClient.createApplication('pix-application-recette');
+
+      // then
+      expect(createApplicationStub).to.have.been.calledOnceWithExactly({ name: 'pix-application-recette' });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
La création d'une application via Slack n'active pas les options attendues par Steampipe.
De plus, le nom de l'application est contrôlé, mais s'il n'est pas correct, le message d'erreur ne mentionne pas les règles attendues.

## :gift: Proposition
Ajouter automatiquement les options concernées.
Si le nom de l'application est incorrect, mentionner les règles attendues.

## :star2: Remarques
Ajout de tests manquants.

## :santa: Pour tester
Configurer PixBotTest:
- supprimer le ngrok
- mettre à jour le manifeste depuis `https://pix-bot-review-pr168.osc-fr1.scalingo.io/run/manifest`

Dans `tech-releases`, saisir `scalingo`

Vérifier que l'application est créée avec:
- les logs routeurs
- le force_https à true
