### PR TITLE
[TECH] Ajout d'un job pour configurer automatiquement l'autoscaler d'applications sur Scalingo (PIX-8638)

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -130,6 +130,21 @@ class ScalingoClient {
       throw new Error(`Impossible to create ${app.name}, ${e.name}`);
     }
   }
+
+  async updateAutoscaler(appname, updateParams) {
+    const autoscalers = await this.client.Autoscalers.for(appname);
+
+    if (!Array.isArray(autoscalers) || !autoscalers.length) {
+      throw new Error(`Aucun autoscaler trouvé pour l'application '${appname}'`);
+    }
+
+    const [webAutoscaler] = autoscalers.filter((autoscaler) => autoscaler.container_type == 'web');
+    if (webAutoscaler) {
+      await this.client.Autoscalers.update(appname, webAutoscaler.id, updateParams);
+    } else {
+      throw new Error(`Aucun autoscaler web trouvé pour l'application '${appname}'`);
+    }
+  }
 }
 
 async function _isUrlReachable(url) {

--- a/config.js
+++ b/config.js
@@ -103,6 +103,22 @@ module.exports = (function () {
       schedule: process.env.PIX_SITE_DEPLOY_SCHEDULE,
     },
 
+    tasks: {
+      autoScaleEnabled: process.env.FT_AUTOSCALE_WEB || false,
+      scheduleAutoScaleUp: process.env.SCHEDULE_AUTOSCALE_UP || '* 0 8 * * *',
+      scheduleAutoScaleDown: process.env.SCHEDULE_AUTOSCALE_DOWN || '* 0 19 * * *',
+      autoScaleApplicationName: process.env.SCHEDULE_AUTOSCALE_APP_NAME,
+      autoScaleRegion: process.env.SCHEDULE_AUTOSCALE_REGION,
+      autoScaleUpSettings: {
+        min: process.env.SCHEDULE_AUTOSCALE_UP_SETTINGS_MIN,
+        max: process.env.SCHEDULE_AUTOSCALE_UP_SETTINGS_MAX,
+      },
+      autoScaleDownSettings: {
+        min: process.env.SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MIN,
+        max: process.env.SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MAX,
+      },
+    },
+
     PIX_REPO_NAME: 'pix',
     PIX_BOT_REPO_NAME: 'pix-bot',
     PIX_BOT_APPS: {

--- a/config.js
+++ b/config.js
@@ -11,6 +11,10 @@ function _getJSON(value) {
   return JSON.parse(value);
 }
 
+function isFeatureEnabled(environmentVariable) {
+  return environmentVariable === 'true';
+}
+
 module.exports = (function () {
   const config = {
     port: _getNumber(process.env.PORT, 3000),
@@ -104,7 +108,7 @@ module.exports = (function () {
     },
 
     tasks: {
-      autoScaleEnabled: process.env.FT_AUTOSCALE_WEB || false,
+      autoScaleEnabled: isFeatureEnabled(process.env.FT_AUTOSCALE_WEB),
       scheduleAutoScaleUp: process.env.SCHEDULE_AUTOSCALE_UP || '* 0 8 * * *',
       scheduleAutoScaleDown: process.env.SCHEDULE_AUTOSCALE_DOWN || '* 0 19 * * *',
       autoScaleApplicationName: process.env.SCHEDULE_AUTOSCALE_APP_NAME,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const githubServices = require('./common/services/github');
 const { deploy } = require('./run/services/deploy');
 const ecoModeService = require('./build/services/eco-mode-service');
 const logger = require('./common/services/logger');
+const taskScheluder = require('./run/services/task-scheduler');
+const { tasks } = require('./run/services/tasks');
 
 const init = async () => {
   await ecoModeService.start();
@@ -20,6 +22,8 @@ const init = async () => {
     },
     config.pixSiteDeploy.schedule,
   );
+
+  taskScheluder(tasks);
 
   await server.start();
 

--- a/run/services/task-scheduler.js
+++ b/run/services/task-scheduler.js
@@ -1,0 +1,29 @@
+const parisTimezone = 'Europe/Paris';
+const CronJob = require('cron').CronJob;
+const logger = require('../../common/services/logger');
+
+const taskScheluder = function (tasksList) {
+  const scheduleTask = ({ schedule, handler }) => {
+    new CronJob({
+      cronTime: schedule,
+      onTick: handler,
+      onComplete: null,
+      start: true,
+      timezone: parisTimezone,
+    });
+  };
+
+  tasksList.forEach(({ name, schedule, enabled, handler }) => {
+    if (enabled) {
+      logger.info({ event: 'task-scheduler', message: `task ${name} scheduled ${schedule}` });
+      scheduleTask({
+        schedule,
+        handler,
+      });
+    } else {
+      logger.info({ event: 'task-scheduler', message: `task ${name} not scheduled` });
+    }
+  });
+};
+
+module.exports = taskScheluder;

--- a/run/services/tasks.js
+++ b/run/services/tasks.js
@@ -1,0 +1,31 @@
+const taskAutoScaleWeb = require('./tasks/autoscale-web');
+const { tasks: config } = require('../../config');
+
+const tasks = [
+  {
+    name: 'morningAutoScale',
+    enabled: config.autoScaleEnabled,
+    schedule: config.scheduleAutoScaleUp,
+    handler: async () => {
+      await taskAutoScaleWeb.run({
+        applicationName: config.autoScaleApplicationName,
+        region: config.autoScaleRegion,
+        autoScalingParameters: config.autoScaleUpSettings,
+      });
+    },
+  },
+  {
+    name: 'eveningAutoScale',
+    enabled: config.autoScaleEnabled,
+    schedule: config.scheduleAutoScaleDown,
+    handler: async () => {
+      await taskAutoScaleWeb.run({
+        applicationName: config.autoScaleApplicationName,
+        region: config.autoScaleRegion,
+        autoScalingParameters: config.autoScaleDownSettings,
+      });
+    },
+  },
+];
+
+module.exports = { tasks };

--- a/run/services/tasks/autoscale-web.js
+++ b/run/services/tasks/autoscale-web.js
@@ -1,0 +1,20 @@
+const logger = require('../../../common/services/logger');
+const ScalingoClient = require('../../../common/services/scalingo-client');
+
+async function taskAutoScaleWeb(
+  { applicationName, region, autoScalingParameters },
+  injectedScalingoClient = ScalingoClient,
+) {
+  try {
+    const client = await injectedScalingoClient.getInstance(region);
+    await client.updateAutoscaler(applicationName, autoScalingParameters);
+    logger.info({
+      event: 'scalingo-autoscaler',
+      message: `${applicationName} has been austocaled with sucess to min: ${autoScalingParameters.min} and max: ${autoScalingParameters.max}`,
+    });
+  } catch (error) {
+    throw new Error(`Scalingo APIError: ${error.message}`);
+  }
+}
+
+module.exports = { run: taskAutoScaleWeb };

--- a/sample.env
+++ b/sample.env
@@ -206,6 +206,79 @@ SCALINGO_TOKEN_PRODUCTION=__CHANGE_ME__
 SCALINGO_API_URL_PRODUCTION=https://api.osc-secnum-fr1.scalingo.com
 
 # ======================
+# SCALINGO CONTAINERS AUTOSCALING SCHEDULED TASK
+# ======================
+
+# Enable web containers autoscaling tasks
+#
+# presence: optional
+# type: text
+# value: true to activate
+# FT_AUTOSCALE_WEB
+
+# Date time at which app web containers autoscaler must be upsized
+#
+# presence: optionnal
+# type: String (RegExp)
+# default: "* 0 8 * * *"
+# SCHEDULE_AUTOSCALE_UP
+
+# Date time at which app web containers autoscaler must be downsized
+#
+# presence: optionnal
+# type: String (RegExp)
+# default: "* 0 19 * * *"
+# SCHEDULE_AUTOSCALE_DOWN
+
+# Name of the application whose web containers have to be autoscaled
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: text
+# default: none
+#SCHEDULE_AUTOSCALE_APP_NAME
+
+# Application that has to be autoscaled name's region
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: text
+# default: none
+# SCHEDULE_AUTOSCALE_REGION
+
+# Minimum number of web containers with which start upsize autoscaling
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: number
+# default: none
+# SCHEDULE_AUTOSCALE_UP_SETTINGS_MIN
+
+# Maximum number of web containers limit to upsize autoscaling
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: number
+# default: none
+# SCHEDULE_AUTOSCALE_UP_SETTINGS_MAX
+
+# Minimum number of web containers with which start donwsize autoscaling
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: number
+# default: none
+# SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MIN
+
+# Maximum number of web containers limit to downsize autoscaling
+# If not present, the application will crash
+#
+# presence: required when autoscaling enabled
+# type: number
+# default: none
+# SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MAX
+
+# ======================
 # BUILD
 # ======================
 

--- a/test/integration/run/services/task-scheduler_test.js
+++ b/test/integration/run/services/task-scheduler_test.js
@@ -1,0 +1,97 @@
+const { expect, sinon } = require('../../../test-helper');
+const logger = require('../../../../common/services/logger');
+const taskScheluder = require('../../../../run/services/task-scheduler');
+
+describe('Integration | Run | Services | schedule-task', function () {
+  let clock;
+  const ONE_SECOND = 1 * 10 ** 3;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function () {
+    clock.restore();
+    sinon.restore();
+  });
+
+  describe('#ScheduleTask', function () {
+    it('should schedule enabled tasks', function () {
+      // given
+      const loggerInfoStub = sinon.stub(logger, 'info');
+
+      const runStub = sinon.stub();
+      const testTasks = [
+        {
+          name: 'task1',
+          enabled: true,
+          schedule: '* * * * * *',
+          handler: runStub,
+        },
+      ];
+
+      // when
+      taskScheluder(testTasks);
+
+      // then
+      expect(runStub).to.not.have.been.called;
+
+      // when
+      clock.tick(ONE_SECOND - 1);
+
+      // then
+      expect(runStub).to.not.have.been.called;
+
+      // when
+      clock.tick(1);
+
+      // then
+      expect(runStub).to.have.been.calledOnce;
+
+      expect(loggerInfoStub.calledOnce).to.be.true;
+      expect(loggerInfoStub.firstCall.args[0]).to.deep.equal({
+        event: 'task-scheduler',
+        message: 'task task1 scheduled * * * * * *',
+      });
+    });
+
+    it('should not schedule tasks', function () {
+      // given
+      const loggerInfoStub = sinon.stub(logger, 'info');
+
+      const runStub = sinon.stub();
+      const testTasks = [
+        {
+          name: 'task1',
+          enabled: false,
+          schedule: '* * * * * *',
+          handler: runStub,
+        },
+      ];
+
+      // when
+      taskScheluder(testTasks);
+      // then
+      expect(runStub).to.not.have.been.called;
+
+      // when
+      clock.tick(ONE_SECOND - 1);
+
+      // then
+      expect(runStub).to.not.have.been.called;
+
+      // when
+      clock.tick(1);
+
+      // then
+      expect(runStub).to.not.have.been.called;
+
+      expect(loggerInfoStub.calledOnce).to.be.true;
+
+      expect(loggerInfoStub.firstCall.args[0]).to.deep.equal({
+        event: 'task-scheduler',
+        message: 'task task1 not scheduled',
+      });
+    });
+  });
+});

--- a/test/integration/run/services/tasks/autoscale-web_test.js
+++ b/test/integration/run/services/tasks/autoscale-web_test.js
@@ -1,0 +1,60 @@
+const taskAutoscaleWeb = require('../../../../../run/services/tasks/autoscale-web');
+const logger = require('../../../../../common/services/logger');
+const { expect, sinon, catchErr } = require('../../../../test-helper');
+
+describe('#task-autoscale-web', function () {
+  it('should call autoscale on web container for specified application', async function () {
+    // given
+    const applicationName = 'pix-api-test';
+    const region = 'recette';
+    const autoScalingParameters = { min: 2, max: 4 };
+
+    const scalingoClientStub = sinon.stub();
+    const updateAutoscalerStub = sinon.stub();
+
+    const loggerInfoStub = sinon.stub(logger, 'info');
+
+    const getInstanceStub = sinon.stub().resolves({
+      updateAutoscaler: updateAutoscalerStub,
+    });
+    scalingoClientStub.getInstance = getInstanceStub;
+
+    // when
+    await taskAutoscaleWeb.run({ applicationName, region, autoScalingParameters }, scalingoClientStub);
+
+    // then
+    expect(getInstanceStub.calledOnceWithExactly(region)).to.be.true;
+    expect(updateAutoscalerStub.calledOnceWithExactly(applicationName, autoScalingParameters)).to.be.true;
+    expect(loggerInfoStub.calledOnce).to.be.true;
+    expect(loggerInfoStub.firstCall.args[0]).to.deep.equal({
+      event: 'scalingo-autoscaler',
+      message: 'pix-api-test has been austocaled with sucess to min: 2 and max: 4',
+    });
+  });
+  it('should throw an error on scalingo errors', async function () {
+    // given
+    const applicationName = 'pix-api-test';
+    const region = 'recette';
+    const autoScalingParameters = { min: 2, max: 4 };
+
+    const scalingoClientStub = sinon.stub();
+    const updateAutoscalerStub = sinon.stub().rejects(new Error('Cannot configure autoscaler'));
+
+    const getInstanceStub = sinon.stub().resolves({
+      updateAutoscaler: updateAutoscalerStub,
+    });
+
+    scalingoClientStub.getInstance = getInstanceStub;
+
+    // when
+    const result = await catchErr(taskAutoscaleWeb.run)(
+      { applicationName, region, autoScalingParameters },
+      scalingoClientStub,
+    );
+
+    // then
+    expect(getInstanceStub.calledOnceWithExactly(region)).to.be.true;
+    expect(result).to.be.instanceOf(Error);
+    expect(result.message).to.be.equal('Scalingo APIError: Cannot configure autoscaler');
+  });
+});

--- a/test/integration/run/services/tasks_test.js
+++ b/test/integration/run/services/tasks_test.js
@@ -1,0 +1,41 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const taskAutoScaleWeb = require('../../../../run/services/tasks/autoscale-web');
+const { tasks: config } = require('../../../../config');
+
+describe('Integration | Run | Services | Scheduled Tasks', function () {
+  describe('#handler', function () {
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('should call handler task function with the right parameters', async function () {
+      // given
+      const applicationName = 'pix-api-recette';
+      const region = 'recette';
+      const autoScalingParameters = { min: 2, max: 4 };
+      const schedule = '* * * * * *';
+
+      sinon.stub(config, 'autoScaleApplicationName').value(applicationName);
+      sinon.stub(config, 'autoScaleRegion').value(region);
+      sinon.stub(config, 'autoScaleUpSettings').value(autoScalingParameters);
+      sinon.stub(config, 'autoScaleEnabled').value(true);
+      sinon.stub(config, 'scheduleAutoScaleUp').value(schedule);
+
+      const { tasks: tasksList } = require('../../../../run/services/tasks');
+      const [morningAutoScaleTask] = tasksList.filter((task) => task.name === 'morningAutoScale');
+
+      const runStub = sinon.stub();
+      const taskAutoScaleWebStub = sinon.stub(taskAutoScaleWeb);
+      taskAutoScaleWebStub.run = runStub;
+
+      // when
+      await morningAutoScaleTask.handler();
+
+      // then
+      expect(morningAutoScaleTask.enabled).to.be.true;
+      expect(morningAutoScaleTask.schedule).to.equal(schedule);
+      expect(runStub.calledOnceWithExactly({ applicationName, region, autoScalingParameters })).to.be.true;
+    });
+  });
+});

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -566,4 +566,188 @@ describe('Scalingo client', () => {
       expect(actual.message).to.equal('Impossible to create pix-application-recette, foo');
     });
   });
+
+  describe('#Scalingo.updateAutoscaler', () => {
+    it('should update web autoscaler for one application', async () => {
+      // given
+      const forAutoscalerStub = sinon.stub();
+      const updateAutoscalerStub = sinon.stub();
+
+      forAutoscalerStub.resolves([
+        {
+          id: 'au-123456789',
+          container_type: 'web',
+        },
+        {
+          id: 'au-111111111',
+          container_type: 'worker',
+        },
+      ]);
+
+      updateAutoscalerStub.resolves();
+
+      const clientStub = {
+        clientFromToken: async () => {
+          return { Autoscalers: { for: forAutoscalerStub, update: updateAutoscalerStub } };
+        },
+      };
+
+      const scalingoClient = await ScalingoClient.getInstance('recette', clientStub);
+
+      const autoscalerUpdateParams = {
+        min_containers: 1,
+        max_containers: 2,
+      };
+
+      // when
+      await scalingoClient.updateAutoscaler('pix-application-recette', autoscalerUpdateParams);
+
+      // then
+      expect(forAutoscalerStub.calledOnceWith('pix-application-recette')).to.be.true;
+      expect(updateAutoscalerStub.calledOnceWith('pix-application-recette', 'au-123456789', autoscalerUpdateParams)).to
+        .be.true;
+    });
+
+    it('should throw when web autoscaler not found', async () => {
+      // given
+      const forAutoscalerStub = sinon.stub();
+      const updateAutoscalerStub = sinon.stub();
+
+      forAutoscalerStub.resolves([
+        {
+          id: 'au-111111111',
+          container_type: 'worker',
+        },
+      ]);
+
+      updateAutoscalerStub.resolves();
+
+      const clientStub = {
+        clientFromToken: async () => {
+          return { Autoscalers: { for: forAutoscalerStub, update: updateAutoscalerStub } };
+        },
+      };
+
+      const scalingoClient = await ScalingoClient.getInstance('recette', clientStub);
+
+      const autoscalerUpdateParams = {
+        min_containers: 1,
+        max_containers: 2,
+      };
+
+      // when
+      let actual;
+      try {
+        await scalingoClient.updateAutoscaler('pix-application-recette', autoscalerUpdateParams);
+      } catch (error) {
+        actual = error;
+      }
+
+      // then
+      expect(actual.message).to.equal("Aucun autoscaler web trouvé pour l'application 'pix-application-recette'");
+      expect(updateAutoscalerStub.called).to.be.false;
+    });
+
+    it('should throw when autoscaler not found', async () => {
+      // given
+      const forAutoscalerStub = sinon.stub();
+      const updateAutoscalerStub = sinon.stub();
+
+      forAutoscalerStub.resolves([]);
+
+      updateAutoscalerStub.resolves();
+
+      const clientStub = {
+        clientFromToken: async () => {
+          return { Autoscalers: { for: forAutoscalerStub, update: updateAutoscalerStub } };
+        },
+      };
+
+      const scalingoClient = await ScalingoClient.getInstance('recette', clientStub);
+
+      const autoscalerUpdateParams = {
+        min_containers: 1,
+        max_containers: 2,
+      };
+
+      // when
+      let actual;
+      try {
+        await scalingoClient.updateAutoscaler('pix-application-recette', autoscalerUpdateParams);
+      } catch (error) {
+        actual = error;
+      }
+
+      // then
+      expect(actual.message).to.equal("Aucun autoscaler trouvé pour l'application 'pix-application-recette'");
+    });
+
+    it('should throw when autoscaler api return undefined', async () => {
+      // given
+      const forAutoscalerStub = sinon.stub();
+      const updateAutoscalerStub = sinon.stub();
+
+      forAutoscalerStub.resolves(undefined);
+
+      updateAutoscalerStub.resolves();
+
+      const clientStub = {
+        clientFromToken: async () => {
+          return { Autoscalers: { for: forAutoscalerStub, update: updateAutoscalerStub } };
+        },
+      };
+
+      const scalingoClient = await ScalingoClient.getInstance('recette', clientStub);
+
+      const autoscalerUpdateParams = {
+        min_containers: 1,
+        max_containers: 2,
+      };
+
+      // when
+      let actual;
+      try {
+        await scalingoClient.updateAutoscaler('pix-application-recette', autoscalerUpdateParams);
+      } catch (error) {
+        actual = error;
+      }
+
+      // then
+      expect(actual.message).to.equal("Aucun autoscaler trouvé pour l'application 'pix-application-recette'");
+    });
+
+    it('should throw when autoscaler api return null', async () => {
+      // given
+      const forAutoscalerStub = sinon.stub();
+      const updateAutoscalerStub = sinon.stub();
+
+      forAutoscalerStub.resolves(null);
+
+      updateAutoscalerStub.resolves();
+
+      const clientStub = {
+        clientFromToken: async () => {
+          return { Autoscalers: { for: forAutoscalerStub, update: updateAutoscalerStub } };
+        },
+      };
+
+      const scalingoClient = await ScalingoClient.getInstance('recette', clientStub);
+
+      const autoscalerUpdateParams = {
+        min_containers: 1,
+        max_containers: 2,
+      };
+
+      // when
+      let actual;
+      try {
+        await scalingoClient.updateAutoscaler('pix-application-recette', autoscalerUpdateParams);
+      } catch (error) {
+        actual = error;
+      }
+
+      // then
+      expect(actual.message).to.equal("Aucun autoscaler trouvé pour l'application 'pix-application-recette'");
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'autoscaler de Scalingo peut mettre du temps à provisionner des containers, un pic de connexion peut donc générer des erreurs.
Cependant, nous connaissons à peu près les horaires des possibles pics de connexion. 

## :robot: Proposition
Ajouter un cron pour configurer automatiquement l'autoscaler à des heures définies en utilisant un service de lancement de tâches :
- mise à jour du **ScalingoClient** en ajoutant la fonction pour configurer l'autoscale pour une app donnée et lui passant des valeurs min et max pour le nombre de containers web à provisionner
- création d'un planificateur de tâches pouvant lancer une liste de tâches à planifier
- création d'une tâche pour l'autoscale des containers web
- création d'une liste de 2 tâches, **morningAutoScale** et **eveningAutoScale**
- chaque peut être paramétrée via des variables d'environnement :
  - FT_AUTOSCALE_WEB
  - SCHEDULE_AUTOSCALE_UP
  - SCHEDULE_AUTOSCALE_DOWN
  - SCHEDULE_AUTOSCALE_APP_NAME
  - SCHEDULE_AUTOSCALE_REGION
  - SCHEDULE_AUTOSCALE_UP_SETTINGS_MIN
  - SCHEDULE_AUTOSCALE_UP_SETTINGS_MAX
  - SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MIN
  - SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MAX

## :rainbow: Remarques
Nous pourrions à terme, rapatrier les tâches de https://github.com/1024pix/scalingo-review-app-manager/blob/master/lib/JobManager.js dans pix-pot, celle-ci etant lancées via le service `ecoModeService`

## :100: Pour tester
🟢 
Lancer le server via `npm start` (l'autoscale n'est pas activé par défaut) et observer l'apparition des logs suivant dans votre terminal :

```bash
{"event":"task-scheduler","message":"task morningAutoScale not scheduled","level":"info"}
{"event":"task-scheduler","message":"task eveningAutoScale not scheduled","level":"info"}
```
