### PR TITLE
[TECH] Corriger l'orthographe de la notification de déploiement en erreur

### DIFF
--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -2,6 +2,7 @@ const dayjs = require('dayjs');
 const slackPostMessageService = require('../../common/services/slack/surfaces/messages/post-message');
 const { Message, Section, Context, Attachment } = require('slack-block-builder');
 const config = require('../../config');
+const logger = require('../../common/services/logger');
 
 function getSlackMessageAttachments(payload) {
   const appName = payload.app_name;
@@ -39,18 +40,18 @@ function getSlackMessageAttachments(payload) {
 
 module.exports = {
   async deployEndpoint(request) {
-    console.log('Scalingo request received');
+    logger.info('Scalingo request received');
     if (request.payload.type_data?.status !== 'build-error') {
       return 'Slack error notification not sent';
     }
 
-    console.log(`Failed deployement on the ${request.payload.app_name} app`);
+    logger.info(`Failed deployement on the ${request.payload.app_name} app`);
 
     const { message, attachments } = getSlackMessageAttachments(request.payload);
 
     await slackPostMessageService.postMessage(message, JSON.stringify(attachments));
 
-    console.log('Slack error notification sent');
+    logger.info('Slack error notification sent');
 
     return 'Slack error notification sent';
   },

--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -45,7 +45,7 @@ module.exports = {
       return 'Slack error notification not sent';
     }
 
-    logger.info(`Failed deployement on the ${request.payload.app_name} app`);
+    logger.info(`Failed deployment on the ${request.payload.app_name} app`);
 
     const { message, attachments } = getSlackMessageAttachments(request.payload);
 

--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -2,6 +2,11 @@ const error = (message, injectedLogger = console) => {
   injectedLogger.error(JSON.stringify(message));
 };
 
+const info = (message, injectedLogger = console) => {
+  injectedLogger.log(JSON.stringify(message));
+};
+
 module.exports = {
   error,
+  info,
 };

--- a/test/acceptance/build/scalingo_test.js
+++ b/test/acceptance/build/scalingo_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Build | Scalingo', function () {
         expect(response.payload).to.equal('Slack error notification sent');
         expect(loggerInfoStub.calledThrice).to.be.true;
         expect(loggerInfoStub.firstCall.args[0]).to.equal('Scalingo request received');
-        expect(loggerInfoStub.secondCall.args[0]).to.equal('Failed deployement on the application app');
+        expect(loggerInfoStub.secondCall.args[0]).to.equal('Failed deployment on the application app');
         expect(loggerInfoStub.thirdCall.args[0]).to.equal('Slack error notification sent');
       });
     });

--- a/test/acceptance/build/scalingo_test.js
+++ b/test/acceptance/build/scalingo_test.js
@@ -1,0 +1,51 @@
+const { expect, StatusCodes, nock, sinon } = require('../../test-helper');
+const server = require('../../../server');
+const logger = require('../../../common/services/logger');
+
+describe('Acceptance | Build | Scalingo', function () {
+  describe('POST build/scalingo/deploy-endpoint', function () {
+    describe('when the build has failed', function () {
+      it('should post a message on slack and log a message', async function () {
+        // given
+        const payload = { app_name: 'application', type_data: { status: 'build-error' } };
+        const messageNock = nock('https://slack.com').post('/api/chat.postMessage').reply(StatusCodes.OK, { ok: true });
+        const loggerInfoStub = sinon.stub(logger, 'info');
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/build/scalingo/deploy-endpoint',
+          payload,
+        });
+
+        // then
+        expect(messageNock).to.have.been.requested;
+        expect(response.statusCode).to.equal(StatusCodes.OK);
+        expect(response.payload).to.equal('Slack error notification sent');
+        expect(loggerInfoStub.calledThrice).to.be.true;
+        expect(loggerInfoStub.firstCall.args[0]).to.equal('Scalingo request received');
+        expect(loggerInfoStub.secondCall.args[0]).to.equal('Failed deployement on the application app');
+        expect(loggerInfoStub.thirdCall.args[0]).to.equal('Slack error notification sent');
+      });
+    });
+    describe('when the build has succeeded', function () {
+      it('should return OK (200) and log a message', async function () {
+        // given
+        const payload = { type_data: { status: 'succeeded' } };
+        const loggerInfoStub = sinon.stub(logger, 'info');
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/build/scalingo/deploy-endpoint',
+          payload,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(StatusCodes.OK);
+        expect(response.payload).to.equal('Slack error notification not sent');
+        expect(loggerInfoStub).to.have.been.calledOnceWithExactly('Scalingo request received');
+      });
+    });
+  });
+});

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -28,4 +28,30 @@ describe('logger', function () {
       });
     });
   });
+  describe('info', function () {
+    describe('when an message is passed', function () {
+      it('should call injectedLogger log with stringified message', function () {
+        // given
+        const injectedLogger = { log: sinon.stub() };
+
+        // when
+        logger.info('message', injectedLogger);
+
+        // then
+        expect(injectedLogger.log).to.have.been.calledOnceWithExactly('"message"');
+      });
+    });
+    describe('when an object is passed', function () {
+      it('should call injectedLogger error with stringified object', function () {
+        // given
+        const injectedLogger = { log: sinon.stub() };
+
+        // when
+        logger.info({ foo: 'bar' }, injectedLogger);
+
+        // then
+        expect(injectedLogger.log).to.have.been.calledOnceWithExactly('{"foo":"bar"}');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
En cas de déploiement en erreur sur `pix-api-integration`, le message posté sur Slack est
`Failed deployement on the pix-api-integration application` 

## :robot: Solution
Poster le message
`Failed deployment on the pix-api-integration application` 

## :rainbow: Remarques
Ajout d'un test d'acceptance

## :100: Pour tester
Vérifier que la CI passe