### PR TITLE
[TECH] Utiliser la version de release qui vient d'être crée plutôt que d'appeler l'API Github

### DIFF
--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -15,8 +15,7 @@ module.exports = {
     const releaseType = payload.view.private_metadata;
 
     async function _publishAndDeploy({ releaseType, environment }) {
-      await publish(releaseType);
-      const latestReleaseTag = await githubService.getLatestReleaseTag();
+      const latestReleaseTag = await publish(releaseType);
       return deploy(environment, latestReleaseTag);
     }
 

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -54,7 +54,8 @@ module.exports = {
       const branchName = await github.getDefaultBranch(config.github.owner, sanitizedRepoName);
       const repositoryURL = `https://${config.github.token}@github.com/${config.github.owner}/${sanitizedRepoName}.git`;
       const args = [config.github.owner, sanitizedRepoName, sanitizedReleaseType, branchName, repositoryURL];
-      await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
+      const newPackageVersion = await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
+      return newPackageVersion;
     } catch (err) {
       console.error(err);
       throw err;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ require('dotenv').config();
 const config = require('./config');
 const server = require('./server');
 const { createCronJob } = require('./common/services/cron-job');
+const githubServices = require('./common/services/github');
 const sendInBlueReport = require('./run/services/sendinblue-report');
 const { deploy } = require('./run/services/deploy');
 const ecoModeService = require('./build/services/eco-mode-service');
@@ -13,8 +14,10 @@ const init = async () => {
   createCronJob('SendInBlue Report', sendInBlueReport.getReport, config.thirdServicesUsageReport.schedule);
   createCronJob(
     'Deploy Pix site',
-    () => {
-      deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS);
+    async () => {
+      const repoName = config.PIX_SITE_REPO_NAME;
+      const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+      deploy(repoName, config.PIX_SITE_APPS, releaseTag);
     },
     config.pixSiteDeploy.schedule
   );

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -10,8 +10,9 @@ module.exports = {
     if (payload.secret !== config.prismic.secret) {
       throw Boom.unauthorized('Secret is missing or is incorrect');
     }
-    const releaseTag = await githubServices.getLatestReleaseTag(config.PIX_SITE_REPO_NAME);
-    await deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS, releaseTag);
+    const repoName = config.PIX_SITE_REPO_NAME;
+    const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+    await deploy(repoName, config.PIX_SITE_APPS, releaseTag);
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },

--- a/run/controllers/deploy-sites.js
+++ b/run/controllers/deploy-sites.js
@@ -1,5 +1,6 @@
 const config = require('../../config');
 const { deploy } = require('../services/deploy');
+const githubServices = require('../../common/services/github');
 
 const Boom = require('@hapi/boom');
 
@@ -9,8 +10,8 @@ module.exports = {
     if (payload.secret !== config.prismic.secret) {
       throw Boom.unauthorized('Secret is missing or is incorrect');
     }
-
-    const releaseTag = await deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS);
+    const releaseTag = await githubServices.getLatestReleaseTag(config.PIX_SITE_REPO_NAME);
+    await deploy(config.PIX_SITE_REPO_NAME, config.PIX_SITE_APPS, releaseTag);
 
     return `pix.fr and pro.pix.fr deployments ${releaseTag} are in progress. Check deployment status on Scalingo`;
   },

--- a/run/services/deploy.js
+++ b/run/services/deploy.js
@@ -1,8 +1,6 @@
-const githubServices = require('../../common/services/github');
 const releasesService = require('../../common/services/releases');
 
-async function deploy(repoName, appNamesList) {
-  const releaseTag = await githubServices.getLatestReleaseTag(repoName);
+async function deploy(repoName, appNamesList, releaseTag) {
   const environment = 'production';
   await Promise.all(
     appNamesList.map((appName) => releasesService.deployPixRepo(repoName, appName, releaseTag, environment))

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -100,10 +100,10 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
     if (_isReleaseTypeInvalid(releaseType)) {
       releaseType = 'minor';
     }
-    await releasesService.publishPixRepo(repoName, releaseType);
-    const releaseTag = await deploy(repoName, appNamesList);
+    const releaseTagAfterRelease = await releasesService.publishPixRepo(repoName, releaseType);
+    await deploy(repoName, appNamesList, releaseTagAfterRelease);
 
-    sendResponse(responseUrl, getSuccessMessage(releaseTag, appNamesList.join(', ')));
+    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, appNamesList.join(', ')));
   } catch (e) {
     sendResponse(responseUrl, getErrorAppMessage(appNamesList.join(', ')));
   }

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -65,7 +65,7 @@ function _isReleaseTypeInvalid(releaseType) {
   return !['major', 'minor', 'patch'].includes(releaseType);
 }
 
-async function publishPixUI(repoName, releaseType, responseUrl) {
+async function _publishPixUI(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
@@ -80,7 +80,7 @@ async function publishPixUI(repoName, releaseType, responseUrl) {
   }
 }
 
-async function publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
+async function _publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
@@ -95,7 +95,7 @@ async function publishAndDeployEmberTestingLibrary(repoName, releaseType, respon
   }
 }
 
-async function publishAndDeployRelease(repoName, appNamesList = [], releaseType, responseUrl) {
+async function _publishAndDeployRelease(repoName, appNamesList = [], releaseType, responseUrl) {
   try {
     if (_isReleaseTypeInvalid(releaseType)) {
       releaseType = 'minor';
@@ -109,7 +109,7 @@ async function publishAndDeployRelease(repoName, appNamesList = [], releaseType,
   }
 }
 
-async function publishAndDeployReleaseWithAppsByEnvironment(repoName, appsByEnv, releaseType, responseUrl) {
+async function _publishAndDeployReleaseWithAppsByEnvironment(repoName, appsByEnv, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
@@ -132,7 +132,7 @@ async function publishAndDeployReleaseWithAppsByEnvironment(repoName, appsByEnv,
   sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, Object.values(appsByEnv).join(', ')));
 }
 
-async function getAndDeployLastVersion({ appName }) {
+async function _getAndDeployLastVersion({ appName }) {
   const lastReleaseTag = await githubServices.getLatestReleaseTag(PIX_REPO_NAME);
   const sanitizedAppName = appName.trim().toLowerCase();
 
@@ -159,7 +159,7 @@ function _isAppFromPixRepo({ appName }) {
   return appNamePrefix === 'pix' && PIX_APPS.includes(shortAppName) && PIX_APPS_ENVIRONMENTS.includes(environment);
 }
 
-async function deployFromBranch(repoName, appNames, branch) {
+async function _deployFromBranch(repoName, appNames, branch) {
   const client = await ScalingoClient.getInstance('production');
   return Promise.all(
     appNames.map((appName) => {
@@ -184,19 +184,19 @@ module.exports = {
   },
 
   async deployGraviteeAPIM() {
-    await deployFromBranch(PIX_GRAVITEE_APIM_REPO_NAME, PIX_GRAVITEE_APIM_APPS_NAME, 'main');
+    await _deployFromBranch(PIX_GRAVITEE_APIM_REPO_NAME, PIX_GRAVITEE_APIM_APPS_NAME, 'main');
   },
 
   async deployGeoAPI() {
-    await deployFromBranch(PIX_GEOAPI_REPO_NAME, [PIX_GEOAPI_APP_NAME], 'main');
+    await _deployFromBranch(PIX_GEOAPI_REPO_NAME, [PIX_GEOAPI_APP_NAME], 'main');
   },
 
   async deployPix360() {
-    await deployFromBranch(PIX_360_REPO_NAME, [PIX_360_APP_NAME], 'main');
+    await _deployFromBranch(PIX_360_REPO_NAME, [PIX_360_APP_NAME], 'main');
   },
 
   async createAndDeployPixLCMS(payload) {
-    await publishAndDeployReleaseWithAppsByEnvironment(
+    await _publishAndDeployReleaseWithAppsByEnvironment(
       PIX_LCMS_REPO_NAME,
       PIX_LCMS_APPS,
       payload.text,
@@ -205,19 +205,19 @@ module.exports = {
   },
 
   async createAndDeployPixUI(payload) {
-    await publishPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
+    await _publishPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployEmberTestingLibrary(payload) {
-    await publishAndDeployEmberTestingLibrary(PIX_EMBER_TESTING_LIBRARY_REPO_NAME, payload.text, payload.response_url);
+    await _publishAndDeployEmberTestingLibrary(PIX_EMBER_TESTING_LIBRARY_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixSiteRelease(payload) {
-    await publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APPS, payload.text, payload.response_url);
+    await _publishAndDeployRelease(PIX_SITE_REPO_NAME, PIX_SITE_APPS, payload.text, payload.response_url);
   },
 
   async createAndDeployPixDatawarehouse(payload) {
-    await publishAndDeployRelease(
+    await _publishAndDeployRelease(
       PIX_DATAWAREHOUSE_REPO_NAME,
       PIX_DATAWAREHOUSE_APPS_NAME,
       payload.text,
@@ -226,7 +226,7 @@ module.exports = {
   },
 
   async createAndDeployPixBotRelease(payload) {
-    await publishAndDeployReleaseWithAppsByEnvironment(
+    await _publishAndDeployReleaseWithAppsByEnvironment(
       PIX_BOT_REPO_NAME,
       PIX_BOT_APPS,
       payload.text,
@@ -235,18 +235,18 @@ module.exports = {
   },
 
   async getAndDeployLastVersion({ appName }) {
-    await getAndDeployLastVersion({ appName });
+    await _getAndDeployLastVersion({ appName });
   },
 
   async createAndDeployDbStats(payload) {
-    await publishAndDeployRelease(PIX_DB_STATS_REPO_NAME, PIX_DB_STATS_APPS_NAME, payload.text, payload.response_url);
+    await _publishAndDeployRelease(PIX_DB_STATS_REPO_NAME, PIX_DB_STATS_APPS_NAME, payload.text, payload.response_url);
   },
 
   async deployMetabase() {
-    await deployFromBranch(PIX_METABASE_REPO_NAME, PIX_METABASE_APPS_NAME, 'master');
+    await _deployFromBranch(PIX_METABASE_REPO_NAME, PIX_METABASE_APPS_NAME, 'master');
   },
 
   async createAndDeployPixTutosRelease(payload) {
-    await publishAndDeployRelease(PIX_TUTOS_REPO_NAME, [PIX_TUTOS_APP_NAME], payload.text, payload.response_url);
+    await _publishAndDeployRelease(PIX_TUTOS_REPO_NAME, [PIX_TUTOS_APP_NAME], payload.text, payload.response_url);
   },
 };

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -65,7 +65,7 @@ function _isReleaseTypeInvalid(releaseType) {
   return !['major', 'minor', 'patch'].includes(releaseType);
 }
 
-async function publishAndDeployPixUI(repoName, releaseType, responseUrl) {
+async function publishPixUI(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
   }
@@ -205,7 +205,7 @@ module.exports = {
   },
 
   async createAndDeployPixUI(payload) {
-    await publishAndDeployPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
+    await publishPixUI(PIX_UI_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployEmberTestingLibrary(payload) {

--- a/scripts/release-pix-repo.sh
+++ b/scripts/release-pix-repo.sh
@@ -45,3 +45,4 @@ tag_release_commit
 push_commit_and_tag_to_remote
 
 echo -e "Release publication for ${GITHUB_OWNER}/${GITHUB_REPOSITORY} ${GREEN}succeeded${RESET_COLOR} (${VERSION_TYPE})."
+echo "v${NEW_PACKAGE_VERSION}"

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -76,6 +76,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function () {
       'Created annotated tag',
       'Pushed release commit to the origin',
       'Release publication for 1024pix/pix-bot-publish-test \x1B[1;32msucceeded\x1B[0m (minor).',
+      'v0.2.0',
       '',
     ];
     const expectedStderr = [/^Cloning into/, /To (.+)/, /dev -> dev/, /v0.2.0 -> v0.2.0/, ''];

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -106,10 +106,12 @@ describe('releases', function () {
   });
 
   describe('#publishPixRepo', function () {
-    it("should call the release pix script with 'minor'", async function () {
+    beforeEach(function () {
       // given
       sinon.stub(github, 'getDefaultBranch').resolves('dev');
+    });
 
+    it("should call the release pix script with 'minor'", async function () {
       //when
       await releasesService.publishPixRepo('pix-site', 'minor');
 
@@ -122,6 +124,14 @@ describe('releases', function () {
           )
         )
       );
+    });
+
+    it('should retrieve new package version', async function () {
+      //when
+      const newPackageVersion = await releasesService.publishPixRepo('pix-site', 'minor');
+
+      // then
+      expect(newPackageVersion).to.equal('3.14.0');
     });
   });
 });

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -19,12 +19,12 @@ const releasesServices = require('../../../../../common/services/releases');
 const githubServices = require('../../../../../common/services/github');
 const ScalingoClient = require('../../../../../common/services/scalingo-client');
 
-describe('Services | Slack | Commands', () => {
+describe('Unit | Run | Services | Slack | Commands', () => {
   beforeEach(function () {
     // given
     sinon.stub(axios, 'post');
     sinon.stub(releasesServices, 'deployPixRepo').resolves();
-    sinon.stub(releasesServices, 'publishPixRepo').resolves();
+    sinon.stub(releasesServices, 'publishPixRepo').resolves('v1.0.0');
     sinon.stub(githubServices, 'getLatestReleaseTag').resolves('v1.0.0');
   });
 
@@ -173,19 +173,19 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-editor', 'minor');
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
+    it('should not retrieve the last release tag from GitHub', () => {
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-editor');
+      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release on production', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-production');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-production', 'v1.0.0');
     });
 
     it('should deploy the release on minimal', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-minimal-production');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-minimal-production', 'v1.0.0');
     });
   });
 
@@ -205,19 +205,19 @@ describe('Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-bot', 'minor');
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
+    it('should not retrieve the last release tag from GitHub', () => {
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-bot');
+      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release for pix-bot-build', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build-production');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build-production', 'v1.0.0');
     });
 
     it('should deploy the release for pix-bot-run', () => {
       // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run-production');
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run-production', 'v1.0.0');
     });
   });
 

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -42,11 +42,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
         sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site', 'minor');
       });
 
-      it('should not retrieve the last release tag from GitHub', () => {
-        // then
-        sinon.assert.notCalled(githubServices.getLatestReleaseTag);
-      });
-
       it('should deploy the release for pix-site and pix-pro', () => {
         // then
         sinon.assert.calledWith(releasesServices.deployPixRepo, 'pix-site', 'pix-site', 'v1.0.0');
@@ -173,11 +168,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-editor', 'minor');
     });
 
-    it('should not retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
-    });
-
     it('should deploy the release on production', () => {
       // then
       sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-production', 'v1.0.0');
@@ -205,11 +195,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-bot', 'minor');
     });
 
-    it('should not retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
-    });
-
     it('should deploy the release for pix-bot-build', () => {
       // then
       sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build-production', 'v1.0.0');
@@ -232,11 +217,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
     it('should publish a new release', () => {
       // then
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-replication', 'minor');
-    });
-
-    it('should not retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release', () => {
@@ -293,11 +273,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-stats', 'minor');
     });
 
-    it('should not retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
-    });
-
     it('should deploy the release', () => {
       // then
       sinon.assert.calledWith(releasesServices.deployPixRepo);
@@ -315,11 +290,6 @@ describe('Unit | Run | Services | Slack | Commands', () => {
     it('should publish a new release', () => {
       // then
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-tutos', 'minor');
-    });
-
-    it('should not retrieve the last release tag from GitHub', () => {
-      // then
-      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release', () => {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -106,7 +106,7 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       await createAndDeployPixUI(payload);
 
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-ui');
+      sinon.assert.calledOnceWithExactly(githubServices.getLatestReleaseTag, 'pix-ui');
     });
 
     it('should create a minor version if no version is given', async () => {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -42,9 +42,9 @@ describe('Unit | Run | Services | Slack | Commands', () => {
         sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-site', 'minor');
       });
 
-      it('should retrieve the last release tag from GitHub', () => {
+      it('should not retrieve the last release tag from GitHub', () => {
         // then
-        sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-site');
+        sinon.assert.notCalled(githubServices.getLatestReleaseTag);
       });
 
       it('should deploy the release for pix-site and pix-pro', () => {
@@ -234,9 +234,9 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-replication', 'minor');
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
+    it('should not retrieve the last release tag from GitHub', () => {
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-db-replication');
+      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release', () => {
@@ -293,9 +293,9 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-db-stats', 'minor');
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
+    it('should not retrieve the last release tag from GitHub', () => {
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-db-stats');
+      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release', () => {
@@ -317,9 +317,9 @@ describe('Unit | Run | Services | Slack | Commands', () => {
       sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-tutos', 'minor');
     });
 
-    it('should retrieve the last release tag from GitHub', () => {
+    it('should not retrieve the last release tag from GitHub', () => {
       // then
-      sinon.assert.calledWith(githubServices.getLatestReleaseTag, 'pix-tutos');
+      sinon.assert.notCalled(githubServices.getLatestReleaseTag);
     });
 
     it('should deploy the release', () => {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous créons une nouvelle release, la version à déployer est récupérée depuis l'API de GitHub plutôt que d'utiliser la version tout juste créée, ce qui peut provoquer des incohérences (release créée mais autre version déployée)

## :robot: Proposition
Utiliser la version qui vient d'être release

## :100: Pour tester
Vérifier la CI
