### PR TITLE
:sparkles:  Ajout de l'URL des review-app de scalingo de pix1d    sur les messages github

### DIFF
--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -5,6 +5,7 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [Certif](https://certif-pr{{pullRequestId}}.review.pix.fr)
   * [Admin](https://admin-pr{{pullRequestId}}.review.pix.fr)
   * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
+  * [Pix1D](https://pix1d-pr{{pullRequestId}}.review.pix.fr)
 
 Les variables d'environnement seront accessibles via les liens suivants :
   * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)


### PR DESCRIPTION
## :unicorn: Problème
L'url de review-app de pix1d n'est pas ajoutée dans le message de notification de création de review-app sur scalingo.

## :robot: Proposition
L'ajouter
