### PR TITLE
[BUGFIX] Corrige l'utilisation de `logger.info` lors du déploiement d'un repo.

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -177,7 +177,7 @@ async function _getTagCommitUrl({ owner, repo, tagName }) {
   const tags = await _getTags(owner, repo);
   const tag = tags.find((tag) => tag.name === tagName);
   if (!tag) {
-    logger.error(`Could not find the tag ${tagName} on ${owner}/${repo}`);
+    logger.error({ message: `Could not find the tag ${tagName} on ${owner}/${repo}` });
     throw new Error(`Could not find the tag ${tagName} on ${owner}/${repo}`);
   }
   return tag.commit.url;

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -81,7 +81,10 @@ module.exports = {
     const sanitizedAppName = _sanitizedArgument(appName);
     try {
       const client = await ScalingoClient.getInstance(environment);
-      logger.info('Deploy : ' + sanitizedAppName + ' | Tag ' + sanitizedReleaseTag + ' | Repo  : ', sanitizedRepoName);
+      logger.info({
+        event: 'deploy',
+        message: `Deploy: ${sanitizedAppName} | Tag: ${sanitizedReleaseTag} | Repo: ${sanitizedRepoName}`,
+      });
       return client.deployFromArchive(sanitizedAppName, sanitizedReleaseTag, sanitizedRepoName);
     } catch (err) {
       logger.error({ event: 'deploy', message: err });

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -14,7 +14,7 @@ class ScalingoClient {
   static async getInstance(environment, injectedClient = scalingo) {
     const { token, apiUrl } = config.scalingo[environment];
     if (!token || !apiUrl) {
-      logger.error(`Scalingo credentials missing for environment ${environment}`);
+      logger.error({ message: `Scalingo credentials missing for environment ${environment}` });
       throw new Error(`Scalingo credentials missing for environment ${environment}`);
     }
     const client = await injectedClient.clientFromToken(token, { apiUrl });
@@ -23,11 +23,11 @@ class ScalingoClient {
 
   async deployFromArchive(pixApp, releaseTag, repository = config.github.repository, options = DEFAULT_OPTS) {
     if (!pixApp) {
-      logger.error('No application to deploy.');
+      logger.error({ message: 'No application to deploy.' });
       throw new Error('No application to deploy.');
     }
     if (!releaseTag) {
-      logger.error('No release tag to deploy.');
+      logger.error({ message: 'No release tag to deploy.' });
       throw new Error('No release tag to deploy.');
     }
 
@@ -54,7 +54,7 @@ class ScalingoClient {
       throw new Error(`Unable to deploy ${scalingoApp} ${releaseTag}`);
     }
 
-    logger.info(`Deployment of ${scalingoApp} ${releaseTag} has been requested`);
+    logger.info({ message: `Deployment of ${scalingoApp} ${releaseTag} has been requested` });
     return `Deployment of ${scalingoApp} ${releaseTag} has been requested`;
   }
 
@@ -74,9 +74,9 @@ class ScalingoClient {
       if (err.status === 404) {
         return false;
       }
-      logger.error(
-        `Impossible to get info for RA ${reviewAppName}. Scalingo API returned ${err.status} : ${err.message}`,
-      );
+      logger.error({
+        message: `Impossible to get info for RA ${reviewAppName}. Scalingo API returned ${err.status} : ${err.message}`,
+      });
       throw new Error(
         `Impossible to get info for RA ${reviewAppName}. Scalingo API returned ${err.status} : ${err.message}`,
       );


### PR DESCRIPTION
## :unicorn: Problème

Lors du déploiement d'un repo, on appelle la fonction `logger.info` avec comme seul argument le message que l'on souhaite logguer.
Comme la fonction attend un objet dans lequel on peut injecter l'objet log contenant lui-même la fonction `info`, cela pour conséquence de lever une erreur.

## :robot: Proposition

On corrige l'appel de la fonction en passant en argument un objet contenant la propriété `message`.

## :rainbow: Remarques

On en profite pour corriger tous les appels de `logger.info` et `logger.error`.

## :100: Pour tester

Appeler la route `/deploy-sites`.
