### PR TITLE
[FEATURE] Permettre le déploiement dès la création d'une release (PIX-13870).

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -192,6 +192,7 @@ async function processWebhook(
     injectedPushOnDefaultBranchWebhook = pushOnDefaultBranchWebhook,
     injectedPullRequestOpenedWebhook = pullRequestOpenedWebhook,
     injectedPullRequestSynchronizeWebhook = pullRequestSynchronizeWebhook,
+    injectedReleaseWebhook = releaseWebhook,
   } = {},
 ) {
   const eventName = request.headers['x-github-event'];
@@ -207,9 +208,34 @@ async function processWebhook(
         return injectedPullRequestSynchronizeWebhook(request);
     }
     return `Ignoring ${request.payload.action} action`;
+  } else if (eventName === 'release') {
+    if (request.payload.action === 'released') {
+      return injectedReleaseWebhook(request);
+    }
+    return `Ignoring ${request.payload.action} action`;
   } else {
     return `Ignoring ${eventName} event`;
   }
+}
+
+async function releaseWebhook(request, repoAppMapping = config.repoAppNames, injectedScalingoClient = ScalingoClient) {
+  const appNames = repoAppMapping[request.payload.repository.name];
+  const tag = request.payload.release.tag_name;
+
+  if (!appNames) {
+    return 'No Scalingo app configured for this repository';
+  }
+
+  return deployTagUsingSCM(appNames, tag, injectedScalingoClient);
+}
+
+async function deployTagUsingSCM(appNames, tag, scalingoClient) {
+  const client = await scalingoClient.getInstance('production');
+  return Promise.all(
+    appNames.map((appName) => {
+      return client.deployUsingSCM(appName, tag);
+    }),
+  );
 }
 
 function _handleNoRACase(request) {
@@ -244,4 +270,5 @@ export {
   pullRequestOpenedWebhook,
   pullRequestSynchronizeWebhook,
   pushOnDefaultBranchWebhook,
+  releaseWebhook,
 };

--- a/config.js
+++ b/config.js
@@ -155,6 +155,8 @@ const configuration = (function () {
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',
     PIX_DBT_APPS_NAME: ['pix-dbt-production', 'pix-dbt-external-production'],
     PIX_DATA_API_PIX_APPS_NAME: ['pix-data-api-pix-production'],
+
+    repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING),
   };
 
   if (process.env.NODE_ENV === 'test') {

--- a/sample.env
+++ b/sample.env
@@ -278,6 +278,12 @@ SCALINGO_API_URL_PRODUCTION=https://api.osc-secnum-fr1.scalingo.com
 # default: none
 # SCHEDULE_AUTOSCALE_DOWN_SETTINGS_MAX
 
+# Mapping between the name of a repository and the Scalingo apps associated with it.
+#
+# This is necessary if you want to deploy applications as soon as a release is created on GitHub.
+# presence: optional
+# REPO_APP_NAMES_MAPPING={ 'pix-site': ['pix-site-production', 'pix-pro-production'] }
+
 # ======================
 # BUILD
 # ======================

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -171,6 +171,42 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           expect(result).to.equal('Ignoring unhandled-action action');
         });
       });
+
+      describe('when event is release', function () {
+        it(`should call releaseWebhook() method on released action`, async function () {
+          // given
+          const request = {
+            headers: {
+              'x-github-event': 'release',
+            },
+            payload: { action: 'released' },
+          };
+
+          const injectedReleaseWebhook = sinon.stub();
+
+          // when
+          await githubController.processWebhook(request, { injectedReleaseWebhook });
+
+          // then
+          expect(injectedReleaseWebhook.calledOnceWithExactly(request)).to.be.true;
+        });
+
+        it('should ignore the action', async function () {
+          // given
+          const request = {
+            headers: {
+              'x-github-event': 'release',
+            },
+            payload: { action: 'unhandled-action' },
+          };
+
+          // when
+          const result = await githubController.processWebhook(request);
+
+          // then
+          expect(result).to.equal('Ignoring unhandled-action action');
+        });
+      });
     });
   });
 
@@ -580,6 +616,78 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 3',
           );
         });
+      });
+    });
+  });
+
+  describe('#releaseWebhook', function () {
+    context('when repo is handle', function () {
+      it('should deploy release', async function () {
+        // given
+        const request = {
+          payload: {
+            action: 'released',
+            release: {
+              tag_name: 'v0.1.0',
+            },
+            repository: {
+              organization: '1024pix',
+              name: 'pix-repo-test',
+            },
+          },
+        };
+        const deployUsingSCMStub = sinon.stub();
+        const injectedConfigurationRepoAppMapping = {
+          'pix-repo-test': ['pix-app-name-production', 'pix-app-name-2-production'],
+        };
+        const injectedScalingoClientStub = {
+          getInstance: () => ({
+            deployUsingSCM: deployUsingSCMStub,
+          }),
+        };
+
+        // when
+        await githubController.releaseWebhook(request, injectedConfigurationRepoAppMapping, injectedScalingoClientStub);
+
+        // then
+        expect(deployUsingSCMStub.firstCall).to.be.calledWith('pix-app-name-production', 'v0.1.0');
+        expect(deployUsingSCMStub.secondCall).to.be.calledWith('pix-app-name-2-production', 'v0.1.0');
+      });
+    });
+
+    context('when repo is not handle', function () {
+      it('should not try to deploy release', async function () {
+        // given
+        const request = {
+          payload: {
+            action: 'released',
+            release: {
+              tag_name: 'v0.1.0',
+            },
+            repository: {
+              organization: '1024pix',
+              name: 'pix-repo-test',
+            },
+          },
+        };
+        const deployUsingSCMStub = sinon.stub();
+        const injectedConfigurationRepoAppMapping = {};
+        const injectedScalingoClientStub = {
+          getInstance: () => ({
+            deployUsingSCM: deployUsingSCMStub,
+          }),
+        };
+
+        // when
+        const result = await githubController.releaseWebhook(
+          request,
+          injectedConfigurationRepoAppMapping,
+          injectedScalingoClientStub,
+        );
+
+        // then
+        expect(deployUsingSCMStub).to.have.not.been.called;
+        expect(result).to.equal('No Scalingo app configured for this repository');
       });
     });
   });

--- a/test/unit/common/models/ScalingoAppName_test.js
+++ b/test/unit/common/models/ScalingoAppName_test.js
@@ -11,7 +11,6 @@ describe('Unit | Common | Models | ScalingoAppName', function () {
 
       // when
       const resultInvalidAppName = ScalingoAppName.isApplicationNameValid(invalidAppName);
-      console.log(resultInvalidAppName);
       // then
       expect(resultInvalidAppName, 'Invalid app name').to.be.false;
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, plusieurs étapes manuelles persistent sur certains repository comme la création de release via l'interface de GitHub et le déploiement depuis une commande Slack. Les deux sont toujours suivies, cela n'a donc pas d'intérêt d'être manuel. 

## :robot: Proposition
Dans cette PR, nous nous concentrons sur la deuxième étape qui est de remplacer la commande Slack par l'utilisation des Webhooks GitHub. 

GitHub appelle déjà Pix Bot à chaque création de release mais Pix Bot ne fait rien de cet évènement. Ici, nous ajoutons donc la logique pour que Pix Bot puisse déployer les apps associées au repo qui a une nouvelle release. 

## :rainbow: Remarques
Cette PR vient avec l'ajout d'une nouvelle variable d'environnement. `REPO_APP_NAMES_MAPPING` qui a pour but d'éviter les PRs pour ajouter une fonctionnalité pour un nouveau repository comme par exemple : #212. 

Actuellement, l'écoute des webhooks se fait dans le dossier/app `build`, mais dans le cadre des releases ça devrait être dans le `run`. Je propose de voir ça dans un second temps, pour ne pas complexifier le code de cette PR en dupliquant la route etc.

## :100: Pour tester
Aucune idée pour brancher ça facilement