### PR TITLE
[FEATURE] Au push sur une PR, on déploie nous même la review app

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -85,6 +85,11 @@ async function pullRequestSynchronizeWebhook(request) {
   const reviewApps = repositoryToScalingoAppsReview[repository];
   const prId = payload.number;
 
+  const { shouldContinue, message } = _handleNoRACase(request);
+  if (!shouldContinue) {
+    return message;
+  }
+
   try {
     const client = await ScalingoClient.getInstance('reviewApps');
     for (const appName of reviewApps) {

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -66,6 +66,7 @@ async function pullRequestOpenedWebhook(request) {
     const client = await ScalingoClient.getInstance('reviewApps');
     for (const appName of reviewApps) {
       await client.deployReviewApp(appName, prId);
+      await client.disableAutoDeploy(appName);
     }
     await addMessageToPullRequest({
       repositoryName: repository,

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -51,6 +51,40 @@ const addMessageToPullRequest = async ({ repositoryName, pullRequestId, scalingo
   });
 };
 
+async function pullRequestWebhook(request) {
+  const payload = request.payload;
+  const repository = payload.pull_request.head.repo.name;
+  const prId = payload.number;
+  const reviewApps = repositoryToScalingoAppsReview[repository];
+  const labelsList = payload.pull_request.labels;
+  if (payload.pull_request.head.repo.fork) {
+    return 'No RA for a fork';
+  }
+  if (payload.action !== 'opened') {
+    return `Ignoring ${payload.action} action`;
+  }
+  if (!reviewApps) {
+    return 'No RA configured for this repository';
+  }
+  if (labelsList.some((label) => label.name == 'no-review-app')) {
+    return 'RA disabled for this PR';
+  }
+  try {
+    const client = await ScalingoClient.getInstance('reviewApps');
+    for (const appName of reviewApps) {
+      await client.deployReviewApp(appName, prId);
+    }
+    await addMessageToPullRequest({
+      repositoryName: repository,
+      scalingoReviewApps: reviewApps,
+      pullRequestId: prId,
+    });
+    return `Created RA on app ${reviewApps.join(', ')} with pr ${prId}`;
+  } catch (error) {
+    throw new Error(`Scalingo APIError: ${error.message}`);
+  }
+}
+
 module.exports = {
   getMessageTemplate,
   getMessage,
@@ -58,37 +92,7 @@ module.exports = {
   async processWebhook(request) {
     const eventName = request.headers['x-github-event'];
     if (eventName === 'pull_request') {
-      const payload = request.payload;
-      const repository = payload.pull_request.head.repo.name;
-      const prId = payload.number;
-      const reviewApps = repositoryToScalingoAppsReview[repository];
-      const labelsList = payload.pull_request.labels;
-      if (payload.pull_request.head.repo.fork) {
-        return 'No RA for a fork';
-      }
-      if (payload.action !== 'opened') {
-        return `Ignoring ${payload.action} action`;
-      }
-      if (!reviewApps) {
-        return 'No RA configured for this repository';
-      }
-      if (labelsList.some((label) => label.name == 'no-review-app')) {
-        return 'RA disabled for this PR';
-      }
-      try {
-        const client = await ScalingoClient.getInstance('reviewApps');
-        for (const appName of reviewApps) {
-          await client.deployReviewApp(appName, prId);
-        }
-        await addMessageToPullRequest({
-          repositoryName: repository,
-          scalingoReviewApps: reviewApps,
-          pullRequestId: prId,
-        });
-        return `Created RA on app ${reviewApps.join(', ')} with pr ${prId}`;
-      } catch (error) {
-        throw new Error(`Scalingo APIError: ${error.message}`);
-      }
+      return pullRequestWebhook(request);
     } else {
       return `Ignoring ${eventName} event`;
     }

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -89,10 +89,14 @@ async function pullRequestSynchronizeWebhook(request) {
   const reviewApps = repositoryToScalingoAppsReview[repository];
   const prId = payload.number;
 
-  const client = await ScalingoClient.getInstance('reviewApps');
-  for (const appName of reviewApps) {
-    const reviewAppName = `${appName}-pr${prId}`;
-    await client.deployUsingSCM(reviewAppName, ref);
+  try {
+    const client = await ScalingoClient.getInstance('reviewApps');
+    for (const appName of reviewApps) {
+      const reviewAppName = `${appName}-pr${prId}`;
+      await client.deployUsingSCM(reviewAppName, ref);
+    }
+  } catch (error) {
+    throw new Error(`Scalingo APIError: ${error.message}`);
   }
 
   return `Triggered deployment of RA on app ${reviewApps.join(', ')} with pr ${prId}`;

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -65,8 +65,8 @@ async function pullRequestOpenedWebhook(request) {
   try {
     const client = await ScalingoClient.getInstance('reviewApps');
     for (const appName of reviewApps) {
-      await client.deployReviewApp(appName, prId);
-      await client.disableAutoDeploy(appName);
+      const { app_name: reviewAppName } = await client.deployReviewApp(appName, prId);
+      await client.disableAutoDeploy(reviewAppName);
     }
     await addMessageToPullRequest({
       repositoryName: repository,

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -62,6 +62,11 @@ class ScalingoClient {
     return this.client.SCMRepoLinks.manualReviewApp(appName, prId);
   }
 
+  disableAutoDeploy(appName) {
+    const opts = { auto_deploy_enabled: false };
+    return this.client.SCMRepoLinks.update(appName, opts);
+  }
+
   async _getAllAppsInfo(environment) {
     const apps = ['api', 'app', 'orga', 'certif', 'admin'];
     const promises = apps.map((appName) => this._getSingleAppInfo(appName, environment));

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -31,10 +31,10 @@ describe('Acceptance | Build | Github', function () {
           .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
           .reply(201);
         const scalingoUpdateOpts1 = nock('https://api.osc-fr1.scalingo.com')
-          .patch('/v1/apps/pix-front-review/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+          .patch('/v1/apps/pix-front-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
           .reply(201);
         const scalingoUpdateOpts2 = nock('https://api.osc-fr1.scalingo.com')
-          .patch('/v1/apps/pix-api-review/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+          .patch('/v1/apps/pix-api-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
           .reply(201);
         nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(200);
 
@@ -67,10 +67,10 @@ describe('Acceptance | Build | Github', function () {
           .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
           .reply(StatusCodes.CREATED);
         nock('https://api.osc-fr1.scalingo.com')
-          .patch('/v1/apps/pix-front-review/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+          .patch('/v1/apps/pix-front-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
           .reply(201);
         nock('https://api.osc-fr1.scalingo.com')
-          .patch('/v1/apps/pix-api-review/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+          .patch('/v1/apps/pix-api-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
           .reply(201);
         const githubNock = nock('https://api.github.com')
           .post('/repos/github-owner/pix/issues/2/comments')

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -5,170 +5,174 @@ describe('Acceptance | Build | Github', function () {
   describe('POST /github/webhook', function () {
     let body;
 
-    beforeEach(function () {
-      body = {
-        action: 'opened',
-        number: 2,
-        pull_request: {
-          labels: [{ name: 'test-label' }],
-          head: {
-            repo: {
-              name: 'pix',
-              fork: false,
+    describe('on pull request event', function () {
+      beforeEach(function () {
+        body = {
+          action: 'opened',
+          number: 2,
+          pull_request: {
+            labels: [{ name: 'test-label' }],
+            head: {
+              repo: {
+                name: 'pix',
+                fork: false,
+              },
             },
           },
-        },
-      };
-    });
-
-    it('responds with 200 and create the RA on scalingo', async function () {
-      const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
-      const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(201);
-      const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(201);
-      nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(200);
-
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
-      });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('Created RA on app pix-front-review, pix-api-review with pr 2');
-      expect(scalingoAuth.isDone()).to.be.true;
-      expect(scalingoDeploy1.isDone()).to.be.true;
-      expect(scalingoDeploy2.isDone()).to.be.true;
-    });
-
-    it('responds with 200 and create the RA on scalingo with no labels', async function () {
-      body.pull_request.labels = [];
-      const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
-      const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(201);
-      const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(201);
-      nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(200);
-
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
-      });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('Created RA on app pix-front-review, pix-api-review with pr 2');
-      expect(scalingoAuth.isDone()).to.be.true;
-      expect(scalingoDeploy1.isDone()).to.be.true;
-      expect(scalingoDeploy2.isDone()).to.be.true;
-    });
-
-    it('responds with OK (200) and add application link to pull request comments', async function () {
-      // given
-      body.pull_request.labels = [];
-      nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.CREATED);
-      nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(StatusCodes.CREATED);
-      nock('https://api.osc-fr1.scalingo.com')
-        .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
-        .reply(StatusCodes.CREATED);
-      const githubNock = nock('https://api.github.com')
-        .post('/repos/github-owner/pix/issues/2/comments')
-        .reply(StatusCodes.OK);
-
-      // when
-      const response = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
+        };
       });
 
-      // then
-      expect(response.statusCode).to.equal(StatusCodes.OK);
-      expect(response.result).to.equal('Created RA on app pix-front-review, pix-api-review with pr 2');
-      expect(githubNock.isDone()).to.be.true;
-    });
+      it('responds with 200 and create the RA on scalingo', async function () {
+        const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
+        const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+          .reply(201);
+        const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+          .reply(201);
+        nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(200);
 
-    it("responds with 200 and doesn't create the RA on scalingo when the PR is from a fork", async function () {
-      body.pull_request.head.repo.fork = true;
-
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.eql('Created RA on app pix-front-review, pix-api-review with pr 2');
+        expect(scalingoAuth.isDone()).to.be.true;
+        expect(scalingoDeploy1.isDone()).to.be.true;
+        expect(scalingoDeploy2.isDone()).to.be.true;
       });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('No RA for a fork');
-    });
 
-    it("responds with 200 and doesn't create the RA on scalingo when the PR is not from a configured repo", async function () {
-      body.pull_request.head.repo.name = 'pix-repository-that-dont-exist';
+      it('responds with OK (200) and add application link to pull request comments', async function () {
+        // given
+        body.pull_request.labels = [];
+        nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.CREATED);
+        nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+          .reply(StatusCodes.CREATED);
+        nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+          .reply(StatusCodes.CREATED);
+        const githubNock = nock('https://api.github.com')
+          .post('/repos/github-owner/pix/issues/2/comments')
+          .reply(StatusCodes.OK);
 
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(StatusCodes.OK);
+        expect(response.result).to.equal('Created RA on app pix-front-review, pix-api-review with pr 2');
+        expect(githubNock.isDone()).to.be.true;
       });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('No RA configured for this repository');
-    });
 
-    it('responds with 200 and do nothing for other action on pull request', async function () {
-      body.action = 'edited';
+      it("responds with 200 and doesn't create the RA on scalingo when the PR is from a fork", async function () {
+        body.pull_request.head.repo.fork = true;
 
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.eql('No RA for a fork');
       });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('Ignoring edited action');
-    });
 
-    it('responds with 200 and do nothing for a pr labelled with no-review-app', async function () {
-      body.pull_request.labels = [{ name: 'no-review-app' }];
-      const res = await server.inject({
-        method: 'POST',
-        url: '/github/webhook',
-        headers: {
-          ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-          'x-github-event': 'pull_request',
-        },
-        payload: body,
+      it("responds with 200 and doesn't create the RA on scalingo when the PR is not from a configured repo", async function () {
+        body.pull_request.head.repo.name = 'pix-repository-that-dont-exist';
+
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.eql('No RA configured for this repository');
       });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result).to.eql('RA disabled for this PR');
+
+      it('responds with 200 and do nothing for other action on pull request', async function () {
+        body.action = 'edited';
+
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.eql('Ignoring edited action');
+      });
+
+      it('responds with 200 and do nothing for a pr labelled with no-review-app', async function () {
+        body.pull_request.labels = [{ name: 'no-review-app' }];
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.eql('RA disabled for this PR');
+      });
+
+      context('when Scalingo API client throws an error', function () {
+        it('responds with 500 internal error', async function () {
+          const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(500, {
+            error: "Internal error occured, we're on it!",
+          });
+
+          const body = {
+            action: 'opened',
+            text: 'app-1',
+            pull_request: { labels: [], head: { repo: { name: 'pix-bot' } } },
+          };
+
+          const response = await server.inject({
+            method: 'POST',
+            url: '/github/webhook',
+            headers: {
+              ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+              'x-github-event': 'pull_request',
+            },
+            payload: body,
+          });
+
+          expect(scalingoTokenNock.isDone()).to.be.true;
+          expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
+          expect(response.result.message).to.equal('An internal server error occurred');
+        });
+      });
     });
 
     it('responds with 200 and do nothing for other event', async function () {
+      body = {};
       const res = await server.inject({
         method: 'POST',
         url: '/github/webhook',
@@ -182,7 +186,8 @@ describe('Acceptance | Build | Github', function () {
       expect(res.result).to.eql('Ignoring deployment event');
     });
 
-    it('responds with 401', async function () {
+    it('responds with 401 on a bad signature', async function () {
+      body = {};
       const res = await server.inject({
         method: 'POST',
         url: '/github/webhook',
@@ -193,33 +198,6 @@ describe('Acceptance | Build | Github', function () {
         payload: body,
       });
       expect(res.statusCode).to.equal(401);
-    });
-    context('when Scalingo API client throws an error', function () {
-      it('responds with 500 internal error', async function () {
-        const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(500, {
-          error: "Internal error occured, we're on it!",
-        });
-
-        const body = {
-          action: 'opened',
-          text: 'app-1',
-          pull_request: { labels: [], head: { repo: { name: 'pix-bot' } } },
-        };
-
-        const response = await server.inject({
-          method: 'POST',
-          url: '/github/webhook',
-          headers: {
-            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
-            'x-github-event': 'pull_request',
-          },
-          payload: body,
-        });
-
-        expect(scalingoTokenNock.isDone()).to.be.true;
-        expect(response.statusCode).to.equal(StatusCodes.INTERNAL_SERVER_ERROR);
-        expect(response.result.message).to.equal('An internal server error occurred');
-      });
     });
   });
 });

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -432,6 +432,37 @@ describe('Scalingo client', () => {
     });
   });
 
+  describe('#Scalingo.disableAutoDeploy', () => {
+    let update;
+    let scalingoClient;
+
+    beforeEach(async function () {
+      update = sinon.stub();
+      const clientStub = {
+        clientFromToken: async () => {
+          return {
+            SCMRepoLinks: {
+              update,
+            },
+          };
+        },
+      };
+
+      scalingoClient = await ScalingoClient.getInstance('reviewApps', clientStub);
+    });
+
+    it('should call update', async () => {
+      // given
+      update.withArgs('pix-app-review').resolves();
+
+      // when
+      await scalingoClient.disableAutoDeploy('pix-app-review');
+
+      // then
+      expect(update.called).to.be.true;
+    });
+  });
+
   describe('#Scalingo.createApplication', () => {
     it('should return application identifier', async () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Nous atteignons rapidement le "rate limiting" de github en utilisant l'auto deploy + les review apps de notre hébergeur

## :robot: Proposition
Utiliser nos outils de déploiements automatique via pix-bot pour optimiser l'utilisation des requêtes vers l'API github

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
