### PR TITLE
[FEATURE] :sparkles: Envoyer un message sur slack en cas de changements sur le fichier config.js

### DIFF
--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -1,11 +1,18 @@
 const openModalReleasePublicationConfirmation = require('./surfaces/modals/publish-release/release-publication-confirmation');
 const { environments, deploy, publish } = require('../../../common/services/releases');
 const githubService = require('../../../common/services/github');
+const slackPostMessageService = require('../../../common/services/slack/surfaces/messages/post-message');
 
 module.exports = {
   async submitReleaseTypeSelection(payload) {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
     const { hasConfigFileChanged, latestTag } = await githubService.hasConfigFileChangedSinceLatestRelease();
+    if (hasConfigFileChanged) {
+      await slackPostMessageService.postMessage({
+        message: 'Changements détéctés sur le fichier config.js dans la release : liens des commits',
+        channel: '#tech-releases',
+      });
+    }
     return openModalReleasePublicationConfirmation({ releaseType, hasConfigFileChanged, latestTag });
   },
 


### PR DESCRIPTION
## :unicorn: Problème
Lors du workflow Slack de MEP/PE, seul les gens ayant déclenché la modale sont prévenus des changements sur le fichier api/lib/config.js 

## :robot: Proposition
Prévenir l'ensemble des personnes sur le channel de release de la modification du fichier, en envoyant un message.

## :rainbow: Remarques
Apportant le détail des PR concernées.

## :100: Pour tester
Utiliser Slack de test, relié à l'application Scalingo `pix-bot-integration`

