### PR TITLE
[FEATURE] Déployer l'intégration du monorepo avec Pix Bot (PIX-8933)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,27 @@ If not, create a custom one in the folder.
 
 ## Test 
 
+### GitHub integration
+
+Generate a secret and store it in `.env`file `GITHUB_WEBHOOK_SECRET` variable.
+
+Start the server.
+`npm start`
+
+Expose it.
+`ngrok http 3000`
+
+Create a webhook on Github organization (or repository) :
+- Payload URL = https://<SOMETHING>.ngrok.io/github/webhook
+- Content type: application/JSON
+- secret = <GITHUB_WEBHOOK_SECRET>
+- SSL verification = Disabled
+- Which events would you like to trigger this webhook? send me everything
+
+Perform some action on Github and check
+- ngrok receive Github request
+- pix-bot API process them
+
 ### Test the endpoint on Slack
 
 If you want to test your new endpoint before deploying it, 

--- a/config.js
+++ b/config.js
@@ -60,6 +60,17 @@ module.exports = (function () {
       validAppNbCharMax: 46,
       validAppNbCharMin: 6,
       maxLogLength: process.env.MAX_LOG_LENGTH || 1000,
+      repositoryToScalingoIntegration: {
+        pix: [
+          'pix-api-integration',
+          'pix-audit-logger-integration',
+          'pix-app-integration',
+          'pix-certif-integration',
+          'pix-orga-integration',
+          'pix-admin-integration',
+          'pix-1d-integration',
+        ],
+      },
     },
 
     openApi: {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "npm run lint:dependencies && npm run lint:code",
     "lint:code": "eslint .",
     "lint:dependencies": "depcheck",
+    "lint:fix": "eslint --fix .",
     "local:trigger-lint-on-commit": "husky install",
     "local:prevent-trigger-lint-on-commit": "git config --unset core.hooksPath",
     "preinstall": "npx check-engine",


### PR DESCRIPTION
## :unicorn: Problème
Le déploiement effectué par Scalingo en auto-deploy épuise notre quota Github.
Ce problème a été remonté, mais n'a pas été corrigé.

## :robot: Proposition
Déployer à leur place en pushant une archive.

## :rainbow: Remarques
On va faire un ticket après pour rendre le code testable en intégration et unitairement.

## :100: Pour tester
Merger la PR.
