### PR TITLE
Ne pas tracer durant les tests

### DIFF
--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -1,3 +1,12 @@
+let enabledFromConfiguration = true;
+
+if (
+  process.env.NODE_ENV === 'test' &&
+  (process.env.TEST_LOG_ENABLED !== undefined || process.env.TEST_LOG_ENABLED !== 'enabled')
+) {
+  enabledFromConfiguration = false;
+}
+
 function serialize({ event, message, job, stack, level }) {
   const log = {
     event,
@@ -10,19 +19,27 @@ function serialize({ event, message, job, stack, level }) {
   return JSON.stringify(log);
 }
 
-const error = ({ event, message, job, stack }, injectedLogger = console) => {
-  injectedLogger.error(serialize({ event, message, job, stack, level: 'error' }));
+const error = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+  if (enabled) {
+    injectedLogger.error(serialize({ event, message, job, stack, level: 'error' }));
+  }
 };
 
-const info = ({ event, message, job, stack }, injectedLogger = console) => {
-  injectedLogger.log(serialize({ event, message, job, stack, level: 'info' }));
+const info = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+  if (enabled) {
+    injectedLogger.log(serialize({ event, message, job, stack, level: 'info' }));
+  }
 };
 
-const warn = ({ event, message, job, stack }, injectedLogger = console) => {
-  injectedLogger.warn(serialize({ event, message, job, stack, level: 'warn' }));
+const warn = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+  if (enabled) {
+    injectedLogger.warn(serialize({ event, message, job, stack, level: 'warn' }));
+  }
 };
-const ok = ({ event, message, job, stack }, injectedLogger = console) => {
-  injectedLogger.ok(serialize({ event, message, job, stack, level: 'ok' }));
+const ok = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+  if (enabled) {
+    injectedLogger.ok(serialize({ event, message, job, stack, level: 'ok' }));
+  }
 };
 
 module.exports = {

--- a/sample.env
+++ b/sample.env
@@ -402,6 +402,14 @@ SCALINGO_API_URL_INTEGRATION=https://api.osc-fr1.scalingo.com
 # default: 1000
 # MAX_LOG_LENGTH=100
 
+# Enable or disable the logging in automated tests
+# Enable it while debugging failing tests
+#
+# presence: optional
+# type: Boolean
+# default: `false`
+# TEST_LOG_ENABLED=true
+
 # ======================
 # GITHUB
 # ======================

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -9,7 +9,7 @@ const {
 const githubService = require('../../../../common/services/github');
 const logger = require('../../../../common/services/logger');
 
-describe('github-test', function () {
+describe('Unit | Build | github-test', function () {
   describe('#getPullRequests', function () {
     it('should return the response for slack', async function () {
       // given

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -9,7 +9,7 @@ describe('logger', function () {
         const injectedLogger = { error: sinon.stub() };
 
         // when
-        logger.error({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger);
+        logger.error({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
         // then
         expect(injectedLogger.error.calledOnce).to.be.true;
         expect(injectedLogger.error.firstCall.args[0]).to.equal(
@@ -23,7 +23,7 @@ describe('logger', function () {
         const injectedLogger = { error: sinon.stub() };
 
         // when
-        logger.error({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger);
+        logger.error({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.error.calledOnce).to.be.true;
@@ -40,7 +40,7 @@ describe('logger', function () {
         const injectedLogger = { log: sinon.stub() };
 
         // when
-        logger.info({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger);
+        logger.info({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.log.calledOnce).to.be.true;
@@ -55,7 +55,7 @@ describe('logger', function () {
         const injectedLogger = { log: sinon.stub() };
 
         // when
-        logger.info({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger);
+        logger.info({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.log.calledOnce).to.be.true;
@@ -72,7 +72,7 @@ describe('logger', function () {
         const injectedLogger = { warn: sinon.stub() };
 
         // when
-        logger.warn({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger);
+        logger.warn({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.warn.calledOnce).to.be.true;
@@ -87,7 +87,7 @@ describe('logger', function () {
         const injectedLogger = { warn: sinon.stub() };
 
         // when
-        logger.warn({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger);
+        logger.warn({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.warn.calledOnce).to.be.true;
@@ -104,7 +104,7 @@ describe('logger', function () {
         const injectedLogger = { ok: sinon.stub() };
 
         // when
-        logger.ok({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger);
+        logger.ok({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.ok.calledOnce).to.be.true;
@@ -119,7 +119,7 @@ describe('logger', function () {
         const injectedLogger = { ok: sinon.stub() };
 
         // when
-        logger.ok({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger);
+        logger.ok({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
 
         // then
         expect(injectedLogger.ok.calledOnce).to.be.true;


### PR DESCRIPTION
## :unicorn: Problème
Le compte-rendu des tests en local est illisible

## :robot: Proposition
Désactiver le log pendant les tests

## :rainbow: Remarques
Cela n'a pas pu être fait partout, notamment dans les scripts bash où il n'y a pas d'injection de dépendance

## :100: Pour tester
`npm run test`