### PR TITLE
[TECH] Refactorer le controller GitHub

### DIFF
--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -88,7 +88,7 @@ describe('Acceptance | Build | Github', function () {
           });
           expect(res.statusCode).to.equal(StatusCodes.OK);
           expect(res.result).to.eql(
-            'Created RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
+            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
           );
           expect(scalingoAuth.isDone()).to.be.true;
           expect(scalingoDeploy1.isDone()).to.be.true;

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -339,6 +339,8 @@ describe('Acceptance | Build | Github', function () {
           const scalingoDeploy2 = getManualDeployNock({ reviewAppName: 'pix-api-review-pr2' });
           const scalingoDeploy3 = getManualDeployNock({ reviewAppName: 'pix-audit-logger-review-pr2' });
 
+          nock('https://api.github.com').post('/repos/github-owner/pix/issues/2/comments').reply(StatusCodes.OK);
+
           const res = await server.inject({
             method: 'POST',
             url: '/github/webhook',

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -358,16 +358,19 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       it('should call scalingo to create and deploy the corresponding applications', async function () {
         // given
         const scalingoClientStub = sinon.stub();
-        const deployReviewAppStub = sinon.stub().returns({ app_name: 'sample_ra_name' });
+        const deployReviewAppStub = sinon.stub();
         const disableAutoDeployStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
+        const reviewAppExistsStub = sinon.stub();
         scalingoClientStub.getInstance = sinon.stub().returns({
           deployReviewApp: deployReviewAppStub,
           disableAutoDeploy: disableAutoDeployStub,
           deployUsingSCM: deployUsingSCMStub,
+          reviewAppExists: reviewAppExistsStub,
         });
         const addMessageToPullRequestStub = sinon.stub();
         const githubServiceStub = sinon.stub();
+        reviewAppExistsStub.resolves(false);
 
         // when
         const response = await githubController.pullRequestOpenedWebhook(
@@ -379,16 +382,16 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
         // then
         expect(deployReviewAppStub.firstCall.calledWith('pix-api-review', 3)).to.be.true;
-        expect(disableAutoDeployStub.firstCall.calledWith('sample_ra_name')).to.be.true;
-        expect(deployUsingSCMStub.firstCall.calledWith('sample_ra_name', 'my-branch')).to.be.true;
+        expect(disableAutoDeployStub.firstCall.calledWith('pix-api-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.firstCall.calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
 
         expect(deployReviewAppStub.secondCall.calledWith('pix-audit-logger-review', 3)).to.be.true;
-        expect(disableAutoDeployStub.secondCall.calledWith('sample_ra_name')).to.be.true;
-        expect(deployUsingSCMStub.secondCall.calledWith('sample_ra_name', 'my-branch')).to.be.true;
+        expect(disableAutoDeployStub.secondCall.calledWith('pix-audit-logger-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.secondCall.calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
 
         expect(deployReviewAppStub.thirdCall.calledWith('pix-front-review', 3)).to.be.true;
-        expect(disableAutoDeployStub.thirdCall.calledWith('sample_ra_name')).to.be.true;
-        expect(deployUsingSCMStub.thirdCall.calledWith('sample_ra_name', 'my-branch')).to.be.true;
+        expect(disableAutoDeployStub.thirdCall.calledWith('pix-front-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.thirdCall.calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
 
         expect(
           addMessageToPullRequestStub.calledOnceWithExactly(
@@ -428,7 +431,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
         // then
         expect(result).to.be.instanceOf(Error);
-        expect(result.message).to.equal('Scalingo APIError: Deployment error');
+        expect(result.message).to.equal('No RA deployed for repository pix and pr3');
       });
     });
   });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -115,13 +115,13 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             },
           };
 
-          const injectedPushOnDefaultBranchWebhook = sinon.stub();
+          const pushOnDefaultBranchWebhook = sinon.stub();
 
           // when
-          await githubController.processWebhook(request, { injectedPushOnDefaultBranchWebhook });
+          await githubController.processWebhook(request, { pushOnDefaultBranchWebhook });
 
           // then
-          expect(injectedPushOnDefaultBranchWebhook.calledOnceWithExactly(request)).to.be.true;
+          expect(pushOnDefaultBranchWebhook.calledOnceWithExactly(request)).to.be.true;
         });
       });
 
@@ -137,13 +137,13 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             // given
             sinon.stub(request, 'payload').value({ action });
 
-            const injectedPullRequestOpenedWebhook = sinon.stub();
+            const pullRequestOpenedWebhook = sinon.stub();
 
             // when
-            await githubController.processWebhook(request, { injectedPullRequestOpenedWebhook });
+            await githubController.processWebhook(request, { pullRequestOpenedWebhook });
 
             // then
-            expect(injectedPullRequestOpenedWebhook.calledOnceWithExactly(request)).to.be.true;
+            expect(pullRequestOpenedWebhook.calledOnceWithExactly(request)).to.be.true;
           });
         });
 
@@ -151,13 +151,13 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           // given
           sinon.stub(request, 'payload').value({ action: 'synchronize' });
 
-          const injectedPullRequestSynchronizeWebhook = sinon.stub();
+          const pullRequestSynchronizeWebhook = sinon.stub();
 
           // when
-          await githubController.processWebhook(request, { injectedPullRequestSynchronizeWebhook });
+          await githubController.processWebhook(request, { pullRequestSynchronizeWebhook });
 
           // then
-          expect(injectedPullRequestSynchronizeWebhook.calledOnceWithExactly(request)).to.be.true;
+          expect(pullRequestSynchronizeWebhook.calledOnceWithExactly(request)).to.be.true;
         });
 
         it('should ignore the action', async function () {
@@ -224,9 +224,9 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
     describe('when deploying main branch on configured repository', function () {
       it('calls scalingo to deploy the corresponding applications', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployFromArchiveStub = sinon.stub();
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployFromArchive: deployFromArchiveStub,
         });
 
@@ -235,7 +235,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         });
 
         // when
-        const result = await githubController.pushOnDefaultBranchWebhook(request, injectedScalingoClientStub);
+        const result = await githubController.pushOnDefaultBranchWebhook(request, scalingoClientStub);
 
         // then
         expect(result).to.equal(
@@ -260,9 +260,9 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
       it('throws an error on scalingo deployment fails', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployFromArchiveStub = sinon.stub().rejects(new Error('Deployment error'));
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployFromArchive: deployFromArchiveStub,
         });
 
@@ -271,7 +271,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         });
 
         // when
-        const result = await catchErr(githubController.pushOnDefaultBranchWebhook)(request, injectedScalingoClientStub);
+        const result = await catchErr(githubController.pushOnDefaultBranchWebhook)(request, scalingoClientStub);
 
         // then
         expect(result).to.be.instanceOf(Error);
@@ -357,23 +357,23 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
     describe('when the Review App creation conditions are met', function () {
       it('should call scalingo to create and deploy the corresponding applications', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployReviewAppStub = sinon.stub().returns({ app_name: 'sample_ra_name' });
         const disableAutoDeployStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployReviewApp: deployReviewAppStub,
           disableAutoDeploy: disableAutoDeployStub,
           deployUsingSCM: deployUsingSCMStub,
         });
-        const injectedAddMessageToPullRequestStub = sinon.stub();
+        const addMessageToPullRequestStub = sinon.stub();
         const githubServiceStub = sinon.stub();
 
         // when
         const response = await githubController.pullRequestOpenedWebhook(
           request,
-          injectedScalingoClientStub,
-          injectedAddMessageToPullRequestStub,
+          scalingoClientStub,
+          addMessageToPullRequestStub,
           githubServiceStub,
         );
 
@@ -391,7 +391,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         expect(deployUsingSCMStub.thirdCall.calledWith('sample_ra_name', 'my-branch')).to.be.true;
 
         expect(
-          injectedAddMessageToPullRequestStub.calledOnceWithExactly(
+          addMessageToPullRequestStub.calledOnceWithExactly(
             {
               repositoryName: 'pix',
               scalingoReviewApps: ['pix-api-review', 'pix-audit-logger-review', 'pix-front-review'],
@@ -408,22 +408,22 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
       it('throws an error on scalingo deployment fails', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployReviewAppStub = sinon.stub().rejects(new Error('Deployment error'));
         const disableAutoDeployStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployReviewApp: deployReviewAppStub,
           disableAutoDeploy: disableAutoDeployStub,
           deployUsingSCM: deployUsingSCMStub,
         });
-        const injectedAddMessageToPullRequestStub = sinon.stub();
+        const addMessageToPullRequestStub = sinon.stub();
 
         // when
         const result = await catchErr(githubController.pullRequestOpenedWebhook)(
           request,
-          injectedScalingoClientStub,
-          injectedAddMessageToPullRequestStub,
+          scalingoClientStub,
+          addMessageToPullRequestStub,
         );
 
         // then
@@ -508,17 +508,17 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
     describe('when the Review App creation conditions are met', function () {
       it('should call scalingo to deploy the corresponding applications', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub();
         const reviewAppExistsStub = sinon.stub().resolves(true);
 
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployUsingSCM: deployUsingSCMStub,
           reviewAppExists: reviewAppExistsStub,
         });
 
         // when
-        const response = await githubController.pullRequestSynchronizeWebhook(request, injectedScalingoClientStub);
+        const response = await githubController.pullRequestSynchronizeWebhook(request, scalingoClientStub);
 
         // then
         expect(deployUsingSCMStub.firstCall.calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
@@ -531,19 +531,16 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
       it('throws an error on scalingo deployment fails', async function () {
         // given
-        const injectedScalingoClientStub = sinon.stub();
+        const scalingoClientStub = sinon.stub();
         const deployUsingSCMStub = sinon.stub().rejects(new Error('Deployment error'));
         const reviewAppExistsStub = sinon.stub().resolves(true);
-        injectedScalingoClientStub.getInstance = sinon.stub().returns({
+        scalingoClientStub.getInstance = sinon.stub().returns({
           deployUsingSCM: deployUsingSCMStub,
           reviewAppExists: reviewAppExistsStub,
         });
 
         // when
-        const result = await catchErr(githubController.pullRequestSynchronizeWebhook)(
-          request,
-          injectedScalingoClientStub,
-        );
+        const result = await catchErr(githubController.pullRequestSynchronizeWebhook)(request, scalingoClientStub);
 
         // then
         expect(result).to.be.instanceOf(Error);
@@ -553,14 +550,14 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       describe('when the review app does not exist', function () {
         it('should call scalingo to create and deploy the corresponding applications', async function () {
           // given
-          const injectedScalingoClientStub = sinon.stub();
+          const scalingoClientStub = sinon.stub();
           const deployUsingSCMStub = sinon.stub();
           const reviewAppExistsStub = sinon.stub().resolves(true);
           reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(false);
           const deployReviewAppStub = sinon.stub();
           const disableAutoDeployStub = sinon.stub();
 
-          injectedScalingoClientStub.getInstance = sinon.stub().returns({
+          scalingoClientStub.getInstance = sinon.stub().returns({
             deployUsingSCM: deployUsingSCMStub,
             reviewAppExists: reviewAppExistsStub,
             deployReviewApp: deployReviewAppStub,
@@ -568,7 +565,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           });
 
           // when
-          const response = await githubController.pullRequestSynchronizeWebhook(request, injectedScalingoClientStub);
+          const response = await githubController.pullRequestSynchronizeWebhook(request, scalingoClientStub);
 
           // then
           expect(deployReviewAppStub.calledOnceWithExactly('pix-api-review', 3)).to.be.true;

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -559,6 +559,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(false);
           const deployReviewAppStub = sinon.stub();
           const disableAutoDeployStub = sinon.stub();
+          const githubServiceStub = sinon.stub();
 
           scalingoClientStub.getInstance = sinon.stub().returns({
             deployUsingSCM: deployUsingSCMStub,
@@ -568,7 +569,11 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           });
 
           // when
-          const response = await githubController.pullRequestSynchronizeWebhook(request, scalingoClientStub);
+          const response = await githubController.pullRequestSynchronizeWebhook(
+            request,
+            scalingoClientStub,
+            githubServiceStub,
+          );
 
           // then
           expect(deployReviewAppStub.calledOnceWithExactly('pix-api-review', 3)).to.be.true;


### PR DESCRIPTION
## :unicorn: Problème
Le controller GitHub qui est chargé de gérer les webhooks provenant de GitHub est compliqué à la lecture car le code est presque semblable, mais n'est pas unifié.

## :robot: Proposition
Unifier le code pour la gestion des RA des Pull Requests.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
- CI OK