### PR TITLE
[BUGFIX] Ne pas jetter d'erreur quand la PR est déjà dans la merge queue.

### DIFF
--- a/build/repositories/pull-request-repository.js
+++ b/build/repositories/pull-request-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../db/knex-database-connection.js';
 
 async function save({ number, repositoryName }) {
-  return knex('pull_requests').insert({ number, repositoryName });
+  return knex('pull_requests').insert({ number, repositoryName }).onConflict().ignore();
 }
 
 async function isAtLeastOneMergeInProgress(repositoryName) {

--- a/test/integration/build/repositories/pull-request-repository_test.js
+++ b/test/integration/build/repositories/pull-request-repository_test.js
@@ -23,6 +23,14 @@ describe('PullRequestRepository', function () {
         isMerging: false,
       });
     });
+
+    it('should ignore on conflict', async function () {
+      await pullRequestRepository.save({ number: 123, repositoryName: 'pix-sample-repo' });
+      await pullRequestRepository.save({ number: 123, repositoryName: 'pix-sample-repo' });
+
+      const result = await knex('pull_requests').select().where({ number: 123, repositoryName: 'pix-sample-repo' });
+      expect(result).to.be.lengthOf(1);
+    });
   });
 
   describe('#isAtLeastOneMergeInProgress', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, lorsque la PR est déjà dans la merge queue et qu'on essaie de l'ajouter à nouveau, cela se passe pas bien. 

## :gift: Proposition

Faire en sorte que le repo ne jette pas d'erreur

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
