### PR TITLE
[TECH] Tracer les erreurs Github

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -294,10 +294,6 @@ module.exports = {
     return _getLatestReleaseTagName(settings.github.owner, repoName);
   },
 
-  async getLatestReleaseTagUrl(repoOwner, repoName = settings.github.repository) {
-    return _getLatestReleaseTagUrl(repoOwner, repoName);
-  },
-
   getLastCommitUrl,
 
   async getCommitAtURL(commitUrl) {

--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -1,0 +1,7 @@
+const error = (message, injectedLogger = console) => {
+  injectedLogger.error(JSON.stringify(message));
+};
+
+module.exports = {
+  error,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "chai": "^4.3.7",
+        "chai-nock": "^1.3.0",
         "depcheck": "^1.4.3",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
@@ -1431,6 +1432,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/chai-nock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/chai-nock/-/chai-nock-1.3.0.tgz",
+      "integrity": "sha512-O3j1bW3ACoUu/sLGYSoX50c1p8dbTkCjw3/dereqzl9BL2XsQAUVC18sJpg3hVwpCk71rjWGumCmHy87t5W+Pg==",
+      "dev": true,
+      "dependencies": {
+        "chai": "^4.2.0",
+        "deep-equal": "^1.0.1"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1763,11 +1774,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2433,6 +2477,15 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2555,10 +2608,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2678,6 +2758,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2703,6 +2799,21 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2777,6 +2888,22 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -3573,6 +3700,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3996,6 +4148,23 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -6029,6 +6198,16 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-nock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/chai-nock/-/chai-nock-1.3.0.tgz",
+      "integrity": "sha512-O3j1bW3ACoUu/sLGYSoX50c1p8dbTkCjw3/dereqzl9BL2XsQAUVC18sJpg3hVwpCk71rjWGumCmHy87t5W+Pg==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.2.0",
+        "deep-equal": "^1.0.1"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6281,11 +6460,35 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -6774,6 +6977,12 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6860,10 +7069,28 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "he": {
       "version": "1.2.0",
@@ -6947,6 +7174,16 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6969,6 +7206,15 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-extglob": {
@@ -7020,6 +7266,16 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-stream": {
       "version": "3.0.0",
@@ -7614,6 +7870,22 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7911,6 +8183,17 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.7",
+    "chai-nock": "^1.3.0",
     "depcheck": "^1.4.3",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -130,7 +130,8 @@ describe('Acceptance | Run | Slack', function () {
           });
         });
         it('returns the confirmation modal', async function () {
-          nockGithubWithNoConfigChanges();
+          // given
+          const nocks = nockGithubWithNoConfigChanges();
 
           const body = {
             type: 'view_submission',
@@ -147,12 +148,16 @@ describe('Acceptance | Run | Slack', function () {
               },
             },
           };
+
+          // when
           const res = await server.inject({
             method: 'POST',
             url: '/run/slack/interactive-endpoint',
             headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
             payload: body,
           });
+
+          // then
           expect(res.statusCode).to.equal(200);
           expect(JSON.parse(res.payload)).to.deep.equal({
             response_action: 'push',
@@ -183,6 +188,10 @@ describe('Acceptance | Run | Slack', function () {
               ],
             },
           });
+          expect(nocks.tags.isDone()).to.be.true;
+          expect(nocks.commit1234.isDone()).to.be.true;
+          expect(nocks.commit456.isDone()).to.be.true;
+          expect(nocks.commits.isDone()).to.be.true;
         });
 
         it('returns the confirmation modal with a warning', async function () {

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -188,10 +188,7 @@ describe('Acceptance | Run | Slack', function () {
               ],
             },
           });
-          expect(nocks.tags.isDone()).to.be.true;
-          expect(nocks.commit1234.isDone()).to.be.true;
-          expect(nocks.commit456.isDone()).to.be.true;
-          expect(nocks.commits.isDone()).to.be.true;
+          nocks.checkAllNocksHaveBeenCalled();
         });
 
         it('returns the confirmation modal with a warning', async function () {

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -4,6 +4,7 @@ const {
   createSlackWebhookSignatureHeaders,
   nockGithubWithNoConfigChanges,
   nockGithubWithConfigChanges,
+  StatusCodes,
 } = require('../../test-helper');
 const server = require('../../../server');
 
@@ -91,6 +92,43 @@ describe('Acceptance | Run | Slack', function () {
       });
 
       describe('with the callback release-tag-selection', function () {
+        describe('when the Github API returns an error', function () {
+          it('should return an INTERNAL_SERVER_ERROR (500)', async function () {
+            // given
+            const tagNock = nock('https://api.github.com')
+              .get('/repos/github-owner/github-repository/tags')
+              .reply(StatusCodes.FORBIDDEN, 'API rate limit exceeded for user ID 1. [rate reset in 8m48s]');
+
+            const body = {
+              type: 'view_submission',
+              view: {
+                callback_id: 'release-tag-selection',
+                state: {
+                  values: {
+                    'deploy-release-tag': {
+                      'release-tag-value': {
+                        value: 'v2.130.0',
+                      },
+                    },
+                  },
+                },
+              },
+            };
+
+            // when
+            const error = await server.inject({
+              method: 'POST',
+              url: '/run/slack/interactive-endpoint',
+              headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
+              payload: body,
+            });
+
+            // then
+            expect(error.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+            expect(error.statusMessage).to.equal('Internal Server Error');
+            expect(tagNock).to.have.been.requested;
+          });
+        });
         it('returns the confirmation modal', async function () {
           nockGithubWithNoConfigChanges();
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -6,8 +6,10 @@ const crypto = require('crypto');
 const config = require('../config');
 
 const { StatusCodes } = require('http-status-codes');
+const _ = require('lodash');
 
 chai.use(require('sinon-chai'));
+chai.use(require('chai-nock'));
 
 // eslint-disable-next-line mocha/no-top-level-hooks
 beforeEach(function () {
@@ -97,7 +99,15 @@ function nockGithubWithNoConfigChanges() {
     .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, []);
 
-  return { tags, commit1234, commit456, commits };
+  const nocks = { tags, commit1234, commit456, commits };
+
+  const checkAllNocksHaveBeenCalled = () => {
+    _.values(nocks).map((nock) => {
+      expect(nock).to.have.been.requested;
+    });
+  };
+
+  return { nocks, checkAllNocksHaveBeenCalled };
 }
 
 function nockGithubWithConfigChanges() {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -53,7 +53,7 @@ function createSlackWebhookSignatureHeaders(body) {
 }
 
 function nockGithubWithNoConfigChanges() {
-  nock('https://api.github.com')
+  const tags = nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/tags')
     .twice()
     .reply(200, [
@@ -69,7 +69,7 @@ function nockGithubWithNoConfigChanges() {
       },
     ]);
 
-  nock('https://api.github.com')
+  const commit1234 = nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/1234')
     .reply(200, {
       commit: {
@@ -79,7 +79,7 @@ function nockGithubWithNoConfigChanges() {
       },
     });
 
-  nock('https://api.github.com')
+  const commit456 = nock('https://api.github.com')
     .get('/repos/github-owner/github-repository/commits/456')
     .reply(200, {
       commit: {
@@ -89,13 +89,15 @@ function nockGithubWithNoConfigChanges() {
       },
     });
 
-  nock('https://api.github.com')
+  const commits = nock('https://api.github.com')
     .filteringPath(
       /since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g,
       'since=XXXX&until=XXXX'
     )
     .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
     .reply(200, []);
+
+  return { tags, commit1234, commit456, commits };
 }
 
 function nockGithubWithConfigChanges() {

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -1,0 +1,31 @@
+const { expect, sinon } = require('../../../test-helper');
+const logger = require('../../../../common/services/logger');
+
+describe('logger', function () {
+  describe('error', function () {
+    describe('when an message is passed', function () {
+      it('should call injectedLogger error with stringified message', function () {
+        // given
+        const injectedLogger = { error: sinon.stub() };
+
+        // when
+        logger.error('message', injectedLogger);
+
+        // then
+        expect(injectedLogger.error).to.have.been.calledOnceWithExactly('"message"');
+      });
+    });
+    describe('when an object is passed', function () {
+      it('should call injectedLogger error with stringified object', function () {
+        // given
+        const injectedLogger = { error: sinon.stub() };
+
+        // when
+        logger.error({ foo: 'bar' }, injectedLogger);
+
+        // then
+        expect(injectedLogger.error).to.have.been.calledOnceWithExactly('{"foo":"bar"}');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
En cas d'erreur Github API (ex: rate_limit atteint), la stack d'erreur n'est pas tracée proprement.
Elle est sur plusieurs lignes au lieu d'une.

![image](https://user-images.githubusercontent.com/56302715/207585963-19be0f95-55f4-461b-bbdc-41ced23427f3.png)

## :robot: Solution
Utiliser un [hook](https://octokit.github.io/rest.js/v19#hooks) Octokit pour tracer l'erreur dans la sortie standard avec un champ qui permettre de la filtrer dans Datadog.

Exemple pour le rate-limit (mais au format chaîne de caractères).
``` json
{
   "event": "github",
   "response": "API rate limit exceeded for user ID 1. [rate reset in 8m48s]",
}
```

## :rainbow: Remarques
Je n'ai pas pu tester manuellement que Hapi, lorsqu'il intercepte l'erreur:
- renvoie une 500 à l'utilisateur;
- trace l'erreur sur une seule ligne;

Il y a un test auto générique là-dessus.
test/acceptance/common/index_test.js

Mais en posant un autre test auto sur `/run/slack/interactive-endpoint`, je vois qu'on ne répond pas de 500.
Faut-il utiliser `Boom` pour que l'erreur soit catchée par Hapi ?

Quand est-ce qu'on passe à `pino` et `hapi-pino` ?
Doit-on vraiment renvoyer une 500 et pas une 503 comme pour PoleEmploi?

## :100: Pour tester
Vérifier que la CI passe

Créer un utilisateur et dépasser le rate-limit ? :thinking: 