### PR TITLE
[TECH] Ajouter le déploiement des reviews app de pix-exploit

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -17,6 +17,7 @@ const repositoryToScalingoAppsReview = {
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],
   'pix-epreuves': ['pix-epreuves-review'],
+  'pix-exploit': ['pix-exploit-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],

--- a/build/templates/pull-request-messages/pix-exploit.md
+++ b/build/templates/pull-request-messages/pix-exploit.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-exploit-review-pr{{pullRequestId}}.osc-fr1.scalingo.io
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-review-pr{{pullRequestId}}/environment


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, Scalingo déploie automatiquement les review apps du projet pix-exploit ce qui n'est pas conseillé à cause du risque de sur utilisation du token github.

## :gift: Proposition
Ajouter le déploiement des reviews app de pix-exploit.