### PR TITLE
:wrench: Désactiver les limites de PR de renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,8 @@
   ],
   "labels": ["renovate","no-review-app"],
   "schedule": ["at any time"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "ignorePresets": ["github>1024pix/renovate-config//presets/group-by-directory"],
   "enabled": true,
   "dependencyDashboard": false


### PR DESCRIPTION
Désactivation des limites de Renovate pour tester le fonctionnement