### PR TITLE
[BUGFIX] Corriger le payload attendu lors d'un évènement check_suite.

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -299,20 +299,21 @@ async function processWebhook(
   } else if (eventName === 'check_suite') {
     if (request.payload.action === 'completed') {
       const repositoryName = request.payload.repository.full_name;
+      const prNumber = request.payload.check_suite.pull_requests[0].number;
       if (request.payload.check_suite.conclusion !== 'success') {
         await pullRequestRepository.remove({
-          number: request.payload.pull_requests[0].number,
+          number: prNumber,
           repositoryName,
         });
       } else {
         const hasReadyToMergeLabel = await githubService.isPrLabelledWith({
           repositoryName,
-          number: request.payload.pull_requests[0].number,
+          number: prNumber,
           label: ':rocket: Ready to Merge',
         });
         if (hasReadyToMergeLabel) {
           await pullRequestRepository.save({
-            number: request.payload.pull_requests[0].number,
+            number: prNumber,
             repositoryName,
           });
         }

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -322,9 +322,8 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               },
               payload: {
                 action: 'completed',
-                pull_requests: [{ number: 123 }],
                 repository: { full_name: repositoryName },
-                check_suite: { conclusion: 'failure' },
+                check_suite: { conclusion: 'failure', pull_requests: [{ number: 123 }] },
               },
             };
 
@@ -353,9 +352,8 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               },
               payload: {
                 action: 'completed',
-                pull_requests: [{ number: prNumber }],
                 repository: { full_name: repositoryName },
-                check_suite: { conclusion: 'success' },
+                check_suite: { conclusion: 'success', pull_requests: [{ number: prNumber }] },
               },
             };
 


### PR DESCRIPTION
## :christmas_tree: Problème

Le payload attendu lors d'un appel du webhook github pour l'action `check_suite` n'est pas conforme à [la documentation.](https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_suite), ce qui provoque des erreurs 500.

## :gift: Proposition

Utiliser le bon format

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
