### PR TITLE
Corriger la suggestion de déploiement Slack

### DIFF
--- a/run/manifest.js
+++ b/run/manifest.js
@@ -61,7 +61,7 @@ manifest.registerSlashCommand({
 manifest.registerSlashCommand({
   command: '/deploy-last-version',
   path: '/slack/commands/deploy-last-version',
-  description: 'Deploy last version of an app',
+  description: 'Déployer sur cette application la dernière release publiée',
   usage_hint: '[pix-admin-production]',
   should_escape: false,
   handler: slackbotController.deployLastVersion,

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -80,7 +80,7 @@ describe('Acceptance | Run | Manifest', function () {
             {
               command: '/deploy-last-version',
               url: `http://${hostname}/slack/commands/deploy-last-version`,
-              description: 'Deploy last version of an app',
+              description: 'Déployer sur cette application la dernière release publiée',
               usage_hint: '[pix-admin-production]',
               should_escape: false,
             },


### PR DESCRIPTION
## :unicorn: Problème
Il existe une action Slack `Deploy last version of an app`.

Elle déploie:
- sur l'application passée en paramètre;
- la dernière release créée (pas forcément MEP), ex `v3.222.0` sur pix https://github.com/1024pix/pix/tags

Pour rappel, dans les autres actions Slack:
- Publier = MER;
- Déployer = MEP.

Le message est ambigü: Deploy = MEP alors qu'on peut effectuer cette action en dehors d'une application de production.

De plus, il est est en anglais alors que le reste est en français.
Du coup, les PO n'osent peut-être pas l'utiliser.

## :robot: Proposition
Le renommer en `Déployer sur cette application la dernière release publiée`
On garde "release publiée" = release en recette.
Et "déployer sur cette application" mentionne le déploiement Scalingo, pas le déploiement = MEP.

## :100: Pour tester
Relire
