### PR TITLE
[BUGFIX] Corrige le déploiement de pix-360

### DIFF
--- a/config.js
+++ b/config.js
@@ -123,7 +123,7 @@ module.exports = (function () {
     ],
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',
     PIX_360_REPO_NAME: 'pix-360',
-    PIX_360_APP_NAME: 'pix-360',
+    PIX_360_APP_NAME: 'pix-360-production',
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -68,7 +68,7 @@ describe('Integration | Run | Services | Slack | Commands', function () {
         },
       };
       const nockDeploy = nock('https://scalingo.production')
-        .post(`/v1/apps/pix-360/deployments`, deploymentPayload)
+        .post(`/v1/apps/pix-360-production/deployments`, deploymentPayload)
         .reply(200, {});
 
       await commands.deployPix360();


### PR DESCRIPTION
## :christmas_tree: Problème
Le nom de l'application pix-360 que l'on déployé était pix-360, alors que c'est pix-360-production.

## :gift: Proposition
Rajouter -production au nom de l'app