### PR TITLE
Mettre à jour les dépendences aussi vite que possible

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "labels": ["renovate","no-review-app",":rocket: Ready to Merge"],
-  "schedule": ["at any time"],
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "enabled": true,
-  "rangeStrategy": "bump",
-  "dependencyDashboard": true
+  "extends": ["github>1024pix/renovate-config:aggressive"],
+  "enabled": true
 }


### PR DESCRIPTION
## :egg: Problème
On veut:
- ouvrir les PR de montée de version aussi tôt que possible;
- les merger dès que les tests passent.

Or le preset existant ne le permet pas.

## :bowl_with_spoon: Proposition
Utiliser un preset partagé.

## :milk_glass: Remarques
Attendre le merge de https://github.com/1024pix/renovate-config/pull/1

## :butter: Pour tester
Merger, réactiver Renovate et suivre le dashboard
