### PR TITLE
[BUGFIX] Corriger la suppression des RA pour les repo non gérés par Pix Bot (PIX-14712)

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -95,6 +95,11 @@ async function _handleCloseRA(request, scalingoClient = ScalingoClient) {
   const prId = payload.number;
   const repository = payload.pull_request.head.repo.name;
   const reviewApps = repositoryToScalingoAppsReview[repository];
+
+  if (!reviewApps) {
+    return `${repository} is not managed by Pix Bot.`;
+  }
+
   let client;
   const closedRA = [];
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une PR d'un repo non managé par Pix Bot est clôturée ou mergée, Pix Bot renvoie une erreur 500.

## :robot: Proposition
- Ne pas tenter de clôturer une RA pour un repo qui n'est pas géré par Pix Bot.