### PR TITLE
[TECH] Renommer le endpoint /deploy-pix-data-api-pix

### DIFF
--- a/config.js
+++ b/config.js
@@ -154,7 +154,7 @@ const configuration = (function () {
     PIX_TUTOS_APP_NAME: 'pix-tutos',
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',
     PIX_DBT_APPS_NAME: ['pix-dbt-production', 'pix-dbt-external-production'],
-    PIX_DATA_API_PIX_APPS_NAME: ['pix-data-api-pix-production'],
+    PIX_API_TO_PG_APPS_NAME: ['pix-api-to-pg-production'],
 
     repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING) || {},
   };

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -28,12 +28,12 @@ const slack = {
     };
   },
 
-  deployPixDataApiPix(request) {
+  deployPixApiToPg(request) {
     const payload = request.pre.payload;
-    commands.deployPixDataApiPix(payload);
+    commands.deployPixApiToPg(payload);
 
     return {
-      text: _getDeployStartedMessage(payload.text, 'PIX data api pix'),
+      text: _getDeployStartedMessage(payload.text, 'PIX API to PG'),
     };
   },
 

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -132,12 +132,12 @@ manifest.addInteractivity({
 });
 
 manifest.registerSlashCommand({
-  command: '/deploy-pix-data-api-pix',
-  path: '/slack/commands/deploy-pix-data-api-pix',
-  description: 'Déploie la version précisée de pix-data-api-pix en production',
-  usage_hint: '/deploy-pix-data-api-pix $version',
+  command: '/deploy-pix-api-to-pg',
+  path: '/slack/commands/deploy-pix-api-to-pg',
+  description: 'Déploie la version précisée de pix-api-to-pg en production',
+  usage_hint: '/deploy-pix-api-to-pg $version',
   should_escape: false,
-  handler: slackbotController.deployPixDataApiPix,
+  handler: slackbotController.deployPixApiToPg,
 });
 
 export default manifest;

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -223,9 +223,9 @@ async function createAndDeployPixTutosRelease(payload) {
   );
 }
 
-async function deployPixDataApiPix(payload) {
+async function deployPixApiToPg(payload) {
   const version = payload.text;
-  await deployTagUsingSCM(config.PIX_DATA_API_PIX_APPS_NAME, version);
+  await deployTagUsingSCM(config.PIX_API_TO_PG_APPS_NAME, version);
 }
 
 export {
@@ -239,6 +239,6 @@ export {
   createAndDeployPixUI,
   deployAirflow,
   deployDBT,
-  deployPixDataApiPix,
+  deployPixApiToPg,
   getAndDeployLastVersion,
 };

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -121,11 +121,11 @@ describe('Acceptance | Run | Manifest', function () {
               usage_hint: '/deploy-dbt $version',
             },
             {
-              command: '/deploy-pix-data-api-pix',
-              description: 'Déploie la version précisée de pix-data-api-pix en production',
+              command: '/deploy-pix-api-to-pg',
+              description: 'Déploie la version précisée de pix-api-to-pg en production',
               should_escape: false,
-              url: `http://${hostname}/slack/commands/deploy-pix-data-api-pix`,
-              usage_hint: '/deploy-pix-data-api-pix $version',
+              url: `http://${hostname}/slack/commands/deploy-pix-api-to-pg`,
+              usage_hint: '/deploy-pix-api-to-pg $version',
             },
             {
               command: '/deploy-metabase',

--- a/test/acceptance/run/slashcommand_test.js
+++ b/test/acceptance/run/slashcommand_test.js
@@ -153,20 +153,20 @@ describe('Acceptance | Run | SlashCommand', function () {
     });
   });
 
-  describe('POST /slack/commands/deploy-pix-data-api-pix', function () {
-    it('responds with 200 and deploys pix-data-api-pix-production', async function () {
+  describe('POST /slack/commands/deploy-pix-api-to-pg', function () {
+    it('responds with 200 and deploys pix-api-to-pg-production', async function () {
       const body = {
         text: 'v0.0.1',
       };
       const res = await server.inject({
         method: 'POST',
-        url: '/slack/commands/deploy-pix-data-api-pix',
+        url: '/slack/commands/deploy-pix-api-to-pg',
         headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
         payload: body,
       });
       expect(res.statusCode).to.equal(200);
       expect(res.result.text).to.equal(
-        'Commande de déploiement de la release "v0.0.1" pour PIX data api pix en production bien reçue.',
+        'Commande de déploiement de la release "v0.0.1" pour PIX API to PG en production bien reçue.',
       );
     });
 
@@ -176,12 +176,12 @@ describe('Acceptance | Run | SlashCommand', function () {
       };
       nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
       const scalingo = nock('https://scalingo.production')
-        .post(`/v1/apps/pix-data-api-pix-production/scm_repo_link/manual_deploy`, { branch: 'v0.0.1' })
+        .post(`/v1/apps/pix-api-to-pg-production/scm_repo_link/manual_deploy`, { branch: 'v0.0.1' })
         .reply(200, {});
 
       server.inject({
         method: 'POST',
-        url: '/slack/commands/deploy-pix-data-api-pix',
+        url: '/slack/commands/deploy-pix-api-to-pg',
         headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
         payload: body,
       });

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -52,23 +52,23 @@ describe('Integration | Run | Services | Slack | Commands', function () {
     });
   });
 
-  describe('#deployPixDataApiPix', function () {
+  describe('#deployPixApiToPg', function () {
     it('should call Scalingo API to deploy a specified tag', async function () {
       const scalingoTokenNock = nock(`https://auth.scalingo.com`).post('/v1/tokens/exchange').reply(200, {});
-      const pixDataApiPixVersion = 'v0.0.1';
+      const pixApiToPgVersion = 'v0.0.1';
       const deploymentPayload = {
-        branch: pixDataApiPixVersion,
+        branch: pixApiToPgVersion,
       };
 
       const commandPayload = {
-        text: pixDataApiPixVersion,
+        text: pixApiToPgVersion,
       };
 
       const nockCall = nock('https://scalingo.production')
-        .post(`/v1/apps/pix-data-api-pix-production/scm_repo_link/manual_deploy`, deploymentPayload)
+        .post(`/v1/apps/pix-api-to-pg-production/scm_repo_link/manual_deploy`, deploymentPayload)
         .reply(200, {});
 
-      await commands.deployPixDataApiPix(commandPayload);
+      await commands.deployPixApiToPg(commandPayload);
 
       expect(scalingoTokenNock.isDone()).to.be.true;
       expect(nockCall.isDone()).to.be.true;


### PR DESCRIPTION
## :fallen_leaf: Problème
L'application `pix-data-api-pix-production` a été renommée en `pix-api-to-pg-production`. Cependant, le endpoint de déploiement concerne encore l'ancienne application qui n'existe plus.

## :chestnut: Proposition
- Renommer le endpoint `/deploy-pix-data-api-pix` en `/deploy-pix-api-to-pg`
- Déployer l'application `pix-api-to-pg-production` plutôt que `pix-data-api-pix-production`