### PR TITLE
[FEATURE]: Ouvrir les liens des reviews dans de nouveaux onglets

### DIFF
--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -1,16 +1,17 @@
+
 Une fois les applications déployées, elles seront accessibles via les liens suivants :
-  * [App (.fr)](https://app-pr{{pullRequestId}}.review.pix.fr)
-  * [App (.org)](https://app-pr{{pullRequestId}}.review.pix.org)
-  * [Orga (.fr)](https://orga-pr{{pullRequestId}}.review.pix.fr)
-  * [Orga (.org)](https://orga-pr{{pullRequestId}}.review.pix.org)
-  * [Certif (.fr)](https://certif-pr{{pullRequestId}}.review.pix.fr)
-  * [Certif (.org)](https://certif-pr{{pullRequestId}}.review.pix.org)
-  * [Junior](https://junior-pr{{pullRequestId}}.review.pix.fr)
-  * [Admin](https://admin-pr{{pullRequestId}}.review.pix.fr)
-  * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
-  * [Audit Logger](https://pix-audit-logger-review-pr{{pullRequestId}}.osc-fr1.scalingo.io/api/)
+* <a href="https://app-pr{{pullRequestId}}.review.pix.fr" target="_blank" title="S'ouvre dans un nouvel onglet">App (.fr)</a>
+* <a href="https://app-pr{{pullRequestId}}.review.pix.org" target="_blank" title="S'ouvre dans un nouvel onglet">App (.org)</a>
+* <a href="https://orga-pr{{pullRequestId}}.review.pix.fr" target="_blank" title="S'ouvre dans un nouvel onglet">Orga (.fr)</a>
+* <a href="https://orga-pr{{pullRequestId}}.review.pix.org" target="_blank" title="S'ouvre dans un nouvel onglet">Orga (.org)</a>
+* <a href="https://certif-pr{{pullRequestId}}.review.pix.fr" target="_blank" title="S'ouvre dans un nouvel onglet">Certif (.fr)</a>
+* <a href="https://certif-pr{{pullRequestId}}.review.pix.org" target="_blank" title="S'ouvre dans un nouvel onglet">Certif (.org)</a>
+* <a href="https://junior-pr{{pullRequestId}}.review.pix.fr" target="_blank" title="S'ouvre dans un nouvel onglet">Junior</a>
+* <a href="https://admin-pr{{pullRequestId}}.review.pix.fr" target="_blank" title="S'ouvre dans un nouvel onglet">Admin</a>
+* <a href="https://api-pr{{pullRequestId}}.review.pix.fr/api/" target="_blank" title="S'ouvre dans un nouvel onglet">API</a>
+* <a href="https://pix-audit-logger-review-pr{{pullRequestId}}.osc-fr1.scalingo.io/api/" target="_blank" title="S'ouvre dans un nouvel onglet">Audit Logger</a>
 
 Les variables d'environnement seront accessibles via les liens suivants :
-  * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)
-  * [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr{{pullRequestId}}/environment)
-  * [scalingo audit-logger](https://dashboard.scalingo.com/apps/osc-fr1/pix-audit-logger-review-pr{{pullRequestId}}/environment)
+  * <a href="https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment" target="_blank" title="S'ouvre dans un nouvel onglet">scalingo front</a>
+  * <a href="https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr{{pullRequestId}}/environment" target="_blank" title="S'ouvre dans un nouvel onglet">scalingo api</a>
+  * <a href="https://dashboard.scalingo.com/apps/osc-fr1/pix-audit-logger-review-pr{{pullRequestId}}/environment" target="_blank" title="S'ouvre dans un nouvel onglet">scalingo audit-logger</a>


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on clique sur une review de du dépôt, la page s'ouvre dans l'onglet actuel, ce qui peut être ralentissant pour retrouver la PR ensuite.
De plus, faire un clique pour les ouvrir est long et parfois compliqué.

## :robot: Proposition
Modifier le template de markdown pour ouvrir de nouveaux onglet au clique.

## :rainbow: Remarques
Cela implique de refermer systématiquement ses pages pour ne pas avoir trop d'onglet ouvert, mais étant donné qu'il s'agit d'une ressource externe à GitHub, cela est plus logique.

## :100: Pour tester
A déterminer.