### PR TITLE
[BUGFIX] Utiliser octokit pour trigger le dispatch worfklow event

### DIFF
--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -1,12 +1,12 @@
 import { config } from '../../config.js';
 
-const GITHUB_WORKFLOW_DISPATCH_URL = `https://api.github.com/repos/${config.github.automerge.repositoryName}/actions/workflows/${config.github.automerge.workflowId}/dispatches`;
-const GITHUB_WORKFLOW_REF = config.github.automerge.workflowRef;
-
 import * as _pullRequestRepository from '../repositories/pull-request-repository.js';
-import { httpAgent as _httpAgent } from '../../common/http-agent.js';
+import _githubService from '../../common/services/github.js';
 
-export async function mergeQueue({ pullRequestRepository = _pullRequestRepository, httpAgent = _httpAgent } = {}) {
+export async function mergeQueue({
+  pullRequestRepository = _pullRequestRepository,
+  githubService = _githubService,
+} = {}) {
   const isAtLeastOneMergeInProgress = await pullRequestRepository.isAtLeastOneMergeInProgress();
   if (isAtLeastOneMergeInProgress) {
     return;
@@ -21,13 +21,14 @@ export async function mergeQueue({ pullRequestRepository = _pullRequestRepositor
     ...pr,
     isMerging: true,
   });
-  await httpAgent.post({
-    url: GITHUB_WORKFLOW_DISPATCH_URL,
-    payload: {
-      ref: GITHUB_WORKFLOW_REF,
-      inputs: {
-        pullRequest: `${pr.repositoryName}/${pr.number}`,
-      },
+  await githubService.triggerWorkflow({
+    workflow: {
+      id: config.github.automerge.workflowId,
+      repositoryName: config.github.automerge.repositoryName,
+      ref: config.github.automerge.workflowRef,
+    },
+    inputs: {
+      pullRequest: `${pr.repositoryName}/${pr.number}`,
     },
   });
 }

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -489,6 +489,14 @@ const github = {
     });
     return response.status === 204;
   },
+
+  async triggerWorkflow({ workflow, inputs }) {
+    const octokit = _createOctokit();
+    await octokit.request(`POST /repos/${workflow.repositoryName}/actions/workflows/${workflow.id}/dispatches`, {
+      ref: workflow.ref,
+      inputs,
+    });
+  },
 };
 
 export default github;

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -670,4 +670,25 @@ describe('Unit | Build | github-test', function () {
       });
     });
   });
+
+  describe('#triggerWorkflow', function () {
+    it('calls github API', async function () {
+      const workflow = {
+        id: 'lo',
+        repositoryName: 'aName',
+        ref: 'aRef',
+      };
+      const inputs = { pullRequest: 'aName/1234' };
+
+      const githubNock = nock('https://api.github.com')
+        .post(`/repos/${workflow.repositoryName}/actions/workflows/${workflow.id}/dispatches`, {
+          ref: workflow.ref,
+          inputs: inputs,
+        })
+        .reply(200);
+
+      await githubService.triggerWorkflow({ workflow, inputs });
+      expect(githubNock.isDone()).to.be.true;
+    });
+  });
 });

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -31,11 +31,11 @@ describe('Unit | Build | Services | merge-queue', function () {
       pullRequestRepository.isAtLeastOneMergeInProgress.resolves(false);
       pullRequestRepository.getOldest.resolves(pr);
 
-      const httpAgent = {
-        post: sinon.stub(),
+      const githubService = {
+        triggerWorkflow: sinon.stub(),
       };
 
-      await mergeQueue({ pullRequestRepository, httpAgent });
+      await mergeQueue({ pullRequestRepository, githubService });
 
       expect(pullRequestRepository.isAtLeastOneMergeInProgress).to.have.been.called;
       expect(pullRequestRepository.update).to.have.been.calledWithExactly({
@@ -43,9 +43,13 @@ describe('Unit | Build | Services | merge-queue', function () {
         repositoryName: 'foo/pix-project',
         isMerging: true,
       });
-      expect(httpAgent.post).to.have.been.calledWithExactly({
-        url: `https://api.github.com/repos/${config.github.automerge.repositoryName}/actions/workflows/${config.github.automerge.workflowId}/dispatches`,
-        payload: { ref: 'main', inputs: { pullRequest: 'foo/pix-project/1' } },
+      expect(githubService.triggerWorkflow).to.have.been.calledWithExactly({
+        workflow: {
+          id: config.github.automerge.workflowId,
+          repositoryName: config.github.automerge.repositoryName,
+          ref: config.github.automerge.workflowRef,
+        },
+        inputs: { pullRequest: 'foo/pix-project/1' },
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Le dispatch du workflow n'utilisait pas octokit et ne passait pas de token d'auth ce qui avait pour conséquence de ne pas lancer de workflow

## :gift: Proposition

Utiliser la lib octokit pour lancer le worflow

## :socks: Remarques
 ras

## :santa: Pour tester
on testera en mergeant la PR
