### PR TITLE
[BUGFIX] Gère le renommage de l'application pix-1d-integration.

### DIFF
--- a/config.js
+++ b/config.js
@@ -72,7 +72,7 @@ module.exports = (function () {
           'pix-certif-integration',
           'pix-orga-integration',
           'pix-admin-integration',
-          'pix-1d-integration',
+          'pix-junior-integration',
         ],
       },
     },


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
L'application `pix-1d-integration` a été renommée en `pix-junior-integration` ce qui entraine l'échec du déploiement continue depuis la branche `dev`.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On renomme les dernières occurrences de `pix-1d` en `pix-junior`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Une CI verte et go !
