### PR TITLE
[TECH] Linter les tests de manière homogène

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,10 @@ module.exports = {
   },
   rules: {
     'mocha/no-setup-in-describe': 'off',
+    'mocha/no-exclusive-tests': 'error',
+    'mocha/no-pending-tests': 'error',
+    'mocha/no-skipped-tests': 'error',
+    'mocha/no-hooks-for-single-case': 'off',
+    'mocha/no-top-level-hooks': 'error',
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
La configuration n'est pas la même que le monorepo: on ne vérifie pas la présence de tests exclusifs `only`, désactivés `skip`
Cela engendre de la confusion

## :robot: Solution
Utiliser la même configuration du plugin eslint `mocha`

## :rainbow: Remarques
On pourrait partager la configuration pour éviter les désynchronisations.

## :100: Pour tester
Ajouter un test exclusif avec `only`.
Vérifier que la CI fail.