### PR TITLE
Expliciter la configuration de l'ecoMode

### DIFF
--- a/build/services/eco-mode-service.js
+++ b/build/services/eco-mode-service.js
@@ -5,12 +5,12 @@ module.exports = {
   async start() {
     const scalingoToken = config.scalingo.reviewApps.token;
     const scalingoApiUrl = config.scalingo.reviewApps.apiUrl;
-    const stopCronTime = process.env.STOP_CRON_TIME;
-    const restartCronTime = process.env.RESTART_CRON_TIME;
+    const stopCronTime = process.env.REVIEW_APP_STOP_SCHEDULE;
+    const restartCronTime = process.env.REVIEW_APP_START_SCHEDULE;
     const timeZone = process.env.TIME_ZONE || 'Europe/Paris';
     const ignoredReviewApps = process.env.IGNORED_REVIEW_APPS ? process.env.IGNORED_REVIEW_APPS.split(',') : [];
 
-    if (!stopCronTime || !restartCronTime) {
+    if (!config.ecoMode.stopSchedule || !config.ecoMode.startSchedule) {
       console.log('No schedule configured for eco mode - skipping.');
       return;
     }

--- a/build/services/eco-mode-service.js
+++ b/build/services/eco-mode-service.js
@@ -5,18 +5,18 @@ module.exports = {
   async start() {
     const scalingoToken = config.scalingo.reviewApps.token;
     const scalingoApiUrl = config.scalingo.reviewApps.apiUrl;
-    const stopCronTime = process.env.REVIEW_APP_STOP_SCHEDULE;
-    const restartCronTime = process.env.REVIEW_APP_START_SCHEDULE;
+    const stopCronTime = config.ecoMode.stopSchedule;
+    const startCronTime = config.ecoMode.startSchedule;
     const timeZone = process.env.TIME_ZONE || 'Europe/Paris';
     const ignoredReviewApps = process.env.IGNORED_REVIEW_APPS ? process.env.IGNORED_REVIEW_APPS.split(',') : [];
 
-    if (!config.ecoMode.stopSchedule || !config.ecoMode.startSchedule) {
+    if (!stopCronTime || !startCronTime) {
       console.log('No schedule configured for eco mode - skipping.');
       return;
     }
     const reviewAppManager = new ReviewAppManager(scalingoToken, scalingoApiUrl, {
       stopCronTime,
-      restartCronTime,
+      restartCronTime: startCronTime,
       timeZone,
       ignoredReviewApps,
     });

--- a/config.js
+++ b/config.js
@@ -16,6 +16,11 @@ module.exports = (function () {
     port: _getNumber(process.env.PORT, 3000),
     environment: process.env.NODE_ENV || 'development',
 
+    ecoMode: {
+      stopSchedule: process.env.REVIEW_APP_STOP_SCHEDULE,
+      startSchedule: process.env.REVIEW_APP_START_SCHEDULE,
+    },
+
     baleen: {
       pat: process.env.BALEEN_PERSONAL_ACCESS_TOKEN,
       appNamespaces: _getJSON(process.env.BALEEN_APP_NAMESPACES),

--- a/sample.env
+++ b/sample.env
@@ -260,14 +260,14 @@ SCALINGO_TOKEN_REVIEW_APPS=__CHANGE_ME__
 # presence: optionnal
 # type: String (RegExp)
 # default: "0 0 19 * * 1-5"
-#STOP_CRON_TIME=0 0 19 * * 1-5
+# REVIEW_APP_STOP_SCHEDULE=0 0 19 * * 1-5
 
 # Date time at which Scalingo sleeping review apps must be restarted.
 #
 # presence: optionnal
 # type: String (RegExp)
 # default: "0 0 8 * * 1-5"
-#RESTART_CRON_TIME=0 0 8 * * 1-5
+#REVIEW_APP_START_SCHEDULE=0 0 8 * * 1-5
 
 # List of review apps that must not be managed.
 #


### PR DESCRIPTION
## :christmas_tree: Problème

La configuration de l'ecoMode n'est pas claire.

On peut la confondre l'co-mode avec celle des autres tâches planifiées. :
- usage sendInBlue;
- pixSite.

De plus, elle n'est pas lue dans le `config.js`.

## :gift: Proposition
Renommer les variables d'environnement.

```
STOP_CRON_TIME => REVIEW_APP_STOP_SCHEDULE 
RESTART_CRON_TIME => REVIEW_APP_START_SCHEDULE
```

## :star2: Remarques
Penser à modifier les variables d'environnement sur les environnements aval (template RA, intégration, recette, production) avant de merger.

## :santa: Pour tester

Alimenter les variables en RA
```
REVIEW_APP_START_SCHEDULE=0 0 8 * * 1-5
REVIEW_APP_STOP_SCHEDULE=0 0 19 * * 1-5
```
Redémarrer

Vérifier dans les logs le message
```
2022-12-30 14:41:51.080758679 +0100 CET [web-1] Started job stop-managed-review-apps with cron time "0 0 19 * * 1,2,3,4,5"
2022-12-30 14:41:51.085549357 +0100 CET [web-1] Started job restart-managed-review-apps with cron time "0 0 8 * * 1,2,3,4,5" 
```