### PR TITLE
[FEATURE] Activer les RA pour pix-api-data

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -8,6 +8,7 @@ import ScalingoClient from '../../common/services/scalingo-client.js';
 import { config } from '../../config.js';
 
 const repositoryToScalingoAppsReview = {
+  'pix-api-data': ['pix-api-data-integration'],
   'pix-bot': ['pix-bot-review'],
   'pix-data': ['pix-airflow-review'],
   'pix-db-replication': ['pix-datawarehouse-integration'],


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de RA pour pix-api-data alors que c'est pratique :) 

## :robot: Proposition
Ajouter la configuration nécessaire, on se base sur l'integration car nous n'avons pas la nécessité d'avoir un template dédié

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
