### PR TITLE
[FEATURE] Permettre la gestion des review-app sur un fork en propriété

### DIFF
--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -18,6 +18,7 @@ describe('Acceptance | Build | Github', function () {
                 repo: {
                   name: 'pix',
                   fork: false,
+                  owner: { login: 'github-owner' },
                 },
               },
             },
@@ -129,8 +130,64 @@ describe('Acceptance | Build | Github', function () {
           expect(githubNock.isDone()).to.be.true;
         });
 
-        it("responds with 200 and doesn't create the RA on scalingo when the PR is from a fork", async function () {
+        it('responds with 200 and create the RA on scalingo when the PR is from a fork owned by the organization', async function () {
           body.pull_request.head.repo.fork = true;
+          body.pull_request.head.repo.owner.login = 'github-owner';
+
+          const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.OK);
+          const replyBody1 = {
+            review_app: {
+              app_name: 'pix-front-review-pr2',
+            },
+          };
+          const replyBody2 = {
+            review_app: {
+              app_name: 'pix-api-review-pr2',
+            },
+          };
+          const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+            .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+            .reply(StatusCodes.CREATED, replyBody1);
+          const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+            .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
+            .reply(StatusCodes.CREATED, replyBody2);
+          const scalingoUpdateOpts1 = nock('https://api.osc-fr1.scalingo.com')
+            .patch('/v1/apps/pix-front-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+            .reply(StatusCodes.CREATED);
+          const scalingoUpdateOpts2 = nock('https://api.osc-fr1.scalingo.com')
+            .patch('/v1/apps/pix-api-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
+            .reply(StatusCodes.CREATED);
+          const scalingoSCMDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+            .post('/v1/apps/pix-front-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
+            .reply(200);
+          const scalingoSCMDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+            .post('/v1/apps/pix-api-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
+            .reply(200);
+          nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(StatusCodes.OK);
+
+          const res = await server.inject({
+            method: 'POST',
+            url: '/github/webhook',
+            headers: {
+              ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+              'x-github-event': 'pull_request',
+            },
+            payload: body,
+          });
+          expect(res.statusCode).to.equal(StatusCodes.OK);
+          expect(res.result).to.eql('Created RA on app pix-front-review, pix-api-review with pr 2');
+          expect(scalingoAuth.isDone()).to.be.true;
+          expect(scalingoDeploy1.isDone()).to.be.true;
+          expect(scalingoDeploy2.isDone()).to.be.true;
+          expect(scalingoUpdateOpts1.isDone()).to.be.true;
+          expect(scalingoUpdateOpts2.isDone()).to.be.true;
+          expect(scalingoSCMDeploy1.isDone()).to.be.true;
+          expect(scalingoSCMDeploy2.isDone()).to.be.true;
+        });
+
+        it("responds with 200 and doesn't create the RA on scalingo when the PR is from a fork not owned by the organization", async function () {
+          body.pull_request.head.repo.fork = true;
+          body.pull_request.head.repo.owner.login = 'another-owner';
 
           const res = await server.inject({
             method: 'POST',
@@ -142,7 +199,7 @@ describe('Acceptance | Build | Github', function () {
             payload: body,
           });
           expect(res.statusCode).to.equal(200);
-          expect(res.result).to.eql('No RA for a fork');
+          expect(res.result).to.eql('No RA for a fork not owned by the organization');
         });
 
         it("responds with 200 and doesn't create the RA on scalingo when the PR is not from a configured repo", async function () {
@@ -201,7 +258,11 @@ describe('Acceptance | Build | Github', function () {
             const body = {
               action: 'opened',
               text: 'app-1',
-              pull_request: { state: 'open', labels: [], head: { repo: { name: 'pix-bot' } } },
+              pull_request: {
+                state: 'open',
+                labels: [],
+                head: { repo: { name: 'pix-bot', owner: { login: 'github_owner' } } },
+              },
             };
 
             const response = await server.inject({
@@ -235,6 +296,7 @@ describe('Acceptance | Build | Github', function () {
               repo: {
                 name: 'pix',
                 fork: false,
+                owner: { login: 'github-owner' },
               },
             },
           },
@@ -282,8 +344,36 @@ describe('Acceptance | Build | Github', function () {
         expect(res.result).to.eql('No RA for closed PR');
       });
 
-      it("responds with 200 and doesn't trigger deployment when the PR is from a fork", async function () {
+      it('responds with 200 and trigger deployment when the PR is from a fork owned by the organization', async function () {
         body.pull_request.head.repo.fork = true;
+        body.pull_request.head.repo.owner.login = 'github-owner';
+        const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
+        const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-front-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
+          .reply(200);
+        const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+          .post('/v1/apps/pix-api-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
+          .reply(200);
+
+        const res = await server.inject({
+          method: 'POST',
+          url: '/github/webhook',
+          headers: {
+            ...createGithubWebhookSignatureHeader(JSON.stringify(body)),
+            'x-github-event': 'pull_request',
+          },
+          payload: body,
+        });
+        expect(res.statusCode).to.equal(StatusCodes.OK);
+        expect(res.result).to.eql('Triggered deployment of RA on app pix-front-review, pix-api-review with pr 2');
+        expect(scalingoAuth.isDone()).to.be.true;
+        expect(scalingoDeploy1.isDone()).to.be.true;
+        expect(scalingoDeploy2.isDone()).to.be.true;
+      });
+
+      it("responds with 200 and doesn't trigger deployment when the PR is from a fork not owned by the organization", async function () {
+        body.pull_request.head.repo.fork = true;
+        body.pull_request.head.repo.owner.login = 'another-owner';
 
         const res = await server.inject({
           method: 'POST',
@@ -295,7 +385,7 @@ describe('Acceptance | Build | Github', function () {
           payload: body,
         });
         expect(res.statusCode).to.equal(200);
-        expect(res.result).to.eql('No RA for a fork');
+        expect(res.result).to.eql('No RA for a fork not owned by the organization');
       });
 
       it("responds with 200 and doesn't trigger deployment the RA on scalingo when the PR is not from a configured repo", async function () {


### PR DESCRIPTION
## :unicorn: Problème
Le repository https://github.com/1024pix/pix4pix est un fork de https://github.com/1024pix/pix
Ses RA ne sont pas prises en compte

## :robot: Proposition
Gérer les RA si l'organisation est propriétaire du fork

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
