### PR TITLE
Déployer audit-logger automatiquement lors de MER / MEP

### DIFF
--- a/config.js
+++ b/config.js
@@ -127,7 +127,7 @@ module.exports = (function () {
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex', 'pix-datawarehouse-data'],
 
-    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api', '1d'],
+    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api', '1d', 'audit-logger'],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
     PIX_TUTOS_REPO_NAME: 'pix-tutos',
     PIX_TUTOS_APP_NAME: 'pix-tutos',

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -43,7 +43,7 @@ describe('releases', function () {
       // when
       const response = await releasesService.deploy('production', 'v1.0');
       // then
-      expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK', 'OK']);
+      expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK', 'OK', 'OK']);
     });
 
     it('should ask scalingo to deploy applications', async () => {
@@ -55,7 +55,7 @@ describe('releases', function () {
       // when
       await releasesService.deploy('production', 'v1.0 ');
       // then
-      expect(scalingoClient.deployFromArchive.callCount).to.equal(6);
+      expect(scalingoClient.deployFromArchive.callCount).to.equal(7);
       expect(scalingoClient.deployFromArchive.args).to.deep.equal([
         ['pix-app', 'v1.0'],
         ['pix-certif', 'v1.0'],
@@ -63,6 +63,7 @@ describe('releases', function () {
         ['pix-orga', 'v1.0'],
         ['pix-api', 'v1.0'],
         ['pix-1d', 'v1.0'],
+        ['pix-audit-logger', 'v1.0'],
       ]);
     });
 
@@ -76,7 +77,7 @@ describe('releases', function () {
       // when
       await releasesService.deploy('production', tag);
       // then
-      expect(scalingoClient.deployFromArchive.callCount).to.equal(6);
+      expect(scalingoClient.deployFromArchive.callCount).to.equal(7);
       expect(scalingoClient.deployFromArchive.firstCall.args[1]).to.equal('v1.0.0');
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Audit-logger n'est pas déployer automatiquement en prod / recette.

## :robot: Proposition
L'ajouter dans les PIX_APPS dans le config.js afin qu'il soit pris en compte.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que le déploiement se fait correctement après la prochaine MER / MEP une fois que cette PR est mergée
