### PR TITLE
[TECH] Utiliser le logger info à la place du logger ok qui n'existe pas

### DIFF
--- a/common/services/logger.js
+++ b/common/services/logger.js
@@ -37,15 +37,9 @@ const warn = ({ event, message, job, stack, data }, injectedLogger = console, en
     injectedLogger.warn(serialize({ event, message, job, stack, data, level: 'warn' }));
   }
 };
-const ok = ({ event, message, job, stack, data }, injectedLogger = console, enabled = enabledFromConfiguration) => {
-  if (enabled) {
-    injectedLogger.ok(serialize({ event, message, job, stack, data, level: 'ok' }));
-  }
-};
 
 module.exports = {
   error,
   info,
   warn,
-  ok,
 };

--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -56,17 +56,9 @@ module.exports = {
       const repositoryURL = `https://${config.github.token}@github.com/${config.github.owner}/${sanitizedRepoName}.git`;
       const args = [config.github.owner, sanitizedRepoName, sanitizedReleaseType, branchName, repositoryURL];
       const newPackageVersion = await _runScriptWithArgument(RELEASE_PIX_SCRIPT, ...args);
-      logger.ok({
+      logger.info({
         event: 'release',
-        message:
-          'Type: ' +
-          releaseType +
-          ' , reponame ' +
-          repoName +
-          ' , Repo URL : ' +
-          repositoryURL +
-          ' , Package version : ' +
-          newPackageVersion,
+        message: `Type: ${releaseType} | Reponame : ${repoName} | Repo URL : ${repositoryURL} | Package version : ${newPackageVersion}`,
       });
       return newPackageVersion;
     } catch (err) {

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -145,7 +145,7 @@ class ScalingoClient {
     try {
       const { id } = await this.client.Apps.create(app);
       await this.client.Apps.update(id, appSettings);
-      logger.ok({ event: 'scalingo', message: `${app.name} created` });
+      logger.info({ event: 'scalingo', message: `${app.name} created` });
       return id;
     } catch (e) {
       logger.error({ event: 'scalingo', message: e });

--- a/test/unit/common/services/logger_test.js
+++ b/test/unit/common/services/logger_test.js
@@ -6,10 +6,9 @@ describe('logger', function () {
     error: 'error',
     info: 'log',
     warn: 'warn',
-    ok: 'ok',
   };
 
-  ['error', 'info', 'warn', 'ok'].forEach((level) => {
+  ['error', 'info', 'warn'].forEach((level) => {
     describe(level, function () {
       describe('when an message is passed', function () {
         it(`should call injectedLogger ${level}`, function () {


### PR DESCRIPTION
## :unicorn: Problème

Le logger ok n'existe pas sur la console. Suite à https://github.com/1024pix/pix-bot/pull/351, on a commencé à l'utiliser (ce qui ne fonctionne pas)

## :robot: Proposition

Supprimer complètement toute référence à ce logger

## :100: Pour tester

🟢 
