### PR TITLE
Empêcher le crash de l'API en cas de configuration incorrecte

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -181,7 +181,7 @@ BALEEN_PERSONAL_ACCESS_TOKEN=__CHANGE_ME__
 # type: JSON
 # sample = {"app-name-1":"namespace-1", "app-name2": "namespace-2"}
 # default: none
-BALEEN_APP_NAMESPACES=__CHANGE_ME__
+BALEEN_APP_NAMESPACES={"app-name-1":"namespace-1", "app-name2": "namespace-2"}
 
 # ======================
 # SCALINGO PROD


### PR DESCRIPTION
## :unicorn: Problème
La variable d'environnement  `BALEEN_APP_NAMESPACES`, si non renseignée, cause un message d'erreur dans les tests.
```
  2) Acceptance | Scripts | release-pix-repo.sh
       Update package version, generate changelog, commit, tag and push:
     Command failed: /home/octo-topi/Documents/Octo/Missions/Pix/repositories/pix-bot/scripts/release-pix-repo.sh 1024pix pix-bot-publish-test minor dev file:///tmp/clean-repositorypim3bh
Cloning into '/tmp/tmp.JgEaRnE8U9'...
undefined:1
__CHANGE_ME__
^
```

Or celui-ci ne mentionne pas la variable d'environnement.

## :robot: Proposition
Propose une valeur dans le `sample.env` qui soit un JSON valide

## :rainbow: Remarques
On pourrait intercepter l'erreur et ajouter un message.
Ou dire dans le `sample.env` qui si elle n'est pas modifiée, les tests sortent en erreur.
Ou modifier la configuration des tests.

## :100: Pour tester
```
cp env .env.old
rm .env
cp sample.env .env
npm run test
```

