### PR TITLE
[FEAT] Ajouter un webhook permettant de bloquer une ip et/ou un ja3 depuis Baleen

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-import process from 'node:process';
+import 'dotenv/config';
 
 function _getNumber(numberAsString, defaultIntNumber) {
   const number = parseInt(numberAsString, 10);

--- a/config.js
+++ b/config.js
@@ -88,6 +88,7 @@ const configuration = (function () {
       requestSigningSecret: process.env.SLACK_SIGNING_SECRET || 'slack-super-signing-secret',
       botToken: process.env.SLACK_BOT_TOKEN,
       webhookUrlForReporting: process.env.SLACK_WEBHOOK_URL_FOR_REPORTING,
+      blockedAccessesChannel: process.env.SLACK_BLOCKED_ACCESSES_CHANNEL,
     },
 
     github: {
@@ -170,6 +171,8 @@ const configuration = (function () {
     config.baleen.pat = 'baleen-pat';
     config.baleen.appNamespaces = _getJSON('{"Pix_Test":"Pix_Namespace","Pix_Test_2":"Pix Namespace 2"}');
     config.baleen.protectedFrontApps = ['Pix_Test'];
+
+    config.slack.blockedAccessesChannel = 'blocked-accesses-channel';
 
     config.datadog.token = 'token';
 

--- a/config.js
+++ b/config.js
@@ -32,6 +32,7 @@ const configuration = (function () {
       appNamespaces: _getJSON(process.env.BALEEN_APP_NAMESPACES),
       CDNInvalidationRetryCount: _getNumber(process.env.BALEEN_CDN_INVALIDATION_RETRY_COUNT, 3),
       CDNInvalidationRetryDelay: _getNumber(process.env.BALEEN_CDN_INVALIDATION_RETRY_DELAY, 2000),
+      protectedFrontApps: _getJSON(process.env.BALEEN_PROTECTED_FRONT_APPS),
     },
 
     scalingo: {
@@ -109,6 +110,10 @@ const configuration = (function () {
       schedule: process.env.PIX_SITE_DEPLOY_SCHEDULE,
     },
 
+    datadog: {
+      token: process.env.DATADOG_TOKEN,
+    },
+
     tasks: {
       autoScaleEnabled: isFeatureEnabled(process.env.FT_AUTOSCALE_WEB),
       scheduleAutoScaleUp: process.env.SCHEDULE_AUTOSCALE_UP || '* 0 8 * * *',
@@ -164,6 +169,9 @@ const configuration = (function () {
 
     config.baleen.pat = 'baleen-pat';
     config.baleen.appNamespaces = _getJSON('{"Pix_Test":"Pix_Namespace","Pix_Test_2":"Pix Namespace 2"}');
+    config.baleen.protectedFrontApps = ['Pix_Test'];
+
+    config.datadog.token = 'token';
 
     config.github.token = undefined;
     config.github.owner = 'github-owner';

--- a/run/controllers/security.js
+++ b/run/controllers/security.js
@@ -1,0 +1,77 @@
+import Boom from '@hapi/boom';
+
+import { config } from '../../config.js';
+import * as cdnServices from '../services/cdn.js';
+import { logger } from '../../common/services/logger.js';
+import slackPostMessageService from '../../common/services/slack/surfaces/messages/post-message.js';
+import { Attachment, Context, Message, Section } from 'slack-block-builder';
+
+const _buildSlackMessage = function ({ ip, ja3 }) {
+  return {
+    channel: `#${config.slack.blockedAccessesChannel}`,
+    message: 'Règle de blocage mise en place sur Baleen.',
+    attachments: Message()
+      .attachments(
+        Attachment({ color: '#106c1f' })
+          .blocks(
+            Section().fields(`IP`, `${ip}`),
+            Section().fields(`JA3`, `${ja3}`),
+            Context().elements(`At ${new Date().toLocaleString()}`),
+          )
+          .fallback('Règle de blocage mise en place sur Baleen.'),
+      )
+      .buildToObject().attachments,
+  };
+};
+
+const securities = {
+  async blockAccessOnBaleen(request) {
+    if (request.headers.authorization !== config.datadog.token) {
+      return Boom.unauthorized('Token is missing or is incorrect');
+    }
+
+    const { monitorId, body } = request.payload;
+
+    if (!body) {
+      const message = `Inconsistent payload : ${JSON.stringify(request.payload)}.`;
+      logger.warn({
+        event: 'block-access-on-baleen',
+        message,
+      });
+      return Boom.badRequest(message);
+    }
+
+    if (!body.match(/>>(.*)<</)) {
+      const message = `Inconsistent payload : ${body}.`;
+      logger.warn({ event: 'block-access-on-baleen', message });
+      return Boom.badRequest(message);
+    }
+
+    const { ip, ja3 } = JSON.parse(body.match(/>>(.*)<</)[1]);
+
+    if (!ip || ip === '') {
+      const message = 'IP is mandatory.';
+      logger.warn({ event: 'block-access-on-baleen', message });
+      return Boom.badRequest(message);
+    }
+
+    if (!ja3 || ja3 === '') {
+      const message = 'JA3 is mandatory.';
+      logger.warn({ event: 'block-access-on-baleen', message: message });
+      return Boom.badRequest(message);
+    }
+
+    try {
+      const result = await cdnServices.blockAccess({ ip, ja3, monitorId });
+      await slackPostMessageService.postMessage(_buildSlackMessage({ ip, ja3 }));
+      return result;
+    } catch (error) {
+      if (error instanceof cdnServices.NamespaceNotFoundError) {
+        return Boom.badRequest();
+      }
+      return error;
+    }
+  },
+};
+
+export default securities;

--- a/run/routes/security.js
+++ b/run/routes/security.js
@@ -1,0 +1,11 @@
+import securityController from '../controllers/security.js';
+
+const securities = [
+  {
+    method: 'POST',
+    path: '/security/block-access-on-baleen-from-datadog',
+    handler: securityController.blockAccessOnBaleen,
+  },
+];
+
+export default securities;

--- a/sample.env
+++ b/sample.env
@@ -183,6 +183,14 @@ BALEEN_PERSONAL_ACCESS_TOKEN=__CHANGE_ME__
 # default: none
 BALEEN_APP_NAMESPACES={"app-name-1":"namespace-1", "app-name2": "namespace-2"}
 
+# Applications for which we want to add blocking rules
+#
+# presence: required
+# type: array
+# sample = ['namespace-1','namespace-2']
+# default: none
+BALEEN_PROTECTED_FRONT_APPS=["namespace-1","namespace-2"]
+
 # ======================
 # SCALINGO PROD
 # ======================
@@ -430,6 +438,20 @@ SCALINGO_API_URL_INTEGRATION=https://api.osc-fr1.scalingo.com
 # sample : GITHUB_WEBHOOK_SECRET=mnCOwQSifUAB5KGqq2EuGXDkscIZozWlPbwY8DezArjPe
 
 GITHUB_WEBHOOK_SECRET=__CHANGE_ME__
+
+# ======================
+# DATADOG
+# ======================
+
+# Datadog webhook secret
+#
+# Secret used by datadog to notify pix-bot
+#
+# presence: mandatory
+# type: text
+# default: none
+# sample : DATADOG_TOKEN=mnCOwQSifUAB5KGqq2EuGXDkscIZozWlPbwY8DezArjPe
+DATADOG_TOKEN=__CHANGE_ME__
 
 
 # DATABASE Configuration

--- a/sample.env
+++ b/sample.env
@@ -163,6 +163,14 @@ SLACK_BOT_TOKEN=__CHANGE_ME__
 # default: none
 SLACK_WEBHOOK_URL_FOR_REPORTING=__CHANGE_ME__
 
+# Slack "Pix Bot" channel to send baleen blocked accesses
+#
+# Channel name without the # before
+# presence: required
+# type: string
+# default: none
+SLACK_BLOCKED_ACCESSES_CHANNEL=__CHANGE_ME__
+
 # ======================
 # CDN MANAGEMENT
 # ======================

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ import runRoutesApplication from './run/routes/applications.js';
 import deploySitesRoutes from './run/routes/deploy-sites.js';
 import runRoutesManifest from './run/routes/manifest.js';
 import runGitHubRoutes from './run/routes/github.js';
+import runSecurityRoutes from './run/routes/security.js';
 
 const manifests = [runManifest, buildManifest];
 const setupErrorHandling = function (server) {
@@ -40,6 +41,7 @@ server.route(runRoutesApplication);
 server.route(scalingoRoutes);
 server.route(deploySitesRoutes);
 server.route(runGitHubRoutes);
+server.route(runSecurityRoutes);
 
 registerSlashCommands(runDeployConfiguration.deployConfiguration, runManifest);
 

--- a/test/acceptance/run/security_test.js
+++ b/test/acceptance/run/security_test.js
@@ -1,0 +1,138 @@
+import { config } from '../../../config.js';
+import server from '../../../server.js';
+import { expect, nock, sinon } from '../../test-helper.js';
+
+describe('Acceptance | Run | Security', function () {
+  let now;
+  let clock;
+
+  beforeEach(function () {
+    now = new Date('2024-01-01');
+    clock = sinon.useFakeTimers({ now, toFake: ['Date'] });
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('POST /security/block-access-on-baleen-from-datadog', function () {
+    it('responds with 200', async function () {
+      // given
+      const namespace = 'Pix_Namespace';
+      const namespaceKey = 'namespace-key1';
+      const monitorId = '1234';
+      const ip = '127.0.0.1';
+      const ja3 = '9709730930';
+
+      nock('https://console.baleen.cloud/api', {
+        reqheaders: {
+          'X-Api-Key': config.baleen.pat,
+          'Content-type': 'application/json',
+        },
+      })
+        .get('/account')
+        .reply(200, {
+          namespaces: {
+            'namespace-key2': 'Test2',
+            'namespace-key1': namespace,
+          },
+        });
+
+      nock('https://console.baleen.cloud/api', {
+        reqheaders: {
+          'X-Api-Key': config.baleen.pat,
+          'Content-type': 'application/json',
+          Cookie: `baleen-namespace=${namespaceKey}`,
+        },
+      })
+        .post('/configs/custom-static-rules', {
+          category: 'block',
+          name: `Blocage ip: ${ip} ja3: ${ja3}`,
+          description: `Blocage automatique depuis le monitor Datadog ${monitorId}`,
+          enabled: true,
+          labels: ['automatic-rule'],
+          conditions: [
+            [
+              { type: 'ip', operator: 'match', value: ip },
+              { type: 'ja3', operator: 'equals', value: ja3 },
+            ],
+          ],
+        })
+        .reply(200);
+
+      nock('https://slack.com', {
+        reqheaders: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${config.slack.botToken}`,
+        },
+      })
+        .post('/api/chat.postMessage', {
+          channel: `#${config.slack.blockedAccessesChannel}`,
+          text: 'Règle de blocage mise en place sur Baleen.',
+          attachments: [
+            {
+              color: '#106c1f',
+              blocks: [
+                {
+                  fields: [
+                    {
+                      text: 'IP',
+                      type: 'mrkdwn',
+                    },
+                    {
+                      text: `${ip}`,
+                      type: 'mrkdwn',
+                    },
+                  ],
+                  type: 'section',
+                },
+                {
+                  fields: [
+                    {
+                      text: 'JA3',
+                      type: 'mrkdwn',
+                    },
+                    {
+                      text: `${ja3}`,
+                      type: 'mrkdwn',
+                    },
+                  ],
+                  type: 'section',
+                },
+                {
+                  elements: [
+                    {
+                      text: `At ${now.toLocaleString()}`,
+                      type: 'mrkdwn',
+                    },
+                  ],
+                  type: 'context',
+                },
+              ],
+              fallback: 'Règle de blocage mise en place sur Baleen.',
+            },
+          ],
+        })
+        .reply(200, {
+          ok: true,
+        });
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/security/block-access-on-baleen-from-datadog',
+        headers: {
+          Authorization: 'token',
+        },
+        payload: {
+          monitorId,
+          body: `>>{"ip":"${ip}","ja3":"${ja3}"}<<`,
+        },
+      });
+
+      expect(res.statusCode).to.equal(200);
+      expect(res.result).to.eql('Règle de blocage mise en place.');
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/test/unit/run/controllers/security_test.js
+++ b/test/unit/run/controllers/security_test.js
@@ -1,0 +1,155 @@
+import { expect } from '../../../test-helper.js';
+import securityController from '../../../../run/controllers/security.js';
+
+describe('Unit | Run | Controller | Security', function () {
+  describe('#blockAccessOnBaleen', function () {
+    describe('when authorization header does not match', function () {
+      it('should return a 401 Unauthorized', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'wrong-token',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(401);
+        expect(response.message).to.equal('Token is missing or is incorrect');
+      });
+    });
+
+    describe('when there is no body attribute', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('Inconsistent payload : {"monitorId":"1234"}.');
+      });
+    });
+
+    describe('when the body is malformed', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+            body: 'malformed body',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('Inconsistent payload : malformed body.');
+      });
+    });
+
+    describe('when the ip parameter is absent', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+            body: '>>{"ja3":"12345"}<<',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('IP is mandatory.');
+      });
+    });
+
+    describe('when the ip parameter is empty', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+            body: '>>{"ip": "","ja3":"12345"}<<',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('IP is mandatory.');
+      });
+    });
+
+    describe('when the ja3 parameter is absent', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+            body: '>>{"ip":"127.0.0.1"}<<',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('JA3 is mandatory.');
+      });
+    });
+
+    describe('when the ja3 parameter is empty', function () {
+      it('should return a 400 Bad Request', async function () {
+        // given
+        const request = {
+          headers: {
+            authorization: 'token',
+          },
+          payload: {
+            monitorId: '1234',
+            body: '>>{"ip": "127.0.0.1","ja3":""}<<',
+          },
+        };
+
+        // when
+        const response = await securityController.blockAccessOnBaleen(request);
+
+        // then
+        expect(response.output.statusCode).to.equal(400);
+        expect(response.message).to.equal('JA3 is mandatory.');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Il est parfois nécessaire de bloquer une ou plusieurs ip/ja3 dans Baleen. Cependant, cette opération doit actuellement être faite manuellement.

## :gift: Proposition
Ajouter un webhook permettant, depuis Datadog, d'ajouter une ou des règles de blocage d'ip et/ou ja3.
