### PR TITLE
[BUGFIX] Mettre à jour le statut d'une RA quand elle est recréée

### DIFF
--- a/build/repository/review-app-repository.js
+++ b/build/repository/review-app-repository.js
@@ -1,7 +1,10 @@
 import { knex } from '../../db/knex-database-connection.js';
 
 export const create = async function ({ name, repository, prNumber, parentApp }) {
-  await knex('review-apps').insert({ name, repository, prNumber, parentApp });
+  await knex('review-apps').insert({ name, repository, prNumber, parentApp }).onConflict('name').merge({
+    createdAt: new Date(),
+    isDeployed: false,
+  });
 };
 
 export const markAsDeployed = async function ({ name }) {


### PR DESCRIPTION
## :fallen_leaf: Problème
Il existe actuellement une contrainte d'unicité sur le nom d'une RA dans la table `review-apps`. Cependant, il arrive parfois qu'une PR nécessite d'être fermée puis rouverte lorsque les addons n'ont pas été bien provisionnés lors du déploiement comme pour la PR [suivante](https://github.com/1024pix/pix/pull/10540). Aujourd'hui, cela cause une erreur car la contrainte est violée.    

## :chestnut: Proposition
Merger une RA plutôt que de renvoyer une erreur quand elle est recrée
