### PR TITLE
[FEATURE] Change les liens vers les reviews app

### DIFF
--- a/build/templates/pull-request-messages/default.md
+++ b/build/templates/pull-request-messages/default.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici]({{webApplicationUrl}}).
-Les variables d'environnement seront accessibles [ici]({{scalingoDashboardUrl}}).
+Une fois l'application déployée, elle sera accessible à cette adresse {{webApplicationUrl}}
+Les variables d'environnement seront accessibles sur scalingo {{scalingoDashboardUrl}}

--- a/build/templates/pull-request-messages/pix-db-replication.md
+++ b/build/templates/pull-request-messages/pix-db-replication.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici](https://datawarehouse-integration-pr{{pullRequestId}}.review.pix.fr).
-Les variables d'environnement seront accessibles [ici](https://dashboard.scalingo.com/apps/osc-fr1/pix-datawarehouse-integration-pr{{pullRequestId}}/environment).
+Une fois l'application déployée, elle sera accessible à cette adresse https://datawarehouse-integration-pr{{pullRequestId}}.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-datawarehouse-integration-pr{{pullRequestId}}/environment

--- a/build/templates/pull-request-messages/pix-editor.md
+++ b/build/templates/pull-request-messages/pix-editor.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici]({{webApplicationUrl}}).
-Les variables d'environnement seront accessibles [ici](https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr{{pullRequestId}}/environment).
+Une fois l'application déployée, elle sera accessible à cette adresse {{webApplicationUrl}}
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr{{pullRequestId}}/environment

--- a/build/templates/pull-request-messages/pix-site.md
+++ b/build/templates/pull-request-messages/pix-site.md
@@ -4,4 +4,4 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [Pix Pro (.fr)](https://pro-pr{{pullRequestId}}.review.pix.fr)
   * [Pix Pro (.org)](https://pro-pr{{pullRequestId}}.review.pix.org)
 
-Les variables d'environnement seront accessibles [ici]({{scalingoDashboardUrl}}).
+Les variables d'environnement seront accessibles sur scalingo {{scalingoDashboardUrl}}

--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -7,5 +7,5 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
 
 Les variables d'environnement seront accessibles via les liens suivants :
-  * [front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)
-  * [api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr{{pullRequestId}}/environment)
+  * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)
+  * [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr{{pullRequestId}}/environment)

--- a/test/unit/build/controllers/pull-request-messages/pix-bot.md
+++ b/test/unit/build/controllers/pull-request-messages/pix-bot.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici](https://bot-pr25.review.pix.fr).
-Les variables d'environnement seront accessibles [ici](https://dashboard.scalingo.com/apps/osc-fr1/pix-bot-review-pr25/environment).
+Une fois l'application déployée, elle sera accessible à cette adresse https://bot-pr25.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-bot-review-pr25/environment

--- a/test/unit/build/controllers/pull-request-messages/pix-db-replication.md
+++ b/test/unit/build/controllers/pull-request-messages/pix-db-replication.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici](https://datawarehouse-integration-pr125.review.pix.fr).
-Les variables d'environnement seront accessibles [ici](https://dashboard.scalingo.com/apps/osc-fr1/pix-datawarehouse-integration-pr125/environment).
+Une fois l'application déployée, elle sera accessible à cette adresse https://datawarehouse-integration-pr125.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-datawarehouse-integration-pr125/environment

--- a/test/unit/build/controllers/pull-request-messages/pix-editor.md
+++ b/test/unit/build/controllers/pull-request-messages/pix-editor.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible [ici](https://editor-pr49.review.pix.fr).
-Les variables d'environnement seront accessibles [ici](https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr49/environment).
+Une fois l'application déployée, elle sera accessible à cette adresse https://editor-pr49.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr49/environment

--- a/test/unit/build/controllers/pull-request-messages/pix.md
+++ b/test/unit/build/controllers/pull-request-messages/pix.md
@@ -7,5 +7,5 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [API](https://api-pr5401.review.pix.fr/api/)
 
 Les variables d'environnement seront accessibles via les liens suivants :
-  * [front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr5401/environment)
-  * [api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr5401/environment)
+  * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr5401/environment)
+  * [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr5401/environment)


### PR DESCRIPTION
## :christmas_tree: Problème
Les liens dans les pull requests pour indiquer la review app et l'application scalingo utilisent du markdown avec nom 'ici'. En plus d'etre tout petit pour espèrer réussir a cliquer du premier coup, ce n'est pas descriptif de la cible.

## :gift: Proposition
Supprimer les liens ici qui n'apportent rien pour mettre directement l'URL cible. Une grande surface de clic disponible et on peut vérifier l'URL en bonus.

## :santa: Pour tester
:(
