### PR TITLE
[TECH] Vérifier si une RA existe avant de la créer

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -125,6 +125,17 @@ async function pullRequestSynchronizeWebhook(request, injectedScalingoClient = S
         await client.deployUsingSCM(reviewAppName, ref);
       }
     } catch (error) {
+      logger.error({
+        event: 'review-app',
+        stack: error.stack,
+        message: `Deployement for application ${reviewAppName} failed : ${error.message}`,
+        data: {
+          repository,
+          reviewApp: reviewAppName,
+          pr: prId,
+          ref,
+        },
+      });
       throw new Error(`Scalingo APIError: ${error.message}`);
     }
   }

--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -2,7 +2,7 @@ let enabledFromConfiguration = true;
 
 if (
   process.env.NODE_ENV === 'test' &&
-  (process.env.TEST_LOG_ENABLED !== undefined || process.env.TEST_LOG_ENABLED !== 'enabled')
+  (process.env.TEST_LOG_ENABLED === undefined || process.env.TEST_LOG_ENABLED !== 'true')
 ) {
   enabledFromConfiguration = false;
 }

--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -7,38 +7,39 @@ if (
   enabledFromConfiguration = false;
 }
 
-function serialize({ event, message, job, stack, level }) {
+function serialize({ event, message, job, stack, level, data }) {
   const log = {
     event,
     message: typeof message === 'object' ? JSON.stringify(message) : message,
     job,
     stack: typeof stack === 'object' ? JSON.stringify(stack) : stack,
     level,
+    data,
   };
 
   return JSON.stringify(log);
 }
 
-const error = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+const error = ({ event, message, job, stack, data }, injectedLogger = console, enabled = enabledFromConfiguration) => {
   if (enabled) {
-    injectedLogger.error(serialize({ event, message, job, stack, level: 'error' }));
+    injectedLogger.error(serialize({ event, message, job, stack, data, level: 'error' }));
   }
 };
 
-const info = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+const info = ({ event, message, job, stack, data }, injectedLogger = console, enabled = enabledFromConfiguration) => {
   if (enabled) {
-    injectedLogger.log(serialize({ event, message, job, stack, level: 'info' }));
+    injectedLogger.log(serialize({ event, message, job, stack, data, level: 'info' }));
   }
 };
 
-const warn = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+const warn = ({ event, message, job, stack, data }, injectedLogger = console, enabled = enabledFromConfiguration) => {
   if (enabled) {
-    injectedLogger.warn(serialize({ event, message, job, stack, level: 'warn' }));
+    injectedLogger.warn(serialize({ event, message, job, stack, data, level: 'warn' }));
   }
 };
-const ok = ({ event, message, job, stack }, injectedLogger = console, enabled = enabledFromConfiguration) => {
+const ok = ({ event, message, job, stack, data }, injectedLogger = console, enabled = enabledFromConfiguration) => {
   if (enabled) {
-    injectedLogger.ok(serialize({ event, message, job, stack, level: 'ok' }));
+    injectedLogger.ok(serialize({ event, message, job, stack, data, level: 'ok' }));
   }
 };
 

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -62,6 +62,20 @@ class ScalingoClient {
     return [await this._getSingleAppInfo(target)];
   }
 
+  async reviewAppExists(reviewAppName) {
+    try {
+      const { name } = await this.client.Apps.find(reviewAppName);
+      return name == reviewAppName;
+    } catch (err) {
+      if (err.status === 404) {
+        return false;
+      }
+      throw new Error(
+        `Impossible to get info for RA ${reviewAppName}. Scalingo API returned ${err.status} : ${err.message}`,
+      );
+    }
+  }
+
   deployReviewApp(appName, prId) {
     return this.client.SCMRepoLinks.manualReviewApp(appName, prId);
   }

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -493,7 +493,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
     });
 
     describe('when the Review App creation conditions are met', function () {
-      it('should calls scalingo to deploy the corresponding applications', async function () {
+      it('should call scalingo to deploy the corresponding applications', async function () {
         // given
         const injectedScalingoClientStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
@@ -535,6 +535,38 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         // then
         expect(result).to.be.instanceOf(Error);
         expect(result.message).to.equal('Scalingo APIError: Deployment error');
+      });
+
+      describe('when the review app does not exist', function () {
+        it('should call scalingo to create and deploy the corresponding applications', async function () {
+          // given
+          const injectedScalingoClientStub = sinon.stub();
+          const deployUsingSCMStub = sinon.stub();
+          const reviewAppExistsStub = sinon.stub().resolves(true);
+          reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(false);
+          const deployReviewAppStub = sinon.stub();
+          const disableAutoDeployStub = sinon.stub();
+
+          injectedScalingoClientStub.getInstance = sinon.stub().returns({
+            deployUsingSCM: deployUsingSCMStub,
+            reviewAppExists: reviewAppExistsStub,
+            deployReviewApp: deployReviewAppStub,
+            disableAutoDeploy: disableAutoDeployStub,
+          });
+
+          // when
+          const response = await githubController.pullRequestSynchronizeWebhook(request, injectedScalingoClientStub);
+
+          // then
+          expect(deployReviewAppStub.calledOnceWithExactly('pix-api-review', 3)).to.be.true;
+          expect(disableAutoDeployStub.calledOnceWithExactly('pix-api-review-pr3')).to.be.true;
+          expect(deployUsingSCMStub.firstCall.calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.secondCall.calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.thirdCall.calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
+          expect(response).to.equal(
+            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 3',
+          );
+        });
       });
     });
   });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -497,8 +497,11 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         // given
         const injectedScalingoClientStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
+        const reviewAppExistsStub = sinon.stub().resolves(true);
+
         injectedScalingoClientStub.getInstance = sinon.stub().returns({
           deployUsingSCM: deployUsingSCMStub,
+          reviewAppExists: reviewAppExistsStub,
         });
 
         // when
@@ -517,8 +520,10 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         // given
         const injectedScalingoClientStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub().rejects(new Error('Deployment error'));
+        const reviewAppExistsStub = sinon.stub().resolves(true);
         injectedScalingoClientStub.getInstance = sinon.stub().returns({
           deployUsingSCM: deployUsingSCMStub,
+          reviewAppExists: reviewAppExistsStub,
         });
 
         // when

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -534,7 +534,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
         // then
         expect(result).to.be.instanceOf(Error);
-        expect(result.message).to.equal('Scalingo APIError: Deployment error');
+        expect(result.message).to.equal('No RA deployed for repository pix and pr3');
       });
 
       describe('when the review app does not exist', function () {

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -17,13 +17,14 @@ describe('logger', function () {
           let injectedLogger = [];
           const functionToStub = injectedLoggerFunction[level];
           injectedLogger[functionToStub] = sinon.stub();
+          const data = { ctx: 'context', meta: 'metadata' };
 
           // when
-          logger[level]({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
+          logger[level]({ event: 'toto', message: 'titi', stack: 'stack', data }, injectedLogger, true);
           // then
           expect(injectedLogger[functionToStub].calledOnce).to.be.true;
           expect(injectedLogger[functionToStub].firstCall.args[0]).to.equal(
-            `{"event":"toto","message":"titi","stack":"stack","level":"${level}"}`,
+            `{"event":"toto","message":"titi","stack":"stack","level":"${level}","data":{"ctx":"context","meta":"metadata"}}`,
           );
         });
       });
@@ -33,14 +34,15 @@ describe('logger', function () {
           let injectedLogger = [];
           const functionToStub = injectedLoggerFunction[level];
           injectedLogger[functionToStub] = sinon.stub();
+          const data = { ctx: 'context', meta: 'metadata' };
 
           // when
-          logger[level]({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
+          logger[level]({ event: 'toto', message: { foo: 'bar' }, stack: 'stack', data }, injectedLogger, true);
 
           // then
           expect(injectedLogger[functionToStub].calledOnce).to.be.true;
           expect(injectedLogger[functionToStub].firstCall.args[0]).to.equal(
-            `{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"${level}"}`,
+            `{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"${level}","data":{"ctx":"context","meta":"metadata"}}`,
           );
         });
       });

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -2,130 +2,47 @@ const { expect, sinon } = require('../../../test-helper');
 const logger = require('../../../../common/services/logger');
 
 describe('logger', function () {
-  describe('error', function () {
-    describe('when an message is passed', function () {
-      it('should call injectedLogger error', function () {
-        // given
-        const injectedLogger = { error: sinon.stub() };
+  const injectedLoggerFunction = {
+    error: 'error',
+    info: 'log',
+    warn: 'warn',
+    ok: 'ok',
+  };
 
-        // when
-        logger.error({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
-        // then
-        expect(injectedLogger.error.calledOnce).to.be.true;
-        expect(injectedLogger.error.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"titi","stack":"stack","level":"error"}',
-        );
+  ['error', 'info', 'warn', 'ok'].forEach((level) => {
+    describe(level, function () {
+      describe('when an message is passed', function () {
+        it(`should call injectedLogger ${level}`, function () {
+          // given
+          let injectedLogger = [];
+          const functionToStub = injectedLoggerFunction[level];
+          injectedLogger[functionToStub] = sinon.stub();
+
+          // when
+          logger[level]({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
+          // then
+          expect(injectedLogger[functionToStub].calledOnce).to.be.true;
+          expect(injectedLogger[functionToStub].firstCall.args[0]).to.equal(
+            `{"event":"toto","message":"titi","stack":"stack","level":"${level}"}`,
+          );
+        });
       });
-    });
-    describe('when an object is passed', function () {
-      it('should call injectedLogger error with object in message', function () {
-        // given
-        const injectedLogger = { error: sinon.stub() };
+      describe('when an object is passed', function () {
+        it(`should call injectedLogger ${level} with object in message`, function () {
+          // given
+          let injectedLogger = [];
+          const functionToStub = injectedLoggerFunction[level];
+          injectedLogger[functionToStub] = sinon.stub();
 
-        // when
-        logger.error({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
+          // when
+          logger[level]({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
 
-        // then
-        expect(injectedLogger.error.calledOnce).to.be.true;
-        expect(injectedLogger.error.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"error"}',
-        );
-      });
-    });
-  });
-  describe('info', function () {
-    describe('when an message is passed', function () {
-      it('should call injectedLogger log', function () {
-        // given
-        const injectedLogger = { log: sinon.stub() };
-
-        // when
-        logger.info({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.log.calledOnce).to.be.true;
-        expect(injectedLogger.log.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"titi","stack":"stack","level":"info"}',
-        );
-      });
-    });
-    describe('when an object is passed', function () {
-      it('should call injectedLogger log with object in message', function () {
-        // given
-        const injectedLogger = { log: sinon.stub() };
-
-        // when
-        logger.info({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.log.calledOnce).to.be.true;
-        expect(injectedLogger.log.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"info"}',
-        );
-      });
-    });
-  });
-  describe('warn', function () {
-    describe('when an message is passed', function () {
-      it('should call injectedLogger warn', function () {
-        // given
-        const injectedLogger = { warn: sinon.stub() };
-
-        // when
-        logger.warn({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.warn.calledOnce).to.be.true;
-        expect(injectedLogger.warn.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"titi","stack":"stack","level":"warn"}',
-        );
-      });
-    });
-    describe('when an object is passed', function () {
-      it('should call injectedLogger warn with object in message', function () {
-        // given
-        const injectedLogger = { warn: sinon.stub() };
-
-        // when
-        logger.warn({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.warn.calledOnce).to.be.true;
-        expect(injectedLogger.warn.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"warn"}',
-        );
-      });
-    });
-  });
-  describe('ok', function () {
-    describe('when an message is passed', function () {
-      it('should call injectedLogger ok', function () {
-        // given
-        const injectedLogger = { ok: sinon.stub() };
-
-        // when
-        logger.ok({ event: 'toto', message: 'titi', stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.ok.calledOnce).to.be.true;
-        expect(injectedLogger.ok.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"titi","stack":"stack","level":"ok"}',
-        );
-      });
-    });
-    describe('when an object is passed', function () {
-      it('should call injectedLogger warn with object in message', function () {
-        // given
-        const injectedLogger = { ok: sinon.stub() };
-
-        // when
-        logger.ok({ event: 'toto', message: { foo: 'bar' }, stack: 'stack' }, injectedLogger, true);
-
-        // then
-        expect(injectedLogger.ok.calledOnce).to.be.true;
-        expect(injectedLogger.ok.firstCall.args[0]).to.equal(
-          '{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"ok"}',
-        );
+          // then
+          expect(injectedLogger[functionToStub].calledOnce).to.be.true;
+          expect(injectedLogger[functionToStub].firstCall.args[0]).to.equal(
+            `{"event":"toto","message":"{\\"foo\\":\\"bar\\"}","stack":"stack","level":"${level}"}`,
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La création de RA ne fonctionne pas toujours, cela pose un problème lors du déploiement sur Scalingo suite à l'évènement github de synchronisation de PR.


## :robot: Proposition
Vérifier si la RA existe avant de la déployer et ajouter la création de celle-ci lors de l'évènement github de synchronisation dans le cas contraire.

## :rainbow: Remarques
- Enrichissement du logger pour un suivi plus facile du monitoring 
- On en profite pour faire une refactorisation des logs 

## :100: Pour tester
Tests ✅ 


