### PR TITLE
[BUGFIX] Gérer le cas où la check_suite n'est pas liée à une PR.

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -299,6 +299,11 @@ async function processWebhook(
   } else if (eventName === 'check_suite') {
     if (request.payload.action === 'completed') {
       const repositoryName = request.payload.repository.full_name;
+
+      if (request.payload.check_suite.pull_requests.length === 0) {
+        return `check_suite is not related to any pull_request`;
+      }
+
       const prNumber = request.payload.check_suite.pull_requests[0].number;
       if (request.payload.check_suite.conclusion !== 'success') {
         await pullRequestRepository.remove({

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -342,7 +342,24 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           });
         });
 
-        describe("when action is 'completed' and conclusion is'success'", function () {
+        describe("when action is 'completed' and conclusion is 'success'", function () {
+          it('should return ignoring message when not pr are related to check_suite', async function () {
+            const request = {
+              headers: {
+                'x-github-event': 'check_suite',
+              },
+              payload: {
+                action: 'completed',
+                repository: { full_name: '1024pix/pix-test' },
+                check_suite: { conclusion: 'success', pull_requests: [] },
+              },
+            };
+
+            const result = await githubController.processWebhook(request, {});
+
+            expect(result).to.equal('check_suite is not related to any pull_request');
+          });
+
           it('should check PR as Ready to Merge label before saved it', async function () {
             const repositoryName = '1024pix/pix-sample-repo';
             const prNumber = 123;


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nous ne gérons pas le cas où la check_suite n'est pas liée à une PR comme par exemple les tests sur main, ce qui provoque des 500.

## :gift: Proposition

Ajouter un early return pour ce cas.

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
