### PR TITLE
[TECH] :sparkles: Réessayer l'invalidation de cache en cas d'échec

### DIFF
--- a/config.js
+++ b/config.js
@@ -147,7 +147,6 @@ module.exports = (function () {
 
     config.baleen.pat = 'baleen-pat';
     config.baleen.appNamespaces = _getJSON('{"Pix_Test":"Pix_Namespace","Pix_Test_2":"Pix Namespace 2"}');
-    config.baleen.CDNInvalidationRetryDelay = 1;
 
     config.github.token = undefined;
     config.github.owner = 'github-owner';

--- a/config.js
+++ b/config.js
@@ -24,6 +24,8 @@ module.exports = (function () {
     baleen: {
       pat: process.env.BALEEN_PERSONAL_ACCESS_TOKEN,
       appNamespaces: _getJSON(process.env.BALEEN_APP_NAMESPACES),
+      CDNInvalidationRetryCount: _getNumber(process.env.BALEEN_CDN_INVALIDATION_RETRY_COUNT, 3),
+      CDNInvalidationRetryDelay: _getNumber(process.env.BALEEN_CDN_INVALIDATION_RETRY_DELAY, 2000),
     },
 
     scalingo: {
@@ -145,6 +147,7 @@ module.exports = (function () {
 
     config.baleen.pat = 'baleen-pat';
     config.baleen.appNamespaces = _getJSON('{"Pix_Test":"Pix_Namespace","Pix_Test_2":"Pix Namespace 2"}');
+    config.baleen.CDNInvalidationRetryDelay = 1;
 
     config.github.token = undefined;
     config.github.owner = 'github-owner';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hapi/hapi": "^21.1.0",
         "@octokit/rest": "^19.0.5",
         "axios": "^1.2.1",
+        "axios-retry": "^3.4.0",
         "cron": "^2.1.0",
         "dayjs": "^1.11.7",
         "dotenv": "^16.0.3",
@@ -164,6 +165,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1172,6 +1184,15 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2742,6 +2763,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -4147,6 +4179,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -5243,6 +5280,14 @@
       "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -6087,6 +6132,15 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "balanced-match": {
@@ -7237,6 +7291,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -8255,6 +8314,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@hapi/hapi": "^21.1.0",
     "@octokit/rest": "^19.0.5",
     "axios": "^1.2.1",
+    "axios-retry": "^3.4.0",
     "cron": "^2.1.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",

--- a/run/services/cdn.js
+++ b/run/services/cdn.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const axiosRetry = require('axios-retry');
 const config = require('../../config');
+const logger = require('../../common/services/logger');
 const _ = require('lodash');
 
 const CDN_URL = 'https://console.baleen.cloud/api';
@@ -44,7 +45,7 @@ async function invalidateCdnCache(application) {
   axiosRetry(axios, {
     retries: config.baleen.CDNInvalidationRetryCount,
     retryDelay: (retryCount) => {
-      console.log(`Cache invalidation retry for application ${application}: ${retryCount}`);
+      logger.info(`Cache invalidation retry for application ${application}: ${retryCount}`);
       return retryCount * config.baleen.CDNInvalidationRetryDelay;
     },
     retryCondition: (error) => {

--- a/test/integration/run/services/cdn_test.js
+++ b/test/integration/run/services/cdn_test.js
@@ -33,6 +33,20 @@ function _stubInvalidationCachePost(namespaceKey) {
 }
 
 describe('Integration | CDN', () => {
+  let defaultRetryCount, defaultRetryDelay;
+
+  before(function () {
+    defaultRetryCount = config.baleen.CDNInvalidationRetryCount;
+    defaultRetryDelay = config.baleen.CDNInvalidationRetryDelay;
+    config.baleen.CDNInvalidationRetryCount = 3;
+    config.baleen.CDNInvalidationRetryDelay = 1;
+  });
+
+  after(function () {
+    config.baleen.CDNInvalidationRetryCount = defaultRetryCount;
+    config.baleen.CDNInvalidationRetryDelay = defaultRetryDelay;
+  });
+
   describe('#invalidateCdnCache', () => {
     it('should call Baleen cache invalidation API', async () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème
L'invalidation de cache Baleen peut renvoyer des 500, Baleen recommande de toujours tenter de relancer la requête plusieurs fois.

## :robot: Proposition
Relancer la requête plusieurs fois (4 essais) pour faire passer l'invalidation de cache

## :100: Pour tester
les tests sont vert 
(On pourrait également rajouter les identifiants Baleen sur la RA et lancer une invalidation du cache sur une instance de test)
