### PR TITLE
[FEATURE] Afficher les équipes et PRs concernées par une modif de fichier de config

### DIFF
--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -5,7 +5,8 @@ const githubService = require('../../../common/services/github');
 module.exports = {
   async submitReleaseTypeSelection(payload) {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
-    const hasConfigFileChanged = await githubService.hasConfigFileChangedSinceLatestRelease();
+    const configFilesChangedCommits = await githubService.getConfigFileChangedCommitsSinceLatestRelease();
+    const hasConfigFileChanged = configFilesChangedCommits.length > 0;
     return openModalReleasePublicationConfirmation(releaseType, hasConfigFileChanged);
   },
 

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -392,17 +392,20 @@ module.exports = {
     return pullRequestsSinceLatestRelease.map((PR) => `${PR.title}`);
   },
 
-  async hasConfigFileChangedSinceLatestRelease(
+  async getConfigFileChangedCommitsSinceLatestRelease(
     repoOwner = settings.github.owner,
     repoName = settings.github.repository,
   ) {
     const latestReleaseDate = await _getLatestReleaseDate(repoOwner, repoName);
     const now = new Date().toISOString();
     const commits = await _getCommitsWhereConfigFileHasChangedBetweenDate(repoOwner, repoName, latestReleaseDate, now);
-    return commits.length > 0;
+    return commits;
   },
 
-  async hasConfigFileChangedInLatestRelease(repoOwner = settings.github.owner, repoName = settings.github.repository) {
+  async getConfigFileChangedCommitsInLatestRelease(
+    repoOwner = settings.github.owner,
+    repoName = settings.github.repository,
+  ) {
     const latestReleaseDate = await _getLatestReleaseDate(repoOwner, repoName);
     const secondToLastReleaseDate = await _getSecondToLastReleaseDate(repoOwner, repoName);
     const commits = await _getCommitsWhereConfigFileHasChangedBetweenDate(
@@ -411,7 +414,7 @@ module.exports = {
       secondToLastReleaseDate,
       latestReleaseDate,
     );
-    return commits.length > 0;
+    return commits;
   },
 
   async getPullRequestsFromCommitsShas(

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -11,7 +11,8 @@ const config = require('../../../config');
 module.exports = {
   async submitReleaseTagSelection(payload) {
     const releaseTag = payload.view.state.values['deploy-release-tag']['release-tag-value'].value;
-    const hasConfigFileChanged = await githubService.hasConfigFileChangedInLatestRelease();
+    const configFilesChangedCommits = await githubService.getConfigFileChangedCommitsInLatestRelease();
+    const hasConfigFileChanged = configFilesChangedCommits.length > 0;
     return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
   },
 

--- a/test/acceptance/build/slack_test.js
+++ b/test/acceptance/build/slack_test.js
@@ -240,7 +240,7 @@ describe('Acceptance | Build | Slack', function () {
                   type: 'section',
                   text: {
                     type: 'mrkdwn',
-                    text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.",
+                    text: `:warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Voici les équipes qui semblent concernées : cross-team,team-eval. À confirmer dans les PRs suivantes :\n- <https://github.com/undefined/undefined/pull/1327|PR #1327>\n- <https://github.com/undefined/undefined/pull/2438|PR #2438>. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.`,
                   },
                 },
                 {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -148,12 +148,20 @@ function nockGithubWithConfigChanges() {
     });
 
   nock('https://api.github.com')
+    .get('/repos/github-owner/github-repository/commits/1234/pulls')
+    .reply(200, [{ number: 1327, labels: [{ name: 'cross-team' }] }]);
+
+  nock('https://api.github.com')
+    .get('/repos/github-owner/github-repository/commits/456/pulls')
+    .reply(200, [{ number: 2438, labels: [{ name: 'team-eval' }] }]);
+
+  nock('https://api.github.com')
     .filteringPath(
       /since=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z&until=\d{4}-\d{2}-\d{2}T\d{2}%3A\d{2}%3A\d{2}.\d{3}Z/g,
       'since=XXXX&until=XXXX',
     )
     .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
-    .reply(200, [{}]);
+    .reply(200, [{ sha: 1234 }, { sha: 456 }]);
 }
 
 function createScalingoTokenNock() {

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -300,7 +300,7 @@ describe('#isBuildStatusOK', function () {
   });
 });
 
-describe('#hasConfigFileChangedSinceLatestRelease', function () {
+describe('#getConfigFileChangedCommitsSinceLatestRelease', function () {
   const latestReleaseDate = '2020-08-13T04:45:06Z';
   const repoOwner = 'github-owner';
   const repoName = 'github-repository';
@@ -319,14 +319,15 @@ describe('#hasConfigFileChangedSinceLatestRelease', function () {
   context('should return true when config file has been changed', function () {
     it('should call Github "commits list" API', async function () {
       // given
+      const commits = [
+        {
+          sha: '5ec2f42',
+        },
+      ];
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: latestReleaseDate, until: now.toISOString(), path: 'api/lib/config.js' })
-        .reply(200, [
-          {
-            sha: '5ec2f42',
-          },
-        ]);
+        .reply(200, commits);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -337,19 +338,21 @@ describe('#hasConfigFileChangedSinceLatestRelease', function () {
         .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       // when
-      const response = await githubService.hasConfigFileChangedSinceLatestRelease(repoOwner, repoName);
+      const response = await githubService.getConfigFileChangedCommitsSinceLatestRelease(repoOwner, repoName);
+
       // then
-      expect(response).to.be.true;
+      expect(response).to.deep.equal(commits);
     });
   });
 
   context('should return false when config file did not changed changed', function () {
     it('should call Github "commits list" API', async function () {
       // given
+      const commits = [];
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: latestReleaseDate, until: now.toISOString(), path: 'api/lib/config.js' })
-        .reply(200, []);
+        .reply(200, commits);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -360,14 +363,15 @@ describe('#hasConfigFileChangedSinceLatestRelease', function () {
         .reply(200, { commit: { committer: { date: latestReleaseDate } } });
 
       // when
-      const response = await githubService.hasConfigFileChangedSinceLatestRelease(repoOwner, repoName);
+      const response = await githubService.getConfigFileChangedCommitsSinceLatestRelease(repoOwner, repoName);
+
       // then
-      expect(response).to.be.false;
+      expect(response).to.deep.equal(commits);
     });
   });
 });
 
-describe('#hasConfigFileChangedInLatestRelease', function () {
+describe('#getConfigFileChangedCommitsInLatestRelease', function () {
   const latestReleaseDate = '2020-08-13T04:45:06Z';
   const secondToLastReleaseDate = '2020-08-10T12:45:06Z';
   const repoOwner = 'github-owner';
@@ -376,14 +380,15 @@ describe('#hasConfigFileChangedInLatestRelease', function () {
   context('should return true when config file has been changed', function () {
     it('should call Github "commits list" API', async function () {
       // given
+      const commits = [
+        {
+          sha: '5ec2f42',
+        },
+      ];
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: secondToLastReleaseDate, until: latestReleaseDate, path: 'api/lib/config.js' })
-        .reply(200, [
-          {
-            sha: '5ec2f42',
-          },
-        ]);
+        .reply(200, commits);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -402,19 +407,21 @@ describe('#hasConfigFileChangedInLatestRelease', function () {
         .reply(200, { commit: { committer: { date: secondToLastReleaseDate } } });
 
       // when
-      const response = await githubService.hasConfigFileChangedInLatestRelease(repoOwner, repoName);
+      const response = await githubService.getConfigFileChangedCommitsInLatestRelease(repoOwner, repoName);
+
       // then
-      expect(response).to.be.true;
+      expect(response).to.deep.equal(commits);
     });
   });
 
   context('should return false when config file did not changed changed', function () {
     it('should call Github "commits list" API', async function () {
       // given
+      const commits = [];
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/commits')
         .query({ since: secondToLastReleaseDate, until: latestReleaseDate, path: 'api/lib/config.js' })
-        .reply(200, []);
+        .reply(200, commits);
 
       nock('https://api.github.com')
         .get('/repos/github-owner/github-repository/tags')
@@ -433,9 +440,10 @@ describe('#hasConfigFileChangedInLatestRelease', function () {
         .reply(200, { commit: { committer: { date: secondToLastReleaseDate } } });
 
       // when
-      const response = await githubService.hasConfigFileChangedInLatestRelease(repoOwner, repoName);
+      const response = await githubService.getConfigFileChangedCommitsInLatestRelease(repoOwner, repoName);
+
       // then
-      expect(response).to.be.false;
+      expect(response).to.deep.equal(commits);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une release, on prévient la personne qui a lancé la MER que le fichier de config a été modifié, ça concerne souvent des changements sur les variables d'environnements. Lors que ça arrive il faut : 
- soit demander aux équipes devs si ça les concerne
- soit regarder dans l'historique qui est concerné et les alerter

## :robot: Proposition
Je propose d'aller chercher l'info à la source : 
- On ajoute à la modal les liens vers les PRs qui ont modifié le fichier de config
- On y ajoute aussi les labels d'équipes de ces PRs

## :rainbow: Remarques
Je ne sais pas dans quoi je me suis lancé... Je suis à Montpellier il fait plus de 30 degrés je crois que je vais décéder. Voici ma dernière contribution.

## :100: Pour tester
Je ne sais pas ?
