### PR TITLE
[FEATURE] Déployer les apps grâce au webhook GitHub sans que le repository soit lié dans Scalingo.

### DIFF
--- a/run/controllers/github.js
+++ b/run/controllers/github.js
@@ -14,21 +14,22 @@ async function processWebhook(request, { injectedReleaseWebhook = releaseWebhook
 }
 
 async function releaseWebhook(request, repoAppMapping = config.repoAppNames, injectedScalingoClient = ScalingoClient) {
-  const appNames = repoAppMapping[request.payload.repository.name];
+  const repository = request.payload.repository.name;
+  const appNames = repoAppMapping[repository];
   const tag = request.payload.release.tag_name;
 
   if (!appNames) {
     return 'No Scalingo app configured for this repository';
   }
 
-  return deployTagUsingSCM(appNames, tag, injectedScalingoClient);
+  return deployFromArchive(appNames, tag, repository, injectedScalingoClient);
 }
 
-async function deployTagUsingSCM(appNames, tag, scalingoClient) {
+async function deployFromArchive(appNames, tag, repository, scalingoClient) {
   const client = await scalingoClient.getInstance('production');
   return Promise.all(
     appNames.map((appName) => {
-      return client.deployUsingSCM(appName, tag);
+      return client.deployFromArchive(appName, tag, repository, { withEnvSuffix: false });
     }),
   );
 }

--- a/test/acceptance/run/github_test.js
+++ b/test/acceptance/run/github_test.js
@@ -48,8 +48,14 @@ describe('Acceptance | Run | Github', function () {
 
           const tag = 'v0.1.0';
           const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.OK);
+          const scalingoDeploymentPayload = {
+            deployment: {
+              git_ref: tag,
+              source_url: 'https://undefined@github.com/github-owner/pix-test/archive/v0.1.0.tar.gz',
+            },
+          };
           const scalingoDeploy = nock('https://scalingo.production')
-            .post(`/v1/apps/pix-test-app-production/scm_repo_link/manual_deploy`, { branch: tag })
+            .post(`/v1/apps/pix-test-app-production/deployments`, scalingoDeploymentPayload)
             .reply(200, {});
 
           const body = {
@@ -72,7 +78,7 @@ describe('Acceptance | Run | Github', function () {
             payload: body,
           });
           expect(res.statusCode).to.equal(StatusCodes.OK);
-          expect(res.result).to.deep.equal(['Deployment of pix-test-app-production v0.1.0 has been requested']);
+          expect(res.result).to.deep.equal(['pix-test-app-production v0.1.0 has been deployed']);
           expect(scalingoAuth.isDone()).to.be.true;
           expect(scalingoDeploy.isDone()).to.be.true;
         });

--- a/test/unit/run/controllers/github_test.js
+++ b/test/unit/run/controllers/github_test.js
@@ -75,13 +75,13 @@ describe('Unit | Run | Controller | Github', function () {
             },
           },
         };
-        const deployUsingSCMStub = sinon.stub();
+        const deployFromArchive = sinon.stub();
         const injectedConfigurationRepoAppMapping = {
           'pix-repo-test': ['pix-app-name-production', 'pix-app-name-2-production'],
         };
         const injectedScalingoClientStub = {
           getInstance: () => ({
-            deployUsingSCM: deployUsingSCMStub,
+            deployFromArchive,
           }),
         };
 
@@ -89,8 +89,12 @@ describe('Unit | Run | Controller | Github', function () {
         await githubController.releaseWebhook(request, injectedConfigurationRepoAppMapping, injectedScalingoClientStub);
 
         // then
-        expect(deployUsingSCMStub.firstCall).to.be.calledWith('pix-app-name-production', 'v0.1.0');
-        expect(deployUsingSCMStub.secondCall).to.be.calledWith('pix-app-name-2-production', 'v0.1.0');
+        expect(deployFromArchive.firstCall).to.be.calledWith('pix-app-name-production', 'v0.1.0', 'pix-repo-test', {
+          withEnvSuffix: false,
+        });
+        expect(deployFromArchive.secondCall).to.be.calledWith('pix-app-name-2-production', 'v0.1.0', 'pix-repo-test', {
+          withEnvSuffix: false,
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le webhook GitHub fonctionne uniquement pour les apps qui est lié à un repository (cf: [Source Code Management - Scalingo](https://doc.scalingo.com/platform/app/scm-integration)). Cependant, nous souhaitons pas lier nos apps à des dépots GitHub.

## :robot: Proposition
Permettre le déploiement sans que le repo soit lié à l'application Scalingo

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
