### PR TITLE
[FEAT] Permettre la suppression de RA n'ayant pas "-review-pr" dans leur nom

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -170,8 +170,8 @@ class ScalingoClient {
   }
 
   async deleteReviewApp(appName) {
-    if (!appName.includes('review')) {
-      throw new Error('Cannot call deleteReviewApp for a non review app.');
+    if (!appName.match(/.*-pr\d+/g)) {
+      throw new Error(`Cannot call deleteReviewApp for the non review app ${appName}.`);
     }
 
     try {

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -833,19 +833,18 @@ describe('Scalingo client', function () {
 
         // then
         expect(result).to.be.instanceOf(Error);
-        expect(result.message).to.equal('Cannot call deleteReviewApp for a non review app.');
+        expect(result.message).to.equal('Cannot call deleteReviewApp for the non review app pix-api-production.');
       });
     });
 
-    it('should delete the review app', async function () {
-      // given
-      const appName = 'pix-api-review-pr1';
+    ['pix-api-review-pr1', 'pix-data-api-pix-integration-pr17'].forEach((appName) => {
+      it('should delete the review app', async function () {
+        // when
+        await client.deleteReviewApp(appName);
 
-      // when
-      await client.deleteReviewApp(appName);
-
-      // then
-      expect(clientAppsDestroy).to.have.been.calledWithExactly(appName, appName);
+        // then
+        expect(clientAppsDestroy).to.have.been.calledWithExactly(appName, appName);
+      });
     });
   });
 });


### PR DESCRIPTION
## :fallen_leaf: Problème
Aujourd'hui, Pix Bot est capable de supprimer les RA dont le nom contient "-review-pr". Cependant, certaines RA comme pix-data-api-pix-integration-pr17 ne sont pas issues d'une application "template" contenant le nom "review".

## :chestnut: Proposition
Utiliser une Regex afin d'identifier les RA