### PR TITLE
[BUGFIX] Les liens vers l'application Airflow scalingo dans la PR sont invalides

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -15,7 +15,7 @@ const repositoryToScalingoAppsReview = {
 };
 
 function getMessageTemplate(repositoryName) {
-  const repositoriesWithSpecificMessage = ['pix-db-replication', 'pix-editor', 'pix-site', 'pix'];
+  const repositoriesWithSpecificMessage = ['pix-data', 'pix-db-replication', 'pix-editor', 'pix-site', 'pix'];
   let relativeFileName;
   if (repositoriesWithSpecificMessage.includes(repositoryName)) {
     relativeFileName = `${repositoryName}.md`;

--- a/build/templates/pull-request-messages/pix-data.md
+++ b/build/templates/pull-request-messages/pix-data.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://airflow-pr{{pullRequestId}}.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-airflow-review-pr{{pullRequestId}}/environment

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -80,6 +80,24 @@ describe('#addMessageToPullRequest', function () {
           comment,
         });
       });
+      it('pix-data', async function () {
+        // given
+        const data = { repositoryName: 'pix-data', pullRequestId: 115 };
+        const commentStub = sinon.stub(githubService, 'commentPullRequest');
+
+        // when
+        await githubController.addMessageToPullRequest(data);
+
+        // then
+        const absoluteFileName = `${__dirname}/pull-request-messages/pix-data.md`;
+        const comment = fs.readFileSync(absoluteFileName, 'utf8');
+
+        expect(commentStub).to.have.been.calledOnceWithExactly({
+          repositoryName: 'pix-data',
+          pullRequestId: 115,
+          comment,
+        });
+      });
     });
   });
 });

--- a/test/unit/build/controllers/pull-request-messages/pix-data.md
+++ b/test/unit/build/controllers/pull-request-messages/pix-data.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://airflow-pr115.review.pix.fr
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-airflow-review-pr115/environment


### PR DESCRIPTION
## :christmas_tree: Problème
Les liens sont invalides.

## :gift: Proposition
Les corriger.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Merger, MEP, et ouvrir une PR sur `pix-data`.
