### PR TITLE
[BUGFIX] Eviter les 500 sur l'appel /github/webhook. 

### DIFF
--- a/config.js
+++ b/config.js
@@ -156,7 +156,7 @@ const configuration = (function () {
     PIX_DBT_APPS_NAME: ['pix-dbt-production', 'pix-dbt-external-production'],
     PIX_DATA_API_PIX_APPS_NAME: ['pix-data-api-pix-production'],
 
-    repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING),
+    repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING) || {},
   };
 
   if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
## :unicorn: Problème
Si la variable `REPO_APP_NAMES_MAPPING` n'est pas configurée alors des 500 ont lieu.

## :robot: Proposition
Ajouter une valeur par défaut

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
