### PR TITLE
[FEATURE] Avoir une merge queue par repository

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -261,11 +261,12 @@ async function processWebhook(
       return handleRA(request);
     }
     if (request.payload.action === 'closed') {
+      const repositoryName = request.payload.repository.full_name;
       await pullRequestRepository.remove({
         number: request.payload.number,
-        repositoryName: request.payload.repository.full_name,
+        repositoryName,
       });
-      await mergeQueue();
+      await mergeQueue({ repositoryName });
       return handleCloseRA(request);
     }
     if (request.payload.action === 'labeled' && request.payload.label.name == 'no-review-app') {
@@ -283,24 +284,26 @@ async function processWebhook(
           number: request.payload.number,
           repositoryName,
         });
-        await mergeQueue();
+        await mergeQueue({ repositoryName });
       }
     }
     if (request.payload.action === 'unlabeled' && request.payload.label.name === ':rocket: Ready to Merge') {
+      const repositoryName = request.payload.repository.full_name;
       await pullRequestRepository.remove({
         number: request.payload.number,
-        repositoryName: request.payload.repository.full_name,
+        repositoryName,
       });
-      await mergeQueue();
+      await mergeQueue({ repositoryName });
     }
     return `Ignoring ${request.payload.action} action`;
   } else if (eventName === 'check_suite') {
     if (request.payload.action === 'completed' && request.payload.check_suite.conclusion !== 'success') {
+      const repositoryName = request.payload.repository.full_name;
       await pullRequestRepository.remove({
         number: request.payload.pull_requests[0].number,
-        repositoryName: request.payload.repository.full_name,
+        repositoryName,
       });
-      await mergeQueue();
+      await mergeQueue({ repositoryName });
     }
   } else {
     return `Ignoring ${eventName} event`;

--- a/build/controllers/merge.js
+++ b/build/controllers/merge.js
@@ -14,7 +14,7 @@ const mergeController = {
     const [organisation, repository, pullRequestNumber] = pullRequest.split('/');
     const repositoryName = `${organisation}/${repository}`;
     await dependencies.pullRequestRepository.remove({ number: Number(pullRequestNumber), repositoryName });
-    await dependencies.mergeQueue();
+    await dependencies.mergeQueue({ repositoryName });
     return h.response().code(204);
   },
 };

--- a/build/repositories/pull-request-repository.js
+++ b/build/repositories/pull-request-repository.js
@@ -4,16 +4,16 @@ async function save({ number, repositoryName }) {
   return knex('pull_requests').insert({ number, repositoryName });
 }
 
-async function isAtLeastOneMergeInProgress() {
+async function isAtLeastOneMergeInProgress(repositoryName) {
   const isAtLeastOneMergeInProgress = await knex('pull_requests')
     .select('isMerging')
-    .where({ isMerging: true })
+    .where({ isMerging: true, repositoryName })
     .first();
   return Boolean(isAtLeastOneMergeInProgress);
 }
 
-async function getOldest() {
-  return knex('pull_requests').where({ isMerging: false }).orderBy('createdAt', 'asc').first();
+async function getOldest(repositoryName) {
+  return knex('pull_requests').where({ isMerging: false, repositoryName }).orderBy('createdAt', 'asc').first();
 }
 
 async function update({ number, repositoryName, isMerging }) {

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -4,15 +4,16 @@ import * as _pullRequestRepository from '../repositories/pull-request-repository
 import _githubService from '../../common/services/github.js';
 
 export async function mergeQueue({
+  repositoryName,
   pullRequestRepository = _pullRequestRepository,
   githubService = _githubService,
 } = {}) {
-  const isAtLeastOneMergeInProgress = await pullRequestRepository.isAtLeastOneMergeInProgress();
+  const isAtLeastOneMergeInProgress = await pullRequestRepository.isAtLeastOneMergeInProgress(repositoryName);
   if (isAtLeastOneMergeInProgress) {
     return;
   }
 
-  const pr = await pullRequestRepository.getOldest();
+  const pr = await pullRequestRepository.getOldest(repositoryName);
   if (!pr) {
     return;
   }

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -181,14 +181,15 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             describe('when repo is allowed', function () {
               it('should call pullRequestRepository.save() method', async function () {
                 // given
+                const repositoryName = '1024pix/pix-sample-repo';
                 sinon.stub(config.github, 'automerge').value({
-                  allowedRepositories: ['1024pix/pix-sample-repo'],
+                  allowedRepositories: [repositoryName],
                 });
                 sinon.stub(request, 'payload').value({
                   action: 'labeled',
                   number: 123,
                   label: { name: ':rocket: Ready to Merge' },
-                  repository: { full_name: '1024pix/pix-sample-repo' },
+                  repository: { full_name: repositoryName },
                   sender: {
                     login: 'ouiiiii',
                   },
@@ -205,10 +206,10 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
                 // then
                 expect(pullRequestRepository.save).to.be.calledOnceWithExactly({
                   number: 123,
-                  repositoryName: '1024pix/pix-sample-repo',
+                  repositoryName,
                 });
 
-                expect(mergeQueue).to.be.calledOnce;
+                expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
               });
             });
 
@@ -247,11 +248,12 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           describe('when label is Ready-to-merge', function () {
             it('should call pullRequestRepository.remove() method', async function () {
               // given
+              const repositoryName = '1024pix/pix-sample-repo';
               sinon.stub(request, 'payload').value({
                 action: 'unlabeled',
                 number: 123,
                 label: { name: ':rocket: Ready to Merge' },
-                repository: { full_name: 'pix-sample-repo' },
+                repository: { full_name: repositoryName },
               });
 
               const mergeQueue = sinon.stub();
@@ -263,10 +265,10 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               // then
               expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
                 number: 123,
-                repositoryName: 'pix-sample-repo',
+                repositoryName: repositoryName,
               });
 
-              expect(mergeQueue).to.be.calledOnce;
+              expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
             });
           });
         });
@@ -274,10 +276,11 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         describe('when action is `closed`', function () {
           it('should call pullRequestRepository.remove() method', async function () {
             // given
+            const repositoryName = '1024pix/pix-sample-repo';
             sinon.stub(request, 'payload').value({
               action: 'closed',
               number: 123,
-              repository: { full_name: '1024pix/pix-sample-repo' },
+              repository: { full_name: repositoryName },
             });
 
             const handleCloseRA = sinon.stub();
@@ -290,10 +293,10 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             // then
             expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
               number: 123,
-              repositoryName: '1024pix/pix-sample-repo',
+              repositoryName,
             });
             expect(handleCloseRA.calledOnceWithExactly(request)).to.be.true;
-            expect(mergeQueue).to.be.calledOnce;
+            expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
           });
         });
 
@@ -312,6 +315,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       describe('when event is check_suite', function () {
         describe("when action is 'completed' and conclusion is not 'success'", function () {
           it('should call pullRequestRepository.remove() method', async function () {
+            const repositoryName = '1024pix/pix-sample-repo';
             const request = {
               headers: {
                 'x-github-event': 'check_suite',
@@ -319,7 +323,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               payload: {
                 action: 'completed',
                 pull_requests: [{ number: 123 }],
-                repository: { full_name: 'pix-sample-repo' },
+                repository: { full_name: repositoryName },
                 check_suite: { conclusion: 'failure' },
               },
             };
@@ -333,9 +337,9 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             // then
             expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
               number: 123,
-              repositoryName: 'pix-sample-repo',
+              repositoryName,
             });
-            expect(mergeQueue).to.be.calledOnce;
+            expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
           });
         });
       });

--- a/test/unit/build/controllers/merge_test.js
+++ b/test/unit/build/controllers/merge_test.js
@@ -42,7 +42,7 @@ describe('Unit | Controller | Merge', function () {
         repositoryName: '1024pix/pix',
       });
 
-      expect(mergeQueue).to.be.calledOnce;
+      expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName: '1024pix/pix' });
       expect(hStub.response).to.be.calledOnce;
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous avons une merge queue pour tous les repos de Pix, ce qui peut faire attendre les repos avec peu de PR pour rien car les PR pourraient être mergée de suite. 

## :gift: Proposition

Faire une merge queue par repository.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
