### PR TITLE
[TECH] :bug: Rendre les tests des scripts indépendants de l'environnement de développement

### DIFF
--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -42,6 +42,7 @@ describe('Acceptance | Scripts | publish.sh', function () {
     const githubRepository = 'pix-bot-publish-test';
     const env = {
       ...process.env,
+      NPM_CONFIG_PRODUCTION: undefined,
       GIT_USER_NAME: gitUser,
       GIT_USER_EMAIL: gitEmail,
       GITHUB_OWNER: githubOwner,

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -41,6 +41,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function () {
     const githubRepository = 'pix-bot-publish-test';
     const env = {
       ...process.env,
+      NPM_CONFIG_PRODUCTION: undefined,
       GIT_USER_NAME: gitUser,
       GIT_USER_EMAIL: gitEmail,
     };


### PR DESCRIPTION
## :unicorn: Problème

En fonction de la configuration du poste de dev, les tests des scripts bash ne passent plus en raison d'un problème de variable NPM_CONFIG_PRODUCTION (si elle est définie, les tests ne passent plus car le message `npm WARN config production Use --omit=dev instead.` s'affiche )

## :robot: Proposition

Plusieurs solutions seraient possible : 

- Effacer la variable dans les tests spécifiquement
- Ajouter la ligne dans le expected si la variable est définie

Je ne suis pas arrêté sur l'une ou l'autre, je suis curieux des retours 🙏 

## :100: Pour tester

Définir `NPM_CONFIG_PRODUCTION` dans le `.env` local et lancer les tests pour valider que les tests passent toujours quelle que soit la valeur. 
