### PR TITLE
[TECH] Ajout d'un template de commentaire pour Pix Tutos

### DIFF
--- a/build/templates/pull-request-messages/pix-tutos.md
+++ b/build/templates/pull-request-messages/pix-tutos.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-tutos-review-pr{{pullRequestId}}.osc-fr1.scalingo.io
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-tutos-review-pr{{pullRequestId}}/environment


### PR DESCRIPTION
## :unicorn: Problème
Actuellement Pix tutos, utilise le router nginx pour avoir des urls sous la forme `https://tutos-pr141.review.pix.fr/`. 
Sous Nuxt 3, des appels à `/api` se font et le router ne le permet pas pour les apps autres que celles du monorepo.

## :robot: Proposition
Comme ce routeur est pas nécessaire, je propose de ne pas l'utiliser et utiliser l'url fourni par Scalingo directement.
Pour cela, nous ajoutons un template de commentaires sur les pull requests de Pix Tutos avec l'url fourni par Scalingo

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
