### PR TITLE
[FEATURE] Pix-15117 supprimer les RA lors de l'ajout du label no-review-app

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -257,6 +257,14 @@ async function processWebhook(
     if (request.payload.action === 'closed') {
       return handleCloseRA(request);
     }
+    if (request.payload.action === 'labeled') {
+      const labelsList = request.payload.pull_request.labels;
+      if (labelsList.some((label) => label.name == 'no-review-app')) {
+        return handleCloseRA(request);
+      } else {
+        return 'no-review-app label is not set for this PR';
+      }
+    }
     return `Ignoring ${request.payload.action} action`;
   } else {
     return `Ignoring ${eventName} event`;

--- a/test/acceptance/scripts/publish_test.js
+++ b/test/acceptance/scripts/publish_test.js
@@ -47,6 +47,7 @@ describe('Acceptance | Scripts | publish.sh', function () {
       GIT_USER_EMAIL: gitEmail,
       GITHUB_OWNER: githubOwner,
       GITHUB_REPOSITORY: githubRepository,
+      LANG: 'en_US.UTF-8',
     };
 
     // when

--- a/test/acceptance/scripts/release-pix-repo_test.js
+++ b/test/acceptance/scripts/release-pix-repo_test.js
@@ -46,6 +46,7 @@ describe('Acceptance | Scripts | release-pix-repo.sh', function () {
       ...process.env,
       GIT_USER_NAME: gitUser,
       GIT_USER_EMAIL: gitEmail,
+      LANG: 'en_US.UTF-8',
     };
 
     // when


### PR DESCRIPTION
## :fallen_leaf: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
supprimer les RA lors de l'ajout du label no-review-app

## :chestnut: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
Les RAs ne sont pas recréées lors de l'ajout du label. Pour cela il faudra fermer et réouvrir la PR.
Le webhook github ne permet pas pas d'avoir un événement lors du retrait du label no-review-app uniquement.
On a un évènement unlabeled et la liste des labels actuels.

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
