### PR TITLE
Déployer le code à la création de la RA

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -55,6 +55,7 @@ async function pullRequestOpenedWebhook(request) {
   const payload = request.payload;
   const repository = payload.pull_request.head.repo.name;
   const prId = payload.number;
+  const ref = payload.pull_request.head.ref;
   const reviewApps = repositoryToScalingoAppsReview[repository];
 
   const { shouldContinue, message } = _handleNoRACase(request);
@@ -67,6 +68,7 @@ async function pullRequestOpenedWebhook(request) {
     for (const appName of reviewApps) {
       const { app_name: reviewAppName } = await client.deployReviewApp(appName, prId);
       await client.disableAutoDeploy(reviewAppName);
+      await client.deployUsingSCM(reviewAppName, ref);
     }
     await addMessageToPullRequest({
       repositoryName: repository,

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const ScalingoClient = require('../../common/services/scalingo-client');
 const gitHubService = require('../../common/services/github');
+const logger = require('../../common/services/logger');
 
 const repositoryToScalingoAppsReview = {
   'pix-bot': ['pix-bot-review'],
@@ -65,6 +66,10 @@ async function pullRequestOpenedWebhook(request) {
 
   try {
     const client = await ScalingoClient.getInstance('reviewApps');
+    logger.info({
+      event: 'review-app',
+      message: `Creating RA for repo ${repository} PR ${prId}`,
+    });
     for (const appName of reviewApps) {
       const { app_name: reviewAppName } = await client.deployReviewApp(appName, prId);
       await client.disableAutoDeploy(reviewAppName);
@@ -74,6 +79,10 @@ async function pullRequestOpenedWebhook(request) {
       repositoryName: repository,
       scalingoReviewApps: reviewApps,
       pullRequestId: prId,
+    });
+    logger.info({
+      event: 'review-app',
+      message: `Created RA for repo ${repository} PR ${prId}`,
     });
     return `Created RA on app ${reviewApps.join(', ')} with pr ${prId}`;
   } catch (error) {
@@ -102,6 +111,11 @@ async function pullRequestSynchronizeWebhook(request) {
   } catch (error) {
     throw new Error(`Scalingo APIError: ${error.message}`);
   }
+
+  logger.info({
+    event: 'review-app',
+    message: `PR${prId} deployement triggered on RA for repo ${repository}`,
+  });
 
   return `Triggered deployment of RA on app ${reviewApps.join(', ')} with pr ${prId}`;
 }


### PR DESCRIPTION
## :unicorn: Problème
Le code n'est pas déployé automatiquement quand une RA est créée, il ne l'est qu'après le premier push sur la PR

## :robot: Proposition
Déployer automatiquement la branche au moment de la création de la RA

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
