### PR TITLE
[FEATURE] Ajout de la commande Slack de déploiement de pix-actions

### DIFF
--- a/config.js
+++ b/config.js
@@ -107,6 +107,7 @@ module.exports = (function () {
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',
     PIX_DB_STATS_APPS_NAME: ['pix-db-stats'],
+    PIX_ACTIONS_REPO_NAME: 'pix-actions',
     PIX_SITE_REPO_NAME: 'pix-site',
     PIX_SITE_APPS: ['pix-site', 'pix-pro'],
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -46,6 +46,15 @@ module.exports = {
     };
   },
 
+  createPixActionsRelease(request) {
+    const payload = request.pre.payload;
+    commands.createPixActionsRelease(payload);
+
+    return {
+      text: _getDeployStartedMessage(payload.text, 'PIX actions'),
+    };
+  },
+
   createAndDeployPixSiteRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixSiteRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -4,6 +4,15 @@ const slackbotController = require('./controllers/slack');
 const manifest = new Manifest('Pix Bot Run');
 
 manifest.registerSlashCommand({
+  command: '/deploy-pix-actions',
+  path: '/slack/commands/create-pix-actions-release',
+  description: 'Pour faire une release des actions GitHub de Pix (ex: automerge)',
+  usage_hint: 'patch|minor|major (minor par défaut)',
+  should_escape: false,
+  handler: slackbotController.createPixActionsRelease,
+});
+
+manifest.registerSlashCommand({
   command: '/deploy-pix-sites',
   path: '/slack/commands/create-and-deploy-pix-site-release',
   description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -3,6 +3,7 @@ const {
   PIX_REPO_NAME,
   PIX_APPS,
   PIX_APPS_ENVIRONMENTS,
+  PIX_ACTIONS_REPO_NAME,
   PIX_SITE_REPO_NAME,
   PIX_SITE_APPS,
   PIX_BOT_REPO_NAME,
@@ -93,6 +94,20 @@ async function _publishAndDeployEmberTestingLibrary(repoName, releaseType, respo
   } else {
     slackPostMessageService.postMessage(`[EMBER-TESTING-LIBRARY] Lib deployed (${releaseTagAfterRelease})`);
     sendResponse(responseUrl, getSuccessReleaseMessage(releaseTagAfterRelease, repoName));
+  }
+}
+
+async function _publishRelease(repoName, releaseType, responseUrl) {
+  if (_isReleaseTypeInvalid(releaseType)) {
+    releaseType = 'minor';
+  }
+  const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
+  const releaseTagAfterRelease = await releasesService.publishPixRepo(repoName, releaseType);
+
+  if (releaseTagBeforeRelease === releaseTagAfterRelease) {
+    sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
+  } else {
+    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
   }
 }
 
@@ -215,6 +230,10 @@ module.exports = {
 
   async createAndDeployEmberTestingLibrary(payload) {
     await _publishAndDeployEmberTestingLibrary(PIX_EMBER_TESTING_LIBRARY_REPO_NAME, payload.text, payload.response_url);
+  },
+
+  async createPixActionsRelease(payload) {
+    await _publishRelease(PIX_ACTIONS_REPO_NAME, payload.text, payload.response_url);
   },
 
   async createAndDeployPixSiteRelease(payload) {

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -35,6 +35,13 @@ describe('Acceptance | Run | Manifest', function () {
           ],
           slash_commands: [
             {
+              command: '/deploy-pix-actions',
+              url: `http://${hostname}/slack/commands/create-pix-actions-release`,
+              description: 'Pour faire une release des actions GitHub de Pix (ex: automerge)',
+              usage_hint: 'patch|minor|major (minor par défaut)',
+              should_escape: false,
+            },
+            {
               command: '/deploy-pix-sites',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-site-release`,
               description: 'Pour faire une release et deployer les sites Pix, Pix Pro et Pix org',

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -6,6 +6,7 @@ const {
   createAndDeployPixLCMS,
   createAndDeployPixUI,
   createAndDeployEmberTestingLibrary,
+  createPixActionsRelease,
   createAndDeployPixSiteRelease,
   createAndDeployPixDatawarehouse,
   createAndDeployPixBotRelease,
@@ -26,6 +27,41 @@ describe('Unit | Run | Services | Slack | Commands', () => {
     sinon.stub(releasesServices, 'deployPixRepo').resolves();
     sinon.stub(releasesServices, 'publishPixRepo').resolves('v1.0.0');
     sinon.stub(githubServices, 'getLatestReleaseTag').resolves('v1.0.0');
+  });
+
+  describe('#createPixActionsRelease', () => {
+    it('should publish a new release', async () => {
+      // given
+      const payload = { text: 'minor' };
+
+      // when
+      await createPixActionsRelease(payload);
+
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-actions', 'minor');
+    });
+
+    it('should retrieve the last release tag from GitHub', async () => {
+      // given
+      const payload = { text: 'minor' };
+
+      // when
+      await createPixActionsRelease(payload);
+
+      // then
+      sinon.assert.calledOnceWithExactly(githubServices.getLatestReleaseTag, 'pix-actions');
+    });
+
+    it('should create a minor version if no version is given', async () => {
+      // given
+      const payload = { text: '' };
+
+      // when
+      await createPixActionsRelease(payload);
+
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-actions', 'minor');
+    });
   });
 
   describe('#createAndDeployPixSiteRelease', () => {


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pour l'instant pas de moyen de déployer pix-actions.

## :robot: Proposition
Ajouter un moyen de release depuis Slack.

## :rainbow: Remarques
RAS

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
