### PR TITLE
[BUGFIX] Eviter les 500 dans le controller GitHub

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -319,7 +319,9 @@ async function processWebhook(
         }
       }
       await mergeQueue({ repositoryName });
+      return `check_suite event handle`;
     }
+    return `Ignoring '${request.payload.action}' action for check_suite event`;
   } else {
     return `Ignoring ${eventName} event`;
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous avons des 500 dans le controller github dans le if correspondant aux events `check_suite`, car Hapi.js souhaite que le controller retourne quelque chose. 

## :gift: Proposition

Ajouter les retours manquants

## :socks: Remarques

D'autres conditions fonctionnent mais utilisent le return `Ignoring action`, ce qui n'est pas génial non plus; 

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
