### PR TITLE
[FEATURE] Clôturer les review apps depuis Pix Bot (PIX-14712)

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -90,6 +90,10 @@ async function _handleRA(
   return `Triggered deployment of RA on app ${deployedRA.join(', ')} with pr ${prId}`;
 }
 
+async function _handleCloseRA() {
+  throw new Error('Not implemented yet !');
+}
+
 async function deployPullRequest(
   scalingoClient,
   reviewApps,
@@ -185,7 +189,7 @@ async function _pushOnDefaultBranchWebhook(request, scalingoClient = ScalingoCli
 
 async function processWebhook(
   request,
-  { pushOnDefaultBranchWebhook = _pushOnDefaultBranchWebhook, handleRA = _handleRA } = {},
+  { pushOnDefaultBranchWebhook = _pushOnDefaultBranchWebhook, handleRA = _handleRA, handleCloseRA = _handleCloseRA } = {},
 ) {
   const eventName = request.headers['x-github-event'];
   if (eventName === 'push') {
@@ -193,6 +197,9 @@ async function processWebhook(
   } else if (eventName === 'pull_request') {
     if (['opened', 'reopened', 'synchronize'].includes(request.payload.action)) {
       return handleRA(request);
+    }
+    if (request.payload.action === 'closed') {
+      return handleCloseRA(request);
     }
     return `Ignoring ${request.payload.action} action`;
   } else {

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -168,6 +168,18 @@ class ScalingoClient {
       throw new Error(`Aucun autoscaler web trouvé pour l'application '${appname}'`);
     }
   }
+
+  async deleteReviewApp(appName) {
+    if (!appName.includes('review')) {
+      throw new Error('Cannot call deleteReviewApp for a non review app.');
+    }
+
+    try {
+      await this.client.Apps.destroy(appName, appName);
+    } catch (err) {
+      logger.error(err);
+    }
+  }
 }
 
 async function _isUrlReachable(url) {

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -160,6 +160,19 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           expect(handleRA.calledOnceWithExactly(request)).to.be.true;
         });
 
+        it('should call handleCloseRA() method on closed action', async function () {
+          // given
+          sinon.stub(request, 'payload').value({ action: 'closed' });
+
+          const handleCloseRA = sinon.stub();
+
+          // when
+          await githubController.processWebhook(request, { handleCloseRA });
+
+          // then
+          expect(handleCloseRA.calledOnceWithExactly(request)).to.be.true;
+        });
+
         it('should ignore the action', async function () {
           // given
           sinon.stub(request, 'payload').value({ action: 'unhandled-action' });


### PR DESCRIPTION
## :unicorn: Problème
Scalingo ne clôture pas automatiquement toutes les reviews apps lorsqu'une PR est clôturée/mergée.

## :robot: Proposition
Ajouter dans Pix Bot la capacité de clôturer une review app.

## :100: Pour tester
```
curl -X POST -H "x-github-event: pull_request" -H "content-type: application/json" http://localhost:3000/github/webhook -d '{"action":"closed","number":83,"pull_request":{"state":"closed","head":{"repo":{"name":"pix-tutos","fork":false}}}}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:3000...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> POST /github/webhook HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.81.0
> Accept: */*
> x-github-event: pull_request
> content-type: application/json
> Content-Length: 115
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: text/html; charset=utf-8
< cache-control: no-cache
< content-length: 44
< Date: Wed, 09 Oct 2024 14:38:00 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
* Connection #0 to host localhost left intact
Closed RA for PR 83 : pix-tutos-review-pr83.%
```
