### PR TITLE
[BUGFIX] Vérifier que la configuration Scalingo est fournie avant l'appel d'authentification

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -133,8 +133,9 @@ async function pushOnDefaultBranchWebhook(request) {
   if (!(repositoryName in config.scalingo.repositoryToScalingoIntegration)) {
     return `Ignoring push event on repository ${repositoryName} as it is not configured`;
   }
+  const scalingoApps = config.scalingo.repositoryToScalingoIntegration[repositoryName];
   const client = await ScalingoClient.getInstance('integration');
-  for (const applicationName of config.scalingo.repositoryToScalingoIntegration[repositoryName]) {
+  for (const applicationName of scalingoApps) {
     try {
       await client.deployFromArchive(applicationName, branchName, repositoryName, { withEnvSuffix: false });
     } catch (error) {
@@ -142,7 +143,7 @@ async function pushOnDefaultBranchWebhook(request) {
     }
   }
 
-  return 'Deploying branch default_branch_name on integration applications : front1-integration, front2-integration, api-integration';
+  return `Deploying branch ${branchName} on integration applications : ` + scalingoApps.join(', ');
 }
 
 function _handleNoRACase(request) {

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -13,6 +13,9 @@ class ScalingoClient {
 
   static async getInstance(environment, injectedClient = scalingo) {
     const { token, apiUrl } = config.scalingo[environment];
+    if (!token || !apiUrl) {
+      throw new Error(`Scalingo credentials missing for environment ${environment}`);
+    }
     const client = await injectedClient.clientFromToken(token, { apiUrl });
     return new ScalingoClient(client, environment);
   }

--- a/config.js
+++ b/config.js
@@ -150,6 +150,10 @@ module.exports = (function () {
 
     config.openApi.authorizationToken = 'open-api-token';
 
+    config.scalingo.reviewApps.token = 'tk-us-scalingo-token-reviewApps';
+    config.scalingo.reviewApps.apiUrl = 'https://scalingo.reviewApps';
+    config.scalingo.integration.token = 'tk-us-scalingo-token-integration';
+    config.scalingo.integration.apiUrl = 'https://scalingo.integration';
     config.scalingo.recette.token = 'tk-us-scalingo-token-recette';
     config.scalingo.recette.apiUrl = 'https://scalingo.recette';
     config.scalingo.production.token = 'tk-us-scalingo-token-production';

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -383,7 +383,7 @@ describe('Acceptance | Build | Github', function () {
           // then
           expect(res.statusCode).to.equal(200);
           expect(res.result).to.equal(
-            'Deploying branch default_branch_name on integration applications : front1-integration, front2-integration, api-integration',
+            'Deploying branch default_branch_name on integration applications : pix-front1-integration, pix-front2-integration, pix-api-integration',
           );
           expect(scalingoDeployFront1.isDone()).to.be.true;
           expect(scalingoDeployFront2.isDone()).to.be.true;

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -42,33 +42,33 @@ describe('Acceptance | Build | Github', function () {
               app_name: 'pix-audit-logger-review-pr2',
             },
           };
-          const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeploy1 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-front-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
             .reply(StatusCodes.CREATED, replyBody1);
-          const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeploy2 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-api-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
             .reply(StatusCodes.CREATED, replyBody2);
-          const scalingoDeploy3 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeploy3 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-audit-logger-review/scm_repo_link/manual_review_app', { pull_request_id: 2 })
             .reply(StatusCodes.CREATED, replyBody3);
-          const scalingoUpdateOpts1 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoUpdateOpts1 = nock('https://scalingo.reviewApps')
             .patch('/v1/apps/pix-front-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
             .reply(StatusCodes.CREATED);
-          const scalingoUpdateOpts2 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoUpdateOpts2 = nock('https://scalingo.reviewApps')
             .patch('/v1/apps/pix-api-review-pr2/scm_repo_link', { scm_repo_link: { auto_deploy_enabled: false } })
             .reply(StatusCodes.CREATED);
-          const scalingoUpdateOpts3 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoUpdateOpts3 = nock('https://scalingo.reviewApps')
             .patch('/v1/apps/pix-audit-logger-review-pr2/scm_repo_link', {
               scm_repo_link: { auto_deploy_enabled: false },
             })
             .reply(StatusCodes.CREATED);
-          const scalingoSCMDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoSCMDeploy1 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-front-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
             .reply(200);
-          const scalingoSCMDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoSCMDeploy2 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-api-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
             .reply(200);
-          const scalingoSCMDeploy3 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoSCMDeploy3 = nock('https://scalingo.reviewApps')
             .post('/v1/apps/pix-audit-logger-review-pr2/scm_repo_link/manual_deploy', {
               branch: 'my-branch',
             })
@@ -217,13 +217,13 @@ describe('Acceptance | Build | Github', function () {
 
       it('responds with 200 and create a deployment on scalingo', async function () {
         const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
-        const scalingoDeploy1 = nock('https://api.osc-fr1.scalingo.com')
+        const scalingoDeploy1 = nock('https://scalingo.reviewApps')
           .post('/v1/apps/pix-front-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
           .reply(200);
-        const scalingoDeploy2 = nock('https://api.osc-fr1.scalingo.com')
+        const scalingoDeploy2 = nock('https://scalingo.reviewApps')
           .post('/v1/apps/pix-api-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
           .reply(200);
-        const scalingoDeploy3 = nock('https://api.osc-fr1.scalingo.com')
+        const scalingoDeploy3 = nock('https://scalingo.reviewApps')
           .post('/v1/apps/pix-audit-logger-review-pr2/scm_repo_link/manual_deploy', { branch: 'my-branch' })
           .reply(200);
 
@@ -342,13 +342,13 @@ describe('Acceptance | Build | Github', function () {
             },
           };
           nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
-          const scalingoDeployFront1 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeployFront1 = nock('https://scalingo.integration')
             .post('/v1/apps/pix-front1-integration/deployments', scalingoDeploymentPayload)
             .reply(200);
-          const scalingoDeployFront2 = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeployFront2 = nock('https://scalingo.integration')
             .post('/v1/apps/pix-front2-integration/deployments', scalingoDeploymentPayload)
             .reply(200);
-          const scalingoDeployApi = nock('https://api.osc-fr1.scalingo.com')
+          const scalingoDeployApi = nock('https://scalingo.integration')
             .post('/v1/apps/pix-api-integration/deployments', scalingoDeploymentPayload)
             .reply(200);
 
@@ -404,13 +404,13 @@ describe('Acceptance | Build | Github', function () {
               },
             };
             nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
-            const scalingoDeployFront1 = nock('https://api.osc-fr1.scalingo.com')
+            const scalingoDeployFront1 = nock('https://scalingo.integration')
               .post('/v1/apps/pix-front1-integration/deployments', scalingoDeploymentPayload)
               .reply(200);
-            const scalingoDeployFront2 = nock('https://api.osc-fr1.scalingo.com')
+            const scalingoDeployFront2 = nock('https://scalingo.integration')
               .post('/v1/apps/pix-front2-integration/deployments', scalingoDeploymentPayload)
               .reply(500, { message: 'error' });
-            const scalingoDeployApi = nock('https://api.osc-fr1.scalingo.com')
+            const scalingoDeployApi = nock('https://scalingo.integration')
               .post('/v1/apps/pix-api-integration/deployments', scalingoDeploymentPayload)
               .reply(200);
 

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -46,6 +46,21 @@ describe('Scalingo client', () => {
       expect(scalingoClient.client).to.exist;
     });
 
+    it('should throw an error when no token is provided', async () => {
+      // given
+      sinon.stub(config.scalingo, 'integration').value({
+        token: undefined,
+        url: 'https://api.osc-fr1.scalingo.com',
+      });
+      // when
+      try {
+        await ScalingoClient.getInstance('integration');
+        expect.fail('should raise an error when credentials are missing');
+      } catch (e) {
+        expect(e.message).to.equal('Scalingo credentials missing for environment integration');
+      }
+    });
+
     it('should throw an error when scalingo authentication failed', async () => {
       // given
       const clientStub = {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cas ou les variables d'environnement configurant le client scalingo ne serait pas définies, Pix bot renvoie une erreur sans l'expliciter

## :robot: Proposition

Gérer le cas ou les identifiants utilisés ne sont pas définis.

## :100: Pour tester
🟢 
