### PR TITLE
Prendre en compte le status ouvert d'une PR lors d'une synchro / dépoloiement de RA 

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -126,6 +126,7 @@ function _handleNoRACase(request) {
   const reviewApps = repositoryToScalingoAppsReview[repository];
   const isFork = payload.pull_request.head.repo.fork;
   const labelsList = payload.pull_request.labels;
+  const state = payload.pull_request.state;
 
   if (isFork) {
     return { message: 'No RA for a fork', shouldContinue: false };
@@ -135,6 +136,9 @@ function _handleNoRACase(request) {
   }
   if (labelsList.some((label) => label.name == 'no-review-app')) {
     return { message: 'RA disabled for this PR', shouldContinue: false };
+  }
+  if (state !== 'open') {
+    return { message: 'No RA for closed PR', shouldContinue: false };
   }
 
   return { shouldContinue: true };


### PR DESCRIPTION
## :unicorn: Problème
Lors de la cloture d'une PR, un dernier force push peut générer des erreurs

## :robot: Proposition
Utiliser le `state` : `open` de l'évènement `Synchronize` pour limiter l'utilisation aux PR ouvertes

