### PR TITLE
[FEATURE] Ajoute le suport du tag `BUMP` en préfixe de PR

### DIFF
--- a/common/models/PullRequestGroupFactory.js
+++ b/common/models/PullRequestGroupFactory.js
@@ -21,6 +21,10 @@ class PullRequestGroupFactory {
         groupTitle: '### :bug: Correction',
       }),
       new PullRequestGroup({
+        tagToGrab: Tag.BUMP,
+        groupTitle: '### :arrow_up: Montée de version',
+      }),
+      new PullRequestGroup({
         tagToGrab: Tag.OTHERS,
         groupTitle: '### :coffee: Autre',
       }),

--- a/common/models/Tags.js
+++ b/common/models/Tags.js
@@ -1,6 +1,7 @@
 const Tag = Object.freeze({
   BREAKING: Symbol.for('breakingChange'),
   BUGFIX: Symbol.for('bugfix'),
+  BUMP: Symbol.for('bump'),
   FEATURE: Symbol.for('feature'),
   OTHERS: Symbol.for('others'),
   TECH: Symbol.for('tech'),

--- a/common/services/changelog.js
+++ b/common/services/changelog.js
@@ -20,7 +20,7 @@ function displayPullRequest(pr) {
 }
 
 function orderPr(listPR) {
-  const typeOrder = ['BREAKING', 'FEATURE', 'BUGFIX', 'TECH'];
+  const typeOrder = ['BREAKING', 'FEATURE', 'BUGFIX', 'TECH', 'BUMP'];
   return sortBy(listPR, (pr) => {
     const typeOfPR = pr.title.substring(1, pr.title.indexOf(']'));
     const typeIndex = indexOf(typeOrder, typeOfPR);

--- a/test/unit/common/models/PullRequestGroupFactory_test.js
+++ b/test/unit/common/models/PullRequestGroupFactory_test.js
@@ -27,6 +27,10 @@ describe('Unit | Common | Models | PullRequestGroupFactory', function () {
           groupTitle: '### :bug: Correction',
         }),
         new PullRequestGroup({
+          tagToGrab: Tag.BUMP,
+          groupTitle: '### :arrow_up: Montée de version',
+        }),
+        new PullRequestGroup({
           tagToGrab: Tag.OTHERS,
           groupTitle: '### :coffee: Autre',
         }),

--- a/test/unit/common/models/Tags_test.js
+++ b/test/unit/common/models/Tags_test.js
@@ -16,6 +16,11 @@ describe('Unit | Common | Models | Tags', function () {
         expectedTag: Symbol.for('bugfix'),
       },
       {
+        testTitle: 'Tag.BUMP if title include [BUMP]',
+        pullRequestTitle: '[BUMP] Pull Request Title',
+        expectedTag: Symbol.for('bump'),
+      },
+      {
         testTitle: 'Tag.FEATURE if title include [FEATURE]',
         pullRequestTitle: '[FEATURE] Pull Request Title',
         expectedTag: Symbol.for('feature'),

--- a/test/unit/common/services/changelog_test.js
+++ b/test/unit/common/services/changelog_test.js
@@ -109,6 +109,7 @@ describe('Unit | Common | Services | Changelog', function () {
         { title: '[BUGFIX] TEST' },
         { title: 'TEST' },
         { title: '[FEATURE] TEST' },
+        { title: '[BUMP] TEST' },
         { title: '[BREAKING] TEST' },
         { title: '[TECH] TEST' },
       ];
@@ -121,7 +122,8 @@ describe('Unit | Common | Services | Changelog', function () {
       expect(result[1].title).to.equal('[FEATURE] TEST');
       expect(result[2].title).to.equal('[BUGFIX] TEST');
       expect(result[3].title).to.equal('[TECH] TEST');
-      expect(result[4].title).to.equal('TEST');
+      expect(result[4].title).to.equal('[BUMP] TEST');
+      expect(result[5].title).to.equal('TEST');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Avec Renovate nous créons des PRs préfixées par le tag `BUMP`. Pour le moment elles se retrouvent dans un groupe du changelog nommé "Autre".

## :robot: Proposition
On propose d'ajouter un tag BUMP pour générer une section `:arrow_up: Montée de version` en bas du changelog (juste avant "Autre").

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
La CI passe
