### PR TITLE
[BUGFIX] Correction de l'url de Pix1d dans les commentaires de PR (PIX-8336)

### DIFF
--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -7,7 +7,7 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [Certif (.org)](https://certif-pr{{pullRequestId}}.review.pix.org)
   * [Admin](https://admin-pr{{pullRequestId}}.review.pix.fr)
   * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
-  * [Pix1D](https://pix1d-pr{{pullRequestId}}.review.pix.fr)
+  * [Pix1D](https://1d-pr{{pullRequestId}}.review.pix.fr)
 
 Les variables d'environnement seront accessibles via les liens suivants :
   * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)


### PR DESCRIPTION
## :unicorn: Problème
L'url vers la review app de Pix1d commence par `pix1d-xxx` au lieu de `1d-xxx`

## :robot: Proposition
Mettre à jour le template de message de PR envoyé par Pixbot

## :rainbow: Remarques
aucune

## :100: Pour tester
Merger cette PR et ouvrir une PR sur le mono-repo
