### PR TITLE
[FEATURE] Ajouter les URL de la RA Orga sur .org et de la RA Certif sur .org

### DIFF
--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -1,8 +1,10 @@
 Une fois les applications déployées, elles seront accessibles via les liens suivants :
   * [App (.fr)](https://app-pr{{pullRequestId}}.review.pix.fr)
   * [App (.org)](https://app-pr{{pullRequestId}}.review.pix.org)
-  * [Orga](https://orga-pr{{pullRequestId}}.review.pix.fr)
-  * [Certif](https://certif-pr{{pullRequestId}}.review.pix.fr)
+  * [Orga (.fr)](https://orga-pr{{pullRequestId}}.review.pix.fr)
+  * [Orga (.org)](https://orga-pr{{pullRequestId}}.review.pix.org)
+  * [Certif (.fr)](https://certif-pr{{pullRequestId}}.review.pix.fr)
+  * [Certif (.org)](https://certif-pr{{pullRequestId}}.review.pix.org)
   * [Admin](https://admin-pr{{pullRequestId}}.review.pix.fr)
   * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
   * [Pix1D](https://pix1d-pr{{pullRequestId}}.review.pix.fr)


### PR DESCRIPTION
## :unicorn: Problème

Certaines PR ont maintenant besoin des URL de la RA Pix Orga sur .org et de la RA Pix Certif sur .org.

Voici quelques exemples de telles PR : 

* Pix Orga .org https://github.com/1024pix/pix/pull/5991
* Pix Certif .org https://github.com/1024pix/pix/pull/5948

## :robot: Proposition

Ajouter 2 nouvelles lignes pour les 2 nouveaux URL à la template de PR pour le monorepo.

## :rainbow: Remarques

RAS

## :100: Pour tester

Je ne sais pas.
