### PR TITLE
[FEATURE] Déployer pix-lcms-minimal en même temps que la production

### DIFF
--- a/config.js
+++ b/config.js
@@ -101,7 +101,10 @@ module.exports = (function () {
       recette: ['pix-bot-build-production'],
     },
     PIX_LCMS_REPO_NAME: 'pix-editor',
-    PIX_LCMS_APP_NAME: 'pix-lcms',
+    PIX_LCMS_APPS: {
+      production: ['pix-lcms-production'],
+      recette: ['pix-lcms-minimal-production'],
+    },
     PIX_UI_REPO_NAME: 'pix-ui',
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',

--- a/config.js
+++ b/config.js
@@ -96,6 +96,10 @@ module.exports = (function () {
 
     PIX_REPO_NAME: 'pix',
     PIX_BOT_REPO_NAME: 'pix-bot',
+    PIX_BOT_APPS: {
+      production: ['pix-bot-run-production'],
+      recette: ['pix-bot-build-production'],
+    },
     PIX_LCMS_REPO_NAME: 'pix-editor',
     PIX_LCMS_APP_NAME: 'pix-lcms',
     PIX_UI_REPO_NAME: 'pix-ui',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -10,7 +10,7 @@ const {
   PIX_DATAWAREHOUSE_REPO_NAME,
   PIX_DATAWAREHOUSE_APPS_NAME,
   PIX_LCMS_REPO_NAME,
-  PIX_LCMS_APP_NAME,
+  PIX_LCMS_APPS,
   PIX_UI_REPO_NAME,
   PIX_EMBER_TESTING_LIBRARY_REPO_NAME,
   PIX_DB_STATS_REPO_NAME,
@@ -118,7 +118,7 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
   }
 }
 
-async function publishAndDeployPixBot(repoName, apps, releaseType, responseUrl) {
+async function publishAndDeployReleaseWithAppsByEnvironment(repoName, appsByEnv, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
@@ -126,11 +126,11 @@ async function publishAndDeployPixBot(repoName, apps, releaseType, responseUrl) 
   const releaseTag = await githubServices.getLatestReleaseTag(repoName);
 
   await Promise.all(
-    Object.keys(apps).map(async (scalingoEnv) => {
+    Object.keys(appsByEnv).map(async (scalingoEnv) => {
       const scalingoInstance = await ScalingoClient.getInstance(scalingoEnv);
 
       await Promise.all(
-        apps[scalingoEnv].map((scalingoAppName) => {
+        appsByEnv[scalingoEnv].map((scalingoAppName) => {
           return scalingoInstance.deployFromArchive(scalingoAppName, releaseTag, repoName, { withEnvSuffix: false });
         })
       );
@@ -199,7 +199,12 @@ module.exports = {
   },
 
   async createAndDeployPixLCMS(payload) {
-    await publishAndDeployRelease(PIX_LCMS_REPO_NAME, [PIX_LCMS_APP_NAME], payload.text, payload.response_url);
+    await publishAndDeployReleaseWithAppsByEnvironment(
+      PIX_LCMS_REPO_NAME,
+      PIX_LCMS_APPS,
+      payload.text,
+      payload.response_url
+    );
   },
 
   async createAndDeployPixUI(payload) {
@@ -224,7 +229,12 @@ module.exports = {
   },
 
   async createAndDeployPixBotRelease(payload) {
-    await publishAndDeployPixBot(PIX_BOT_REPO_NAME, PIX_BOT_APPS, payload.text, payload.response_url);
+    await publishAndDeployReleaseWithAppsByEnvironment(
+      PIX_BOT_REPO_NAME,
+      PIX_BOT_APPS,
+      payload.text,
+      payload.response_url
+    );
   },
 
   async getAndDeployLastVersion({ appName }) {

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -136,7 +136,7 @@ async function publishAndDeployReleaseWithAppsByEnvironment(repoName, appsByEnv,
       );
     })
   );
-  sendResponse(responseUrl, `Pix Bot deployed (${releaseTag})`);
+  sendResponse(responseUrl, getSuccessMessage(releaseTag, Object.values(appsByEnv).join(', ')));
 }
 
 async function getAndDeployLastVersion({ appName }) {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -207,7 +207,7 @@ describe('Services | Slack | Commands', () => {
 
     it('should deploy the release for pix-bot-run', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run-production');
     });
   });
 

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -156,8 +156,12 @@ describe('Services | Slack | Commands', () => {
   });
 
   describe('#createAndDeployPixLCMS', () => {
+    let client;
+
     beforeEach(async function () {
       // given
+      client = { deployFromArchive: sinon.spy() };
+      sinon.stub(ScalingoClient, 'getInstance').resolves(client);
       const payload = { text: 'minor' };
       // when
       await createAndDeployPixLCMS(payload);
@@ -173,9 +177,14 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-editor');
     });
 
-    it('should deploy the release', () => {
+    it('should deploy the release on production', () => {
       // then
-      sinon.assert.calledWith(releasesServices.deployPixRepo);
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-production');
+    });
+
+    it('should deploy the release on minimal', () => {
+      // then
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-minimal-production');
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
Précédemment, pix-minimal qui est utilisé pour la partie open-source de pix et les test d'acceptance était déployé lors d'un merge sur dev. Cela pouvais déclencher des problèmes sur le dépot pix si une incompatibilité était introduite.

## :bowl_with_spoon: Proposition
Déployer pix-lcms-minimal-production en même temps que la "vraie" production.

## :milk_glass: Remarques
J'ai refactorer le déploiement de pix-bot qui faisait la même chose que ce dont j'avais  besoin. Un deploy sur 2 environnements séparé.

## :butter: Pour tester
:green_circle: 
