### PR TITLE
[BUGFIX] Corriger la manière de s'assurer qu'une application est bien une RA

### DIFF
--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -6,6 +6,7 @@ import slackPostMessageService from '../../common/services/slack/surfaces/messag
 import { config } from '../../config.js';
 import * as reviewAppRepository from '../repository/review-app-repository.js';
 import githubService from '../../common/services/github.js';
+import { ScalingoAppName } from '../../common/models/ScalingoAppName.js';
 
 function getSlackMessageAttachments(payload) {
   const appName = payload.app_name;
@@ -90,7 +91,7 @@ const scalingo = {
       return h.response().code(200);
     }
 
-    if (!appName.includes('review-pr')) {
+    if (!ScalingoAppName.isReviewApp(appName)) {
       logger.error({ event, message: `The application ${appName} is not linked to a pull request.` });
       return h.response().code(200);
     }

--- a/common/models/ScalingoAppName.js
+++ b/common/models/ScalingoAppName.js
@@ -2,6 +2,7 @@
 import { config } from '../../config.js';
 const alphanumericAndDashOnly = /^([a-zA-Z0-9]+-)+[a-zA-Z0-9]+$/;
 const prefix = config.scalingo.validAppPrefix;
+
 class ScalingoAppName {
   static isApplicationNameValid(applicationName) {
     const suffix = config.scalingo.validAppSuffix;
@@ -12,6 +13,10 @@ class ScalingoAppName {
     const appNameStartsWithPix = applicationName.startsWith(prefix);
     const appNameEndsWithCorrectSuffix = suffix.includes(applicationName.split('-').slice(-1)[0]);
     return appNameMatchesRegex && appNameHasCorrectLength && appNameStartsWithPix && appNameEndsWithCorrectSuffix;
+  }
+
+  static isReviewApp(applicationName) {
+    return Boolean(applicationName.match(/.*-pr\d+/g));
   }
 }
 

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -3,6 +3,7 @@ import * as scalingo from 'scalingo';
 
 import { config } from '../../config.js';
 import { logger } from './logger.js';
+import { ScalingoAppName } from '../models/ScalingoAppName.js';
 
 const DEFAULT_OPTS = { withEnvSuffix: true };
 
@@ -170,7 +171,7 @@ class ScalingoClient {
   }
 
   async deleteReviewApp(appName) {
-    if (!appName.match(/.*-pr\d+/g)) {
+    if (!ScalingoAppName.isReviewApp(appName)) {
       throw new Error(`Cannot call deleteReviewApp for the non review app ${appName}.`);
     }
 

--- a/test/unit/common/models/ScalingoAppName_test.js
+++ b/test/unit/common/models/ScalingoAppName_test.js
@@ -70,4 +70,22 @@ describe('Unit | Common | Models | ScalingoAppName', function () {
       expect(result).to.be.true;
     });
   });
+
+  describe('#isReviewApp', function () {
+    describe('when the application is not a review app', function () {
+      ['pix-api-production', 'pix-app-recette', 'pix-orga-integration'].forEach((appName) => {
+        it(`should return false for ${appName}`, function () {
+          expect(ScalingoAppName.isReviewApp(appName)).to.be.false;
+        });
+      });
+    });
+
+    describe('when the application is a review app', function () {
+      ['pix-api-review-pr123', 'pix-integration-pr76656'].forEach((appName) => {
+        it(`should return false for ${appName}`, function () {
+          expect(ScalingoAppName.isReviewApp(appName)).to.be.true;
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, pix bot ne sait mettre à jour le check `check-ra-deployment` que pour les applications qui suivent le pattern `review-pr`. Cependant, il existe des review apps qui ne le suivent pas comme celles de pix-db-replication (ex: pix-datawarehouse-integration-pr270)   

## :gift: Proposition
Permettre de gérer le `check-ra-deployment` pour les RA de pix-db-replication.

## :socks: Remarques
J'en ai profité pour uniformiser cette gestion partout dans pix bot.