### PR TITLE
:art: Faire un bump de version mineure par défaut

### DIFF
--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -64,12 +64,7 @@ function _isReleaseTypeInvalid(releaseType) {
 }
 async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
-    slackPostMessageService.postMessage(
-      'Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".'
-    );
-    throw new Error(
-      'Erreur lors du choix de la nouvelle version de Pix UI. Veuillez indiquer "major", "minor" ou "patch".'
-    );
+    releaseType = 'minor';
   }
   const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.publishPixRepo(repoName, releaseType);
@@ -85,12 +80,7 @@ async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
 
 async function publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
-    slackPostMessageService.postMessage(
-      'Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".'
-    );
-    throw new Error(
-      'Erreur lors du choix de la nouvelle version d\'ember-testing-library. Veuillez indiquer "major", "minor" ou "patch".'
-    );
+    releaseType = 'minor';
   }
   const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
   await releasesService.publishPixRepo(repoName, releaseType);

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -108,15 +108,15 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-ui');
     });
 
-    it('should stop release if no version is given', async () => {
+    it('should create a minor version if no version is given', async () => {
       // given
       const payload = { text: '' };
 
       // when
-      const response = await catchErr(createAndDeployPixUI)(payload);
+      await createAndDeployPixUI(payload);
 
       // then
-      expect(response).to.be.instanceOf(Error);
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-ui', 'minor');
     });
   });
 
@@ -143,15 +143,15 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'ember-testing-library');
     });
 
-    it('should stop release if no version is given', async () => {
+    it('should create a minor version if no version is given', async () => {
       // given
       const payload = { text: '' };
 
       // when
-      const response = await catchErr(createAndDeployEmberTestingLibrary)(payload);
+      await createAndDeployEmberTestingLibrary(payload);
 
       // then
-      expect(response).to.be.instanceOf(Error);
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'ember-testing-library', 'minor');
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
Pour pix-ui et pix-ember-testing-library, le comportement actuel est de renvoyer une erreur si la version de bump de release n'est pas envoyée. Ce comportement est différent du comportement des autres applications, qui font un bump mineur par défaut.

## :bowl_with_spoon: Proposition
Faire un bump mineur lorsque la version n'est pas précisée

## :butter: Pour tester
🟢 
