### PR TITLE
[TECH]  Permettre la création de review app sur pix-epreuves.

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -12,6 +12,7 @@ const repositoryToScalingoAppsReview = {
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],
+  'pix-epreuves': ['pix-epreuves-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],

--- a/build/templates/pull-request-messages/pix-epreuves.md
+++ b/build/templates/pull-request-messages/pix-epreuves.md
@@ -1,0 +1,1 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://epreuves-pr{{pullRequestId}}.review.pix.fr/viewer.html


### PR DESCRIPTION
## :unicorn: Problème
Les RA sur pix-epreuves sont déployées automatiquement via github ce qui nous rend dépendant de la réussite de la CI.

## :robot: Proposition
Utiliser pix-bot pour déployer l'application.

## :rainbow: Remarques
RAS

## :100: Pour tester
IDK
