### PR TITLE
[FEATURE] Ajouter un lien vers la diff lors du déploiement de la release en production

### DIFF
--- a/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
+++ b/run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js
@@ -2,7 +2,7 @@ const { Modal, Blocks } = require('slack-block-builder');
 
 const callbackId = 'release-deployment-confirmation';
 
-function modal(releaseTag, hasConfigFileChanged) {
+function modal(releaseTag, hasConfigFileChanged, previousReleaseTag) {
   return Modal({
     title: 'Confirmation',
     callbackId,
@@ -13,7 +13,7 @@ function modal(releaseTag, hasConfigFileChanged) {
     ...(hasConfigFileChanged
       ? [
           Blocks.Section({
-            text: ":warning: Il y a eu des ajout(s)/suppression(s) dans le fichier *config.js*. Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo PRODUCTION*.",
+            text: `:warning: Il y a eu des ajout(s)/suppression(s) dans le fichier [config.js](https://github.com/1024pix/pix/compare/${previousReleaseTag}...${releaseTag}). Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo PRODUCTION*.`,
           }),
         ]
       : []),
@@ -23,15 +23,15 @@ function modal(releaseTag, hasConfigFileChanged) {
   ]);
 }
 
-module.exports = (releaseTag, hasConfigFileChanged) => {
+module.exports = (releaseTag, hasConfigFileChanged, previousReleaseTag) => {
   return {
     response_action: 'push',
-    view: modal(releaseTag, hasConfigFileChanged).buildToObject(),
+    view: modal(releaseTag, hasConfigFileChanged, previousReleaseTag).buildToObject(),
   };
 };
 
 module.exports.sampleView = () => {
-  return modal('v6.6.6', true);
+  return modal('v6.6.6', true, 'v6.6.5');
 };
 
 module.exports.callbackId = callbackId;

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -11,10 +11,14 @@ const axios = require('axios');
 
 module.exports = {
   async submitReleaseTagSelection(payload) {
+    let releaseCurrentlyInProduction = '';
     const releaseTag = payload.view.state.values['deploy-release-tag']['release-tag-value'].value;
     const hasConfigFileChanged = await githubService.hasConfigFileChangedInLatestRelease();
-    const response = await axios.get('https://app.pix.fr/api/');
-    const releaseCurrentlyInProduction = `v${response.data.version}`;
+    if (hasConfigFileChanged) {
+      const response = await axios.get('https://app.pix.fr/api/');
+      releaseCurrentlyInProduction = `v${response.data.version}`;
+    }
+
     return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged, releaseCurrentlyInProduction);
   },
 

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -7,12 +7,15 @@ const slackGetUserInfos = require('../../../common/services/slack/surfaces/user-
 const ScalingoClient = require('../../../common/services/scalingo-client');
 const { ScalingoAppName } = require('../../../common/models/ScalingoAppName');
 const config = require('../../../config');
+const axios = require('axios');
 
 module.exports = {
   async submitReleaseTagSelection(payload) {
     const releaseTag = payload.view.state.values['deploy-release-tag']['release-tag-value'].value;
     const hasConfigFileChanged = await githubService.hasConfigFileChangedInLatestRelease();
-    return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged);
+    const response = await axios.get('https://app.pix.fr/api/');
+    const releaseCurrentlyInProduction = `v${response.data.version}`;
+    return openModalReleaseDeploymentConfirmation(releaseTag, hasConfigFileChanged, releaseCurrentlyInProduction);
   },
 
   async submitApplicationNameSelection(payload) {

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -132,17 +132,6 @@ describe('Acceptance | Run | Slack', function () {
         it('returns the confirmation modal', async function () {
           // given
           const nocks = nockGithubWithNoConfigChanges();
-
-          const pixApiNock = nock('https://app.pix.fr').get('/api/').reply(200, {
-            name: 'pix-api',
-            version: '6.6.5',
-            description: "Plateforme d'évaluation et de certification des compétences numériques",
-            environment: 'production',
-            'container-version': 'v6.6.5',
-            'container-app-name': 'pix-api-production',
-            'current-lang': 'fr',
-          });
-
           const body = {
             type: 'view_submission',
             view: {
@@ -199,7 +188,6 @@ describe('Acceptance | Run | Slack', function () {
             },
           });
           nocks.checkAllNocksHaveBeenCalled();
-          expect(pixApiNock.isDone()).to.be.true;
         });
 
         it('returns the confirmation modal with a warning', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une MEP, une modification du fichier de configuration API ne veut pas forcément dire qu'un variables d'environnement doive être modifiée.

## :robot: Proposition
Ajouter le lien sur la diff pour consulter plus facilement le fichier.

## :rainbow: Remarques
On pourra faire mieux ensuite et détecter les variables d'environnemment avec  `process.env`.

## :100: Pour tester
Merger