### PR TITLE
[BUGFIX] Corriger le lien vers PixEditor dans le message automatique envoyée au Reviews Apps

### DIFF
--- a/build/templates/pull-request-messages/pix-editor.md
+++ b/build/templates/pull-request-messages/pix-editor.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible à cette adresse {{webApplicationUrl}}
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-lcms-review-pr{{pullRequestId}}.osc-fr1.scalingo.io
 Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr{{pullRequestId}}/environment

--- a/test/unit/build/controllers/pull-request-messages/pix-editor.md
+++ b/test/unit/build/controllers/pull-request-messages/pix-editor.md
@@ -1,2 +1,2 @@
-Une fois l'application déployée, elle sera accessible à cette adresse https://editor-pr49.review.pix.fr
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-lcms-review-pr49.osc-fr1.scalingo.io
 Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review-pr49/environment


### PR DESCRIPTION
## :egg: Problème
Le lien vers PixEditor est incorrect.
Ancien lien (exemple) : editor-pr87.review.pix.fr](https://editor-pr87.review.pix.fr/ 

## :bowl_with_spoon: Proposition
Nouveau lien (exemple): https://pix-lcms-review-pr87.osc-fr1.scalingo.io

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
