### PR TITLE
[TECH] Forcer l'utilisation de node-fetch par Octokit

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -1,4 +1,5 @@
 const { Octokit } = require('@octokit/rest');
+const fetch = require('node-fetch');
 const { zipWith, countBy, entries, noop } = require('lodash');
 const crypto = require('crypto');
 const tsscmp = require('tsscmp');
@@ -45,6 +46,7 @@ function _createOctokit() {
   }
   const octokit = new Octokit({
     ...authCredentials,
+    request: { fetch },
     log: {
       debug: noop,
       info: _logRequest,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dayjs": "^1.11.7",
         "dotenv": "^16.0.3",
         "lodash": "^4.17.21",
+        "node-fetch": "^2.7.0",
         "scalingo": "^0.8.0",
         "scalingo-review-app-manager": "^1.0.5",
         "slack-block-builder": "^2.7.2",
@@ -3849,9 +3850,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",
+    "node-fetch": "^2.7.0",
     "scalingo": "^0.8.0",
     "scalingo-review-app-manager": "^1.0.5",
     "slack-block-builder": "^2.7.2",


### PR DESCRIPTION
## :unicorn: Problème

Le client Github Octokit utilise par défaut `fetch` natif, qui n'est pas encore compatible avec Nock, et qui nous empêche ainsi de passer en node18 sans devoir passer des flags spécifiques de désactivation.

## :robot: Proposition

Forcer l'usage de la lib `node-fetch` (en v2 car la v3 n'est compatible qu'ESM) au client Octokit le temps que nock puisse ajouter le support `fetch`

## :rainbow: Remarques

Une issue est en cours sur le projet Nock pour prendre en compte aussi le fetch natif : https://www.github.com/nock/nock/issues/2397

Octokit propose d'utiliser node-fetch au besoin : https://github.com/octokit/octokit.js/#fetch-missing

## :100: Pour tester

Sur node16: 🟢
Passer à node18 en local et valider que les tests passent correctement.