### PR TITLE
[BUGFIX] Corriger l'injection de dépendance dans le controller merge

### DIFF
--- a/build/controllers/merge.js
+++ b/build/controllers/merge.js
@@ -1,11 +1,11 @@
-import * as mergeQueue from '../services/merge-queue.js';
+import { mergeQueue } from '../services/merge-queue.js';
 import * as pullRequestRepository from '../repositories/pull-request-repository.js';
 import { config } from '../../config.js';
 import Boom from '@hapi/boom';
 
 const mergeController = {
-  async handle(request, _, dependencies = { mergeQueue, pullRequestRepository }) {
-    const token = request.headers.authorization.replace('Bearer ', '');
+  async handle(request, h, dependencies = { mergeQueue, pullRequestRepository }) {
+    const token = request.headers.authorization?.replace('Bearer ', '');
     if (token !== config.authorizationToken) {
       throw Boom.unauthorized('Token is missing or is incorrect');
     }
@@ -15,6 +15,7 @@ const mergeController = {
     const repositoryName = `${organisation}/${repository}`;
     await dependencies.pullRequestRepository.remove({ number: Number(pullRequestNumber), repositoryName });
     await dependencies.mergeQueue();
+    return h.response().code(204);
   },
 };
 

--- a/test/acceptance/build/merge_test.js
+++ b/test/acceptance/build/merge_test.js
@@ -1,0 +1,47 @@
+import server from '../../../server.js';
+import { expect } from '../../test-helper.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { describe } from 'mocha';
+import { config } from '../../../config.js';
+
+describe('Acceptance | Build | Merge', function () {
+  beforeEach(async function () {
+    await knex('pull_requests').truncate();
+  });
+
+  describe('POST /merge', function () {
+    describe('when user is not authenticated', function () {
+      it('responds with 401', async function () {
+        const body = { pullRequest: '1024pix/pix-test/1' };
+
+        const res = await server.inject({
+          method: 'POST',
+          url: '/merge',
+          payload: body,
+        });
+
+        expect(res.statusCode).to.equal(401);
+      });
+    });
+
+    describe('when user is authenticated', function () {
+      it('responds with 200 and remove PR in database', async function () {
+        await knex('pull_requests').insert({ repositoryName: '1024pix/pix-test', number: 1 });
+        const body = { pullRequest: '1024pix/pix-test/1' };
+
+        const res = await server.inject({
+          method: 'POST',
+          url: '/merge',
+          headers: {
+            Authorization: `Bearer ${config.authorizationToken}`,
+          },
+          payload: body,
+        });
+
+        expect(res.statusCode).to.equal(204);
+        const result = await knex('pull_requests').where({ repositoryName: '1024pix/pix-test', number: 1 }).first();
+        expect(result).to.equal(undefined);
+      });
+    });
+  });
+});

--- a/test/unit/build/controllers/merge_test.js
+++ b/test/unit/build/controllers/merge_test.js
@@ -28,9 +28,13 @@ describe('Unit | Controller | Merge', function () {
 
       const mergeQueue = sinon.stub();
       const pullRequestRepository = { remove: sinon.stub() };
+      const hStub = {
+        response: sinon.stub(),
+      };
+      hStub.response.returns({ code: () => {} });
 
       // when
-      await mergeController.handle(request, {}, { pullRequestRepository, mergeQueue });
+      await mergeController.handle(request, hStub, { pullRequestRepository, mergeQueue });
 
       // then
       expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
@@ -39,6 +43,7 @@ describe('Unit | Controller | Merge', function () {
       });
 
       expect(mergeQueue).to.be.calledOnce;
+      expect(hStub.response).to.be.calledOnce;
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

La fonction mergeQueue est mal importée dans le controller

## :gift: Proposition

Corriger l'import et ajouter un test d'acceptance

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
