### PR TITLE
[TECH] :recycle:  Suppression d'un `await` inutile

### DIFF
--- a/build/services/eco-mode-service.js
+++ b/build/services/eco-mode-service.js
@@ -25,7 +25,7 @@ const ecoModeService = {
       timeZone,
       ignoredReviewApps,
     });
-    await reviewAppManager.startEcoMode();
+    reviewAppManager.startEcoMode();
   },
 };
 


### PR DESCRIPTION
## :unicorn: Problème

Par réflexe, nous ajoutons des `async`/`await` un peu partout, mais certains ne servent à rien.

## :robot: Proposition

Suppression d'un `await` inutile.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
