### PR TITLE
[FEATURE] Activer les RA pour pix-api-data-pix

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -11,6 +11,7 @@ const repositoryToScalingoAppsReview = {
   'pix-api-data': ['pix-api-data-integration'],
   'pix-bot': ['pix-bot-review'],
   'pix-data': ['pix-airflow-review'],
+  'pix-data-api-pix': ['pix-data-api-pix-integration'],
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],

--- a/build/templates/pull-request-messages/pix-api-data-pix.md
+++ b/build/templates/pull-request-messages/pix-api-data-pix.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-data-api-pix-integration-pr{{pullRequestId}}.scalingo.io
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-secnum-fr1/pix-data-api-pix-integration-pr{{pullRequestId}}/environment


### PR DESCRIPTION
## :unicorn: Problème
Les RA pour pix-api-data-pix ne sont pas gérées par pix-bot mais directement par Scalingo (ce qui est une mauvaise pratique)

## :robot: Proposition
Ajouter pix-api-data-pix et inclure un template de PR