### PR TITLE
Activer les review-app de l'application Pix4Pix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # Pix Bot (ex-SAM)
 
-Pix Bot is this smart person who thinks of turning off the light when leaving the office and turning on the coffee machine when arriving in the morning.
-
-Pix Bot is this eco-responsible application that preserves resources (yours 💰 and those of the planet 🌍) while ensuring comfortable activity for the team.
-
+## Goals
 Pix Bot helps developers and teams who host their applications on [Scalingo](https://scalingo.com) to manage them pragmatically and economically.
 
-Services provided by Pix Bot:
-- shut down Review Apps, at the time you want, every day of the week
-- re-start stopped Review Apps, when you want, every day of the week
-- deploy a specific release into production via secured API
-- deploy a specific release into production via a Slack command or shortcut
+It offers the following services:
+- create a Review App;
+- shut down and restart Review Apps, at the time you want, every day of the week;
+- deploy a specific release into production via a secured API;
+- deploy a specific release into production via a Slack command or shortcut;
+- call external service after a deployment (CDN invalidation).
 
 Pix Bot is deployed into two apps:
 - Pix Bot Build: contains the commands for the development tools
 - Pix Bot Run: contains the commands related to the releases
 
-## Getting started
-
-### Run locally
+## Run locally
 
 *1/* Get the sources
 
@@ -51,6 +47,28 @@ Command to run the `publish` script:
 ```sh
 GITHUB_OWNER=#github_owner# GITHUB_REPOSITORY=#github_repository# GITHUB_PERSONAL_ACCESS_TOKEN=#github_personal_token# GIT_USER_NAME=#user_name# GIT_USER_EMAIL=#user_email# scripts/publish.sh (path|minor|major)
 ```
+
+## Deploy an application through Slack
+
+Create a Slack endpoint in [manifest](./run/manifest.js)
+```js
+manifest.registerSlashCommand({
+  command: '/deploy-pix-datawarehouse',
+  path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
+  description:
+    'Crée une release de Pix-Datawarehouse et la déploie en production (pix-datawarehouse-production & pix-datawarehouse-ex-production)',
+  usage_hint: '[patch, minor, major]',
+  should_escape: false,
+  handler: slackbotController.createAndDeployPixDatawarehouseRelease,
+});
+```
+
+
+## Activate review-application for an application
+
+
+
+## Test 
 
 ### Test the endpoint on Slack
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,25 @@ manifest.registerSlashCommand({
 
 ## Activate review-application for an application
 
+### Register the Scalingo application(s)
 
+Add GitHub repository and Scalingo application name in [the mapping](./build/controllers/github.js)
+```js
+const repositoryToScalingoAppsReview = {
+   <GITHUB-REPOSITORY-NAME>: [<SCALINGO-APPLICATION-NAME>],
+     (..)
+}
+```
+
+You can have more than one Scalingo application per GitHub repository.
+
+### Customize review-application comment
+A comment is added to teh pull request, including:
+- review application URL;
+- review application administration URL.
+
+Check if the [default template](./build/templates/pull-request-messages/default.md) fit your needs.
+If not, create a custom one in the folder.
 
 ## Test 
 

--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -15,6 +15,7 @@ const repositoryToScalingoAppsReview = {
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],
   pix: ['pix-front-review', 'pix-api-review'],
+  pix4pix: ['pix-4pix-front-review', 'pix-4pix-api-review'],
 };
 
 function getMessageTemplate(repositoryName) {

--- a/build/templates/pull-request-messages/pix-4pix.md
+++ b/build/templates/pull-request-messages/pix-4pix.md
@@ -1,0 +1,11 @@
+Une fois les applications déployées, elles seront accessibles via les liens suivants :
+  * [App (.fr)](https://app-pr{{pullRequestId}}review.pix4.pix.digital)
+  * [Orga (.fr)](https://orga-pr{{pullRequestId}}review.pix4.pix.digital)
+  * [Certif (.fr)](https://certif-pr{{pullRequestId}}review.pix4.pix.digital)
+  * [Admin](https://admin-pr{{pullRequestId}}review.pix4.pix.digital)
+  * [API](https://api-pr{{pullRequestId}}review.pix4.pix.digital/api/)
+  * [Pix1D](https://pix1d-pr{{pullRequestId}}review.pix4.pix.digital)
+
+Les variables d'environnement seront accessibles via les liens suivants :
+  * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-4pix-front-review-pr{{pullRequestId}}/environment)
+  * [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-4pix-api-review-pr{{pullRequestId}}/environment)


### PR DESCRIPTION
## :unicorn: Problème
Les review-app de Pix4Pix ne sont pas activées.

## :robot: Proposition
Les activer.

## :rainbow: Remarques
Pour qu'elles soient accessibles, [cette PR](https://github.com/1024pix/pix-review-router/pull/13) devra être mergée

## :100: Pour tester
Merger et ouvrir une PR sur le repository Gihtub.
Vérifier qu'une review-pp est créée dans Scalingo.
Vérifier que les liens postés dans la PR mènent à l'application.
