### PR TITLE
[FEATURE] ajoute à la mergequeue lorsque la check_suite se met à jour

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -497,6 +497,12 @@ const github = {
       inputs,
     });
   },
+
+  async isPrLabelledWith({ number, repositoryName, label }) {
+    const octokit = _createOctokit();
+    const { data } = await octokit.request(`GET /repos/${repositoryName}/pulls/${number}`);
+    return data.labels.some((ghLabel) => ghLabel.name === label);
+  },
 };
 
 export default github;

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -691,4 +691,64 @@ describe('Unit | Build | github-test', function () {
       expect(githubNock.isDone()).to.be.true;
     });
   });
+
+  describe('#isPrLabelledWith', function () {
+    let githubNock;
+    const repositoryName = '1024pix/pix';
+    const prNumber = 123;
+
+    beforeEach(function () {
+      const response = {
+        labels: [
+          {
+            id: 123,
+            node_id: 'MDU6TGFiZWwyMDgwNDU5NDY=',
+            url: 'https://api.github.com/repos/octocat/Hello-World/labels/%3Apanda%3A label',
+            name: ':panda: label',
+            description: 'Something is like a panda',
+            color: 'FFFFFF',
+            default: true,
+          },
+          {
+            id: 123,
+            node_id: 'MDU6TGFiZWwyMDgwNDU5NDY=',
+            url: 'https://api.github.com/repos/octocat/Hello-World/labels/working',
+            name: 'working',
+            description: 'Something is working',
+            color: 'f29efef',
+            default: true,
+          },
+        ],
+      };
+      githubNock = nock('https://api.github.com')
+        .get(`/repos/${repositoryName}/pulls/${prNumber}`)
+        .reply(200, response);
+    });
+
+    describe('when PR is labelled with `:panda: label`', function () {
+      it('should return true for :panda: label', async function () {
+        const label = ':panda: label';
+
+        const hasPandaLabel = await githubService.isPrLabelledWith({
+          number: prNumber,
+          repositoryName,
+          label,
+        });
+        expect(hasPandaLabel).to.be.true;
+        expect(githubNock.isDone()).to.be.true;
+      });
+
+      it('should return false for bug', async function () {
+        const label = 'bug';
+
+        const hasBugLabel = await githubService.isPrLabelledWith({
+          number: prNumber,
+          repositoryName,
+          label,
+        });
+        expect(hasBugLabel).to.be.false;
+        expect(githubNock.isDone()).to.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu'on rebase et relance les check d'un PR, il arrive q'un des checks echouent (flaky / problème de déploiement).
On supprime alors la PR de la mergequeue. 
Cela implique de devoir à nouveau passer sur la PR pour supprimer puis ajouter à nouveau le tag `🚀 Ready to Merge` 

## :gift: Proposition

Lorsqu'on recoit un évenement `check_suite` et que le statut est `success` on ajoute de nouveau la PR dans la mergequeue si elle contient le label `:rocket: Ready to Merge`

## :socks: Remarques
RAS
## :santa: Pour tester

