### PR TITLE
[BUGFIX] Insérer les review-apps en base avant le déploiement de Scalingo

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -166,10 +166,10 @@ async function deployPullRequest(
       if (reviewAppExists) {
         await client.deployUsingSCM(reviewAppName, ref);
       } else {
+        await reviewAppRepository.create({ name: reviewAppName, repository, prNumber: prId, parentApp: appName });
         await client.deployReviewApp(appName, prId);
         await client.disableAutoDeploy(reviewAppName);
         await client.deployUsingSCM(reviewAppName, ref);
-        await reviewAppRepository.create({ name: reviewAppName, repository, prNumber: prId, parentApp: appName });
       }
       deployedRA.push({ name: appName, isCreated: !reviewAppExists });
     } catch (error) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Il arrive parfois que le déploiement d'une review-app chez Scalingo se passe mal (voir cet [exemple](https://app.datadoghq.eu/logs?query=service%3Apix-bot-build-production%20pr10540&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Casc&viz=stream&from_ts=1731403841553&to_ts=1731576641553&live=true)). Or, l'enregistrement d'un déploiement de RA se produit actuellement après les appels à Scalingo et, s'il y a une erreur en amont, cet enregistrement n'est jamais fait.

## :chestnut: Proposition
Insérer les review-apps en base avant le déploiement de Scalingo
