### PR TITLE
Revert "[FEATURE] Ne pas créer de RA quand la PR est en draft (PIX-9921)"

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -210,7 +210,6 @@ function _handleNoRACase(request) {
   const isFork = payload.pull_request.head.repo.fork;
   const labelsList = payload.pull_request.labels;
   const state = payload.pull_request.state;
-  const draft = payload.pull_request.draft;
 
   if (isFork) {
     return { message: 'No RA for a fork', shouldContinue: false };
@@ -223,9 +222,6 @@ function _handleNoRACase(request) {
   }
   if (state !== 'open') {
     return { message: 'No RA for closed PR', shouldContinue: false };
-  }
-  if (draft) {
-    return { message: 'No RA for draft PR', shouldContinue: false };
   }
 
   return { shouldContinue: true };

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -425,7 +425,6 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       payload: {
         number: 3,
         pull_request: {
-          draft: false,
           state: 'open',
           labels: [],
           head: {
@@ -489,27 +488,6 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
           // then
           expect(response).to.equal('No RA for closed PR');
-        });
-      });
-
-      describe('when the PR is in draft mode', function () {
-        it('should not create a Review App', async function () {
-          // given
-          const injectedScalingoClientStub = sinon.stub();
-          const deployUsingSCMStub = sinon.stub();
-
-          injectedScalingoClientStub.getInstance = sinon.stub().returns({
-            deployUsingSCM: deployUsingSCMStub,
-          });
-
-          sinon.stub(request.payload.pull_request, 'draft').value(true);
-
-          // when
-          const response = await githubController.pullRequestSynchronizeWebhook(request, injectedScalingoClientStub);
-
-          // then
-          expect(deployUsingSCMStub).to.not.have.been.called;
-          expect(response).to.equal('No RA for draft PR');
         });
       });
     });


### PR DESCRIPTION
Reverts 1024pix/pix-bot#363

La RA n'est pas créé automatiquement lorsque la PR passe de DRAFT à pas DRAFT. 

De plus, il serait intéressant de mettre en place un « forçage » via le tag « no-review-app » ou un autre tag pour forcer le déploiement de la RA