### PR TITLE
Ajout d'une commande slack de déploiement pour pix-api-data

### DIFF
--- a/config.js
+++ b/config.js
@@ -103,6 +103,10 @@ module.exports = (function () {
       production: ['pix-lcms-production'],
       recette: ['pix-lcms-minimal-production'],
     },
+    PIX_API_DATA_REPO_NAME: 'pix-api-data',
+    PIX_API_DATA_APPS: {
+      production: ['pix-api-data-production'],
+    },
     PIX_UI_REPO_NAME: 'pix-ui',
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -55,6 +55,15 @@ module.exports = {
     };
   },
 
+  createAndDeployPixAPIDataRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixAPIData(payload);
+
+    return {
+      text: _getDeployStartedMessage(payload.text, 'PIX API DATA'),
+    };
+  },
+
   createAndDeployPixDatawarehouseRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixDatawarehouse(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -40,6 +40,15 @@ manifest.registerSlashCommand({
 });
 
 manifest.registerSlashCommand({
+  command: '/deploy-pix-api-data',
+  path: '/slack/commands/create-and-deploy-pix-api-data-release',
+  description: 'Crée une release de pix-api-data et la déploie en production (https://api-data.pix.fr)',
+  usage_hint: '[patch, minor, major]',
+  should_escape: false,
+  handler: slackbotController.createAndDeployPixAPIDataRelease,
+});
+
+manifest.registerSlashCommand({
   command: '/deploy-pix-datawarehouse',
   path: '/slack/commands/create-and-deploy-pix-datawarehouse-release',
   description:

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -11,6 +11,8 @@ const {
   PIX_DATAWAREHOUSE_APPS_NAME,
   PIX_LCMS_REPO_NAME,
   PIX_LCMS_APPS,
+  PIX_API_DATA_REPO_NAME,
+  PIX_API_DATA_APPS,
   PIX_UI_REPO_NAME,
   PIX_EMBER_TESTING_LIBRARY_REPO_NAME,
   PIX_DB_STATS_REPO_NAME,
@@ -175,6 +177,15 @@ module.exports = {
     await _publishAndDeployReleaseWithAppsByEnvironment(
       PIX_LCMS_REPO_NAME,
       PIX_LCMS_APPS,
+      payload.text,
+      payload.response_url,
+    );
+  },
+
+  async createAndDeployPixAPIData(payload) {
+    await _publishAndDeployReleaseWithAppsByEnvironment(
+      PIX_API_DATA_REPO_NAME,
+      PIX_API_DATA_APPS,
       payload.text,
       payload.response_url,
     );

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -63,6 +63,13 @@ describe('Acceptance | Run | Manifest', function () {
               should_escape: false,
             },
             {
+              command: '/deploy-pix-api-data',
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-api-data-release`,
+              description: 'Crée une release de pix-api-data et la déploie en production (https://api-data.pix.fr)',
+              usage_hint: '[patch, minor, major]',
+              should_escape: false,
+            },
+            {
               command: '/deploy-pix-datawarehouse',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-datawarehouse-release`,
               description:

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const { catchErr, sinon } = require('../../../../test-helper');
 const {
   createAndDeployPixLCMS,
+  createAndDeployPixAPIData,
   createAndDeployPixUI,
   createAndDeployEmberTestingLibrary,
   createAndDeployPixSiteRelease,
@@ -174,6 +175,29 @@ describe('Unit | Run | Services | Slack | Commands', () => {
     it('should deploy the release on minimal', () => {
       // then
       sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-minimal-production', 'v1.0.0');
+    });
+  });
+
+  describe('#createAndDeployPixAPIData', () => {
+    let client;
+
+    beforeEach(async function () {
+      // given
+      client = { deployFromArchive: sinon.spy() };
+      sinon.stub(ScalingoClient, 'getInstance').resolves(client);
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixAPIData(payload);
+    });
+
+    it('should publish a new release', () => {
+      // then
+      sinon.assert.calledWith(releasesServices.publishPixRepo, 'pix-api-data', 'minor');
+    });
+
+    it('should deploy the release on production', () => {
+      // then
+      sinon.assert.calledWith(client.deployFromArchive, 'pix-api-data-production', 'v1.0.0');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de commande pour déployer pix-api-data

## :robot: Proposition
L'ajouter

## :rainbow: Remarques
L'app pix-api-data-production n'existe pas encore mais cette PR est en prévision des MEP de cette app.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
