### PR TITLE
[TECH] Ajout de logs quand l'autoscaler démarre

### DIFF
--- a/run/services/tasks/autoscale-web.js
+++ b/run/services/tasks/autoscale-web.js
@@ -5,6 +5,10 @@ async function taskAutoScaleWeb(
   { applicationName, region, autoScalingParameters },
   injectedScalingoClient = ScalingoClient,
 ) {
+  logger.info({
+    event: 'scalingo-autoscaler',
+    message: `Starting autoscaling for ${applicationName} with min: ${autoScalingParameters.min} and max: ${autoScalingParameters.max}`,
+  });
   try {
     const client = await injectedScalingoClient.getInstance(region);
     await client.updateAutoscaler(applicationName, autoScalingParameters);

--- a/test/integration/run/services/tasks/autoscale-web_test.js
+++ b/test/integration/run/services/tasks/autoscale-web_test.js
@@ -25,8 +25,12 @@ describe('#task-autoscale-web', function () {
     // then
     expect(getInstanceStub.calledOnceWithExactly(region)).to.be.true;
     expect(updateAutoscalerStub.calledOnceWithExactly(applicationName, autoScalingParameters)).to.be.true;
-    expect(loggerInfoStub.calledOnce).to.be.true;
+    expect(loggerInfoStub.calledTwice).to.be.true;
     expect(loggerInfoStub.firstCall.args[0]).to.deep.equal({
+      event: 'scalingo-autoscaler',
+      message: 'Starting autoscaling for pix-api-test with min: 2 and max: 4',
+    });
+    expect(loggerInfoStub.secondCall.args[0]).to.deep.equal({
       event: 'scalingo-autoscaler',
       message: 'pix-api-test has been austocaled with sucess to min: 2 and max: 4',
     });


### PR DESCRIPTION
## :unicorn: Problème
Nous ne savons quand l'autoscaler est vraiment démarré.

## :robot: Proposition
Nous avons ajouté des logs juste avant que la tâche démarre.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
🟢 
