### PR TITLE
[TECH] Utiliser un client HTTP pour communiquer avec Slack

### DIFF
--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -56,7 +56,7 @@ module.exports = {
 
     const { message, attachments } = getSlackMessageAttachments(request.payload);
 
-    await slackPostMessageService.postMessage(message, JSON.stringify(attachments));
+    await slackPostMessageService.postMessage({ message, attachments: JSON.stringify(attachments) });
 
     logger.warn({
       event: 'scalingo',

--- a/build/controllers/slack.js
+++ b/build/controllers/slack.js
@@ -93,7 +93,8 @@ module.exports = {
   },
 
   _interruptRelease() {
-    slackPostMessageService.postMessage('MER bloquée. Etat de l‘environnement d‘intégration à vérifier.');
+    const message = 'MER bloquée. Etat de l‘environnement d‘intégration à vérifier.';
+    slackPostMessageService.postMessage({ message });
     return {
       response_action: 'clear',
     };

--- a/common/http-agent.js
+++ b/common/http-agent.js
@@ -1,0 +1,49 @@
+const axios = require('axios');
+const logger = require('./services/logger');
+
+class HttpResponse {
+  constructor({ code, data, isSuccessful }) {
+    this.code = code;
+    this.data = data;
+    this.isSuccessful = isSuccessful;
+  }
+}
+
+const httpAgent = {
+  async post({ url, payload, headers }) {
+    try {
+      const config = {
+        headers,
+      };
+      const httpResponse = await axios.post(url, payload, config);
+
+      return new HttpResponse({
+        code: httpResponse.status,
+        data: httpResponse.data,
+        isSuccessful: true,
+      });
+    } catch (httpErr) {
+      let code;
+      let data;
+
+      if (httpErr.response) {
+        code = httpErr.response.status;
+        data = httpErr.response.data;
+      } else {
+        code = null;
+        data = httpErr.message;
+      }
+
+      const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
+      logger.error({ event: 'http-client-request', message });
+
+      return new HttpResponse({
+        code,
+        data,
+        isSuccessful: false,
+      });
+    }
+  },
+};
+
+module.exports = { httpAgent };

--- a/common/services/slack/surfaces/messages/post-message.js
+++ b/common/services/slack/surfaces/messages/post-message.js
@@ -1,29 +1,20 @@
-const axios = require('axios');
 const config = require('../../../../../config');
-const logger = require('../../../logger');
+const { httpAgent } = require('../../../../http-agent');
 
 module.exports = {
-  async postMessage(message, attachments, channel = '#tech-releases') {
-    const options = {
-      method: 'POST',
-      url: 'https://slack.com/api/chat.postMessage',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${config.slack.botToken}`,
-      },
-      data: {
-        channel: channel,
-        text: message,
-        attachments: attachments,
-      },
+  async postMessage(message, attachments, channel = '#tech-releases', injectedHttpAgent = httpAgent) {
+    const url = 'https://slack.com/api/chat.postMessage';
+
+    const headers = {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.slack.botToken}`,
+    };
+    const payload = {
+      channel: channel,
+      text: message,
+      attachments: attachments,
     };
 
-    const response = await axios(options);
-    if (!response.data.ok) {
-      logger.error({ event: 'post-message', message: response.data });
-      throw new Error('Slack error received');
-    }
-
-    return response;
+    await injectedHttpAgent.post({ url, payload, headers });
   },
 };

--- a/common/services/slack/surfaces/messages/post-message.js
+++ b/common/services/slack/surfaces/messages/post-message.js
@@ -2,7 +2,7 @@ const config = require('../../../../../config');
 const { httpAgent } = require('../../../../http-agent');
 
 module.exports = {
-  async postMessage(message, attachments, channel = '#tech-releases', injectedHttpAgent = httpAgent) {
+  async postMessage({ message, attachments, channel = '#tech-releases', injectedHttpAgent = httpAgent }) {
     const url = 'https://slack.com/api/chat.postMessage';
 
     const headers = {

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -70,7 +70,8 @@ async function _publishPixUI(repoName, releaseType, responseUrl) {
   if (releaseTagBeforeRelease === releaseTagAfterRelease) {
     sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
-    slackPostMessageService.postMessage(`[PIX-UI] App deployed (${releaseTagAfterRelease})`);
+    const message = `[PIX-UI] App deployed (${releaseTagAfterRelease})`;
+    slackPostMessageService.postMessage({ message });
     sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
   }
 }
@@ -85,7 +86,8 @@ async function _publishAndDeployEmberTestingLibrary(repoName, releaseType, respo
   if (releaseTagBeforeRelease === releaseTagAfterRelease) {
     sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
   } else {
-    slackPostMessageService.postMessage(`[EMBER-TESTING-LIBRARY] Lib deployed (${releaseTagAfterRelease})`);
+    const message = `[EMBER-TESTING-LIBRARY] Lib deployed (${releaseTagAfterRelease})`;
+    slackPostMessageService.postMessage({ message });
     sendResponse(responseUrl, getSuccessReleaseMessage(releaseTagAfterRelease, repoName));
   }
 }

--- a/run/services/slack/view-submissions.js
+++ b/run/services/slack/view-submissions.js
@@ -45,7 +45,8 @@ module.exports = {
   submitReleaseDeploymentConfirmation(payload) {
     const releaseTag = payload.view.private_metadata;
     if (!githubService.isBuildStatusOK({ tagName: releaseTag.trim().toLowerCase() })) {
-      slackPostMessageService.postMessage('MEP bloquée. Etat de l‘environnement de recette à vérifier.');
+      const message = 'MEP bloquée. Etat de l‘environnement de recette à vérifier.';
+      slackPostMessageService.postMessage({ message });
     } else {
       deploy(environments.production, releaseTag);
     }
@@ -61,7 +62,7 @@ module.exports = {
     const invitationLink = await client.inviteCollaborator(appId, userEmail);
     const message = `app ${applicationName} created <${invitationLink}|invitation link>`;
     const channel = `@${payload.user.id}`;
-    slackPostMessageService.postMessage(message, null, channel);
+    slackPostMessageService.postMessage({ message, channel });
     return {
       response_action: 'clear',
     };

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -77,10 +77,10 @@ describe('Integration | Build | Scalingo', function () {
             fallback: '[pix-github-actions-test] App deployment error',
           },
         ];
-        expect(slackPostMessageService.postMessage).to.have.been.calledWith(
-          '[pix-github-actions-test] App deployment error',
-          JSON.stringify(expectedPayload),
-        );
+        expect(slackPostMessageService.postMessage).to.have.been.calledWith({
+          message: '[pix-github-actions-test] App deployment error',
+          attachments: JSON.stringify(expectedPayload),
+        });
         expect(res.statusCode).to.equal(200);
       });
     });

--- a/test/unit/common/http-agent_test.js
+++ b/test/unit/common/http-agent_test.js
@@ -1,0 +1,85 @@
+const { expect, sinon } = require('../../test-helper');
+const axios = require('axios');
+const { httpAgent } = require('../../../common/http-agent');
+
+const { post } = httpAgent;
+
+describe('Unit | Common | http-agent', function () {
+  describe('#post', function () {
+    context('when successful', function () {
+      it('should return the response status and success from the http call ', async function () {
+        // given
+        const url = 'someUrl';
+        const payload = 'somePayload';
+        const headers = { a: 'someHeaderInfo' };
+        const axiosResponse = {
+          data: 'data',
+          status: 200,
+        };
+        sinon
+          .stub(axios, 'post')
+          .withArgs(url, payload, {
+            headers,
+          })
+          .resolves(axiosResponse);
+
+        // when
+        const actualResponse = await post({ url, payload, headers });
+
+        // then
+        expect(actualResponse).to.deep.equal({
+          isSuccessful: true,
+          code: 200,
+          data: 'data',
+        });
+      });
+    });
+    context('when an error occurs', function () {
+      context('when error.response exists', function () {
+        it('should return statusCode and response', async function () {
+          // given
+          const url = 'someUrl';
+          const payload = 'somePayload';
+          const headers = { a: 'someHeaderInfo' };
+          const axiosError = {
+            response: {
+              data: { a: '1', b: '2' },
+              status: 400,
+            },
+          };
+          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+
+          // when
+          const response = await post({ url, payload, headers });
+
+          // then
+          expect(response).to.deep.equal({
+            isSuccessful: false,
+            code: 400,
+            data: { a: '1', b: '2' },
+          });
+        });
+      });
+      context('when error.response does not exists', function () {
+        it('should return the error message', async function () {
+          // given
+          const url = 'someUrl';
+          const payload = 'somePayload';
+          const headers = { a: 'someHeaderInfo' };
+          const axiosError = new Error('error message');
+          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+
+          // when
+          const actualResponse = await post({ url, payload, headers });
+
+          // then
+          expect(actualResponse).to.deep.equal({
+            code: null,
+            data: 'error message',
+            isSuccessful: false,
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/unit/common/services/slack/surfaces/messages/post-message_test.js
+++ b/test/unit/common/services/slack/surfaces/messages/post-message_test.js
@@ -11,7 +11,12 @@ describe('Unit | Common | Services | Slack | Surfaces | Messages | Post-Message'
       sinon.stub(config.slack, 'botToken').value('faketoken');
       const httpAgent = { post: sinon.stub() };
       //when
-      await postMessage(messageToSend, {}, destinationChannel, httpAgent);
+      await postMessage({
+        message: messageToSend,
+        attachments: {},
+        channel: destinationChannel,
+        injectedHttpAgent: httpAgent,
+      });
 
       //then
       expect(httpAgent.post).to.have.been.calledOnceWith({

--- a/test/unit/common/services/slack/surfaces/messages/post-message_test.js
+++ b/test/unit/common/services/slack/surfaces/messages/post-message_test.js
@@ -1,0 +1,27 @@
+const { postMessage } = require('../../../../../../../common/services/slack/surfaces/messages/post-message');
+const { expect, sinon } = require('../../../../../../test-helper');
+const config = require('../../../../../../../config');
+
+describe('Unit | Common | Services | Slack | Surfaces | Messages | Post-Message', function () {
+  describe('#postMessage', function () {
+    it('should make a call to slack API post-message endpoint', async function () {
+      //given
+      const messageToSend = 'test message';
+      const destinationChannel = '#mychannel';
+      sinon.stub(config.slack, 'botToken').value('faketoken');
+      const httpAgent = { post: sinon.stub() };
+      //when
+      await postMessage(messageToSend, {}, destinationChannel, httpAgent);
+
+      //then
+      expect(httpAgent.post).to.have.been.calledOnceWith({
+        url: 'https://slack.com/api/chat.postMessage',
+        payload: { channel: '#mychannel', text: 'test message', attachments: {} },
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer faketoken',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le code qui envoie un message sur slack n'est pas testé. 
Ce code laisse passer des erreurs.

## :robot: Proposition
Implémenter un client HTTP utilisant Axios gérant les erreurs.
Utiliser ce client HTTP dans la méthode `postMessage()`.

## :100: Pour tester
🟢 
