### PR TITLE
[BUGFIX] Corriger le message envoyé sur slack lors de changements du fichier config.js

### DIFF
--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -8,8 +8,9 @@ module.exports = {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
     const { hasConfigFileChanged, latestTag } = await githubService.hasConfigFileChangedSinceLatestRelease();
     if (hasConfigFileChanged) {
+      const message = `:warning: Il y a eu des ajout(s)/suppression(s) [dans le fichier config.js](https://github.com/1024pix/pix/compare/${latestTag}...dev). Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.`;
       await slackPostMessageService.postMessage({
-        message: 'Changements détéctés sur le fichier config.js dans la release : liens des commits',
+        message,
         channel: '#tech-releases',
       });
     }

--- a/build/services/slack/view-submissions.js
+++ b/build/services/slack/view-submissions.js
@@ -8,7 +8,10 @@ module.exports = {
     const releaseType = payload.view.state.values['publish-release-type']['release-type-option'].selected_option.value;
     const { hasConfigFileChanged, latestTag } = await githubService.hasConfigFileChangedSinceLatestRelease();
     if (hasConfigFileChanged) {
-      const message = `:warning: Il y a eu des ajout(s)/suppression(s) [dans le fichier config.js](https://github.com/1024pix/pix/compare/${latestTag}...dev). Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.`;
+      const message =
+        ':warning: Il y a eu des ajout(s)/suppression(s) ' +
+        `<https://github.com/1024pix/pix/compare/${latestTag}...dev|dans le fichier config.js>. ` +
+        "Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.";
       await slackPostMessageService.postMessage({
         message,
         channel: '#tech-releases',

--- a/common/services/slack/surfaces/messages/post-message.js
+++ b/common/services/slack/surfaces/messages/post-message.js
@@ -1,5 +1,6 @@
 const config = require('../../../../../config');
 const { httpAgent } = require('../../../../http-agent');
+const logger = require('../../../logger');
 
 module.exports = {
   async postMessage({ message, attachments, channel = '#tech-releases', injectedHttpAgent = httpAgent }) {
@@ -15,6 +16,15 @@ module.exports = {
       attachments: attachments,
     };
 
-    await injectedHttpAgent.post({ url, payload, headers });
+    const slackResponse = await injectedHttpAgent.post({ url, payload, headers });
+    if (slackResponse.isSuccessful) {
+      if (!slackResponse.data.ok) {
+        logger.error({
+          event: 'slack-post-message',
+          message: `Slack error occured while sending message : ${slackResponse.data.error}`,
+          stack: `Payload for error was ${JSON.stringify(payload)}`,
+        });
+      }
+    }
   },
 };

--- a/test/acceptance/build/slack_test.js
+++ b/test/acceptance/build/slack_test.js
@@ -226,12 +226,20 @@ describe('Acceptance | Build | Slack', function () {
             .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
             .reply(200, [{}]);
 
-          const message = `:warning: Il y a eu des ajout(s)/suppression(s) [dans le fichier config.js](https://github.com/1024pix/pix/compare/v6.6.6...dev). Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.`;
+          const message =
+            ':warning: Il y a eu des ajout(s)/suppression(s) ' +
+            '<https://github.com/1024pix/pix/compare/v6.6.6...dev|dans le fichier config.js>. ' +
+            "Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.";
+
+          const expectedRequestBody = {
+            channel: '#tech-releases',
+            text: message,
+          };
 
           const slackMessageNock = nock('https://slack.com')
-            .post('/api/chat.postMessage', {
-              channel: '#tech-releases',
-              text: message,
+            .post('/api/chat.postMessage', (body) => {
+              expect(body).to.deep.equal(expectedRequestBody);
+              return true;
             })
             .reply(200, {
               ok: true,

--- a/test/acceptance/build/slack_test.js
+++ b/test/acceptance/build/slack_test.js
@@ -226,10 +226,12 @@ describe('Acceptance | Build | Slack', function () {
             .get('/repos/github-owner/github-repository/commits?since=XXXX&until=XXXX&path=api%2Flib%2Fconfig.js')
             .reply(200, [{}]);
 
+          const message = `:warning: Il y a eu des ajout(s)/suppression(s) [dans le fichier config.js](https://github.com/1024pix/pix/compare/v6.6.6...dev). Pensez à vérifier que toutes les variables d'environnement sont bien à jour sur *Scalingo RECETTE*.`;
+
           const slackMessageNock = nock('https://slack.com')
             .post('/api/chat.postMessage', {
               channel: '#tech-releases',
-              text: 'Changements détéctés sur le fichier config.js dans la release : liens des commits',
+              text: message,
             })
             .reply(200, {
               ok: true,

--- a/test/unit/common/services/slack/surfaces/messages/post-message_test.js
+++ b/test/unit/common/services/slack/surfaces/messages/post-message_test.js
@@ -1,6 +1,7 @@
 const { postMessage } = require('../../../../../../../common/services/slack/surfaces/messages/post-message');
 const { expect, sinon } = require('../../../../../../test-helper');
 const config = require('../../../../../../../config');
+const logger = require('../../../../../../../common/services/logger');
 
 describe('Unit | Common | Services | Slack | Surfaces | Messages | Post-Message', function () {
   describe('#postMessage', function () {
@@ -9,7 +10,7 @@ describe('Unit | Common | Services | Slack | Surfaces | Messages | Post-Message'
       const messageToSend = 'test message';
       const destinationChannel = '#mychannel';
       sinon.stub(config.slack, 'botToken').value('faketoken');
-      const httpAgent = { post: sinon.stub() };
+      const httpAgent = { post: sinon.stub().resolves({ isSuccessful: true, data: { ok: true } }) };
       //when
       await postMessage({
         message: messageToSend,
@@ -26,6 +27,37 @@ describe('Unit | Common | Services | Slack | Surfaces | Messages | Post-Message'
           'content-type': 'application/json',
           authorization: 'Bearer faketoken',
         },
+      });
+    });
+    it('should log slack API errors', async function () {
+      //given
+      const messageToSend = 'test message';
+      const destinationChannel = '#mychannel';
+      sinon.stub(config.slack, 'botToken').value('faketoken');
+      const errorLoggerStub = sinon.stub(logger, 'error');
+      const slackErrorResponse = { isSuccessful: true, data: { ok: false, error: 'not_in_channel' } };
+      const httpAgent = { post: sinon.stub().resolves(slackErrorResponse) };
+      //when
+      await postMessage({
+        message: messageToSend,
+        attachments: {},
+        channel: destinationChannel,
+        injectedHttpAgent: httpAgent,
+      });
+
+      //then
+      expect(httpAgent.post).to.have.been.calledOnceWith({
+        url: 'https://slack.com/api/chat.postMessage',
+        payload: { channel: '#mychannel', text: 'test message', attachments: {} },
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer faketoken',
+        },
+      });
+      expect(errorLoggerStub).to.have.been.calledOnceWith({
+        event: 'slack-post-message',
+        message: 'Slack error occured while sending message : not_in_channel',
+        stack: 'Payload for error was {"channel":"#mychannel","text":"test message","attachments":{}}',
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Le message actuel n'apporte aucune information utile à l'identification des changements sur le fichier de config. 

## :robot: Proposition

Modifier le message pour ajouter l'url du diff GitHub. 
On journalise également les erreurs de l'API slack. 

## :100: Pour tester
Configurer la review app avec les tokens du slack de test, et sur le projet GitHub de test. Créer une Release via l'action
