### PR TITLE
[FEATURE] Ajout d'une commande slack pour déploiement de pix-data-api-pix (PIX-13714)

### DIFF
--- a/config.js
+++ b/config.js
@@ -154,6 +154,7 @@ const configuration = (function () {
     PIX_TUTOS_APP_NAME: 'pix-tutos',
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',
     PIX_DBT_APPS_NAME: ['pix-dbt-production', 'pix-dbt-external-production'],
+    PIX_DATA_API_PIX_APPS_NAME: ['pix-data-api-pix-production'],
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -28,6 +28,15 @@ const slack = {
     };
   },
 
+  deployPixDataApiPix(request) {
+    const payload = request.pre.payload;
+    commands.deployPixDataApiPix(payload);
+
+    return {
+      text: _getDeployStartedMessage(payload.text, 'PIX data api pix'),
+    };
+  },
+
   createAndDeployPixSiteRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixSiteRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -131,4 +131,13 @@ manifest.addInteractivity({
   handler: slackbotController.interactiveEndpoint,
 });
 
+manifest.registerSlashCommand({
+  command: '/deploy-pix-data-api-pix',
+  path: '/slack/commands/deploy-pix-data-api-pix',
+  description: 'Déploie la version précisée de pix-data-api-pix en production',
+  usage_hint: '/deploy-pix-data-api-pix $version',
+  should_escape: false,
+  handler: slackbotController.deployPixDataApiPix,
+});
+
 export default manifest;

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -223,6 +223,11 @@ async function createAndDeployPixTutosRelease(payload) {
   );
 }
 
+async function deployPixDataApiPix(payload) {
+  const version = payload.text;
+  await deployTagUsingSCM(config.PIX_DATA_API_PIX_APPS_NAME, version);
+}
+
 export {
   createAndDeployDbStats,
   createAndDeployEmberTestingLibrary,
@@ -234,5 +239,6 @@ export {
   createAndDeployPixUI,
   deployAirflow,
   deployDBT,
+  deployPixDataApiPix,
   getAndDeployLastVersion,
 };

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -121,6 +121,13 @@ describe('Acceptance | Run | Manifest', function () {
               usage_hint: '/deploy-dbt $version',
             },
             {
+              command: '/deploy-pix-data-api-pix',
+              description: 'Déploie la version précisée de pix-data-api-pix en production',
+              should_escape: false,
+              url: `http://${hostname}/slack/commands/deploy-pix-data-api-pix`,
+              usage_hint: '/deploy-pix-data-api-pix $version',
+            },
+            {
               command: '/deploy-metabase',
               description: 'Déploie metabase',
               should_escape: false,

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -51,4 +51,27 @@ describe('Integration | Run | Services | Slack | Commands', function () {
       expect(nockCallB.isDone()).to.be.true;
     });
   });
+
+  describe('#deployPixDataApiPix', function () {
+    it('should call Scalingo API to deploy a specified tag', async function () {
+      const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
+      const pixDataApiPixVersion = 'v0.0.1';
+      const deploymentPayload = {
+        branch: pixDataApiPixVersion,
+      };
+
+      const commandPayload = {
+        text: pixDataApiPixVersion,
+      };
+
+      const nockCall = nock('https://scalingo.production')
+        .post(`/v1/apps/pix-data-api-pix-production/scm_repo_link/manual_deploy`, deploymentPayload)
+        .reply(200, {});
+
+      await commands.deployPixDataApiPix(commandPayload);
+
+      expect(scalingoTokenNock.isDone()).to.be.true;
+      expect(nockCall.isDone()).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Souhait d'ajouter une commande slack pour le déploiement de pix-data-api-pix

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
