### PR TITLE
[TECH] Simplifier l'usage de la merge queue

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -249,7 +249,7 @@ async function processWebhook(
     handleRA = _handleRA,
     handleCloseRA = _handleCloseRA,
     pullRequestRepository = _pullRequestRepository,
-    mergeQueue = _mergeQueue,
+    mergeQueue = _mergeQueue.manage,
     githubService = commonGithubService,
   } = {},
 ) {

--- a/build/controllers/merge.js
+++ b/build/controllers/merge.js
@@ -1,10 +1,9 @@
 import { mergeQueue } from '../services/merge-queue.js';
-import * as pullRequestRepository from '../repositories/pull-request-repository.js';
 import { config } from '../../config.js';
 import Boom from '@hapi/boom';
 
 const mergeController = {
-  async handle(request, h, dependencies = { mergeQueue: mergeQueue.manage, pullRequestRepository }) {
+  async handle(request, h, dependencies = { mergeQueue }) {
     const token = request.headers.authorization?.replace('Bearer ', '');
     if (token !== config.authorizationToken) {
       throw Boom.unauthorized('Token is missing or is incorrect');
@@ -13,8 +12,7 @@ const mergeController = {
     const { pullRequest } = request.payload;
     const [organisation, repository, pullRequestNumber] = pullRequest.split('/');
     const repositoryName = `${organisation}/${repository}`;
-    await dependencies.pullRequestRepository.remove({ number: Number(pullRequestNumber), repositoryName });
-    await dependencies.mergeQueue({ repositoryName });
+    await dependencies.mergeQueue.unmanagePullRequest({ repositoryName, number: Number(pullRequestNumber) });
     return h.response().code(204);
   },
 };

--- a/build/controllers/merge.js
+++ b/build/controllers/merge.js
@@ -4,7 +4,7 @@ import { config } from '../../config.js';
 import Boom from '@hapi/boom';
 
 const mergeController = {
-  async handle(request, h, dependencies = { mergeQueue, pullRequestRepository }) {
+  async handle(request, h, dependencies = { mergeQueue: mergeQueue.manage, pullRequestRepository }) {
     const token = request.headers.authorization?.replace('Bearer ', '');
     if (token !== config.authorizationToken) {
       throw Boom.unauthorized('Token is missing or is incorrect');

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -46,6 +46,14 @@ export class MergeQueue {
     });
     await this.manage({ repositoryName });
   }
+
+  async unmanagePullRequest({ repositoryName, number }) {
+    await this.#pullRequestRepository.remove({
+      repositoryName,
+      number,
+    });
+    await this.manage({ repositoryName });
+  }
 }
 
 export const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -38,6 +38,14 @@ export class MergeQueue {
       },
     });
   }
+
+  async managePullRequest({ repositoryName, number }) {
+    await this.#pullRequestRepository.save({
+      repositoryName,
+      number,
+    });
+    await this.manage({ repositoryName });
+  }
 }
 
 export const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -1,35 +1,43 @@
 import { config } from '../../config.js';
 
-import * as _pullRequestRepository from '../repositories/pull-request-repository.js';
-import _githubService from '../../common/services/github.js';
+import * as pullRequestRepository from '../repositories/pull-request-repository.js';
+import githubService from '../../common/services/github.js';
 
-export async function mergeQueue({
-  repositoryName,
-  pullRequestRepository = _pullRequestRepository,
-  githubService = _githubService,
-} = {}) {
-  const isAtLeastOneMergeInProgress = await pullRequestRepository.isAtLeastOneMergeInProgress(repositoryName);
-  if (isAtLeastOneMergeInProgress) {
-    return;
+export class MergeQueue {
+  #pullRequestRepository;
+  #githubService;
+
+  constructor({ pullRequestRepository, githubService }) {
+    this.#pullRequestRepository = pullRequestRepository;
+    this.#githubService = githubService;
   }
 
-  const pr = await pullRequestRepository.getOldest(repositoryName);
-  if (!pr) {
-    return;
-  }
+  async manage({ repositoryName }) {
+    const isAtLeastOneMergeInProgress = await this.#pullRequestRepository.isAtLeastOneMergeInProgress(repositoryName);
+    if (isAtLeastOneMergeInProgress) {
+      return;
+    }
 
-  await pullRequestRepository.update({
-    ...pr,
-    isMerging: true,
-  });
-  await githubService.triggerWorkflow({
-    workflow: {
-      id: config.github.automerge.workflowId,
-      repositoryName: config.github.automerge.repositoryName,
-      ref: config.github.automerge.workflowRef,
-    },
-    inputs: {
-      pullRequest: `${pr.repositoryName}/${pr.number}`,
-    },
-  });
+    const pr = await this.#pullRequestRepository.getOldest(repositoryName);
+    if (!pr) {
+      return;
+    }
+
+    await this.#pullRequestRepository.update({
+      ...pr,
+      isMerging: true,
+    });
+    await this.#githubService.triggerWorkflow({
+      workflow: {
+        id: config.github.automerge.workflowId,
+        repositoryName: config.github.automerge.repositoryName,
+        ref: config.github.automerge.workflowRef,
+      },
+      inputs: {
+        pullRequest: `${pr.repositoryName}/${pr.number}`,
+      },
+    });
+  }
 }
+
+export const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -195,21 +195,18 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
                   },
                 });
 
-                const mergeQueue = sinon.stub();
-                const pullRequestRepository = { save: sinon.stub() };
+                const mergeQueue = { managePullRequest: sinon.stub() };
                 const githubService = { checkUserBelongsToPix: sinon.stub() };
                 githubService.checkUserBelongsToPix.resolves(true);
 
                 // when
-                await githubController.processWebhook(request, { githubService, pullRequestRepository, mergeQueue });
+                await githubController.processWebhook(request, { githubService, mergeQueue });
 
                 // then
-                expect(pullRequestRepository.save).to.be.calledOnceWithExactly({
+                expect(mergeQueue.managePullRequest).to.be.calledOnceWithExactly({
                   number: 123,
                   repositoryName,
                 });
-
-                expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
               });
             });
 
@@ -256,19 +253,16 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
                 repository: { full_name: repositoryName },
               });
 
-              const mergeQueue = sinon.stub();
-              const pullRequestRepository = { remove: sinon.stub() };
+              const mergeQueue = { unmanagePullRequest: sinon.stub() };
 
               // when
-              await githubController.processWebhook(request, { pullRequestRepository, mergeQueue });
+              await githubController.processWebhook(request, { mergeQueue });
 
               // then
-              expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
+              expect(mergeQueue.unmanagePullRequest).to.be.calledOnceWithExactly({
                 number: 123,
                 repositoryName: repositoryName,
               });
-
-              expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
             });
           });
         });
@@ -284,19 +278,17 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
             });
 
             const handleCloseRA = sinon.stub();
-            const mergeQueue = sinon.stub();
-            const pullRequestRepository = { remove: sinon.stub() };
+            const mergeQueue = { unmanagePullRequest: sinon.stub() };
 
             // when
-            await githubController.processWebhook(request, { handleCloseRA, pullRequestRepository, mergeQueue });
+            await githubController.processWebhook(request, { handleCloseRA, mergeQueue });
 
             // then
-            expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
+            expect(mergeQueue.unmanagePullRequest).to.be.calledOnceWithExactly({
               number: 123,
               repositoryName,
             });
             expect(handleCloseRA.calledOnceWithExactly(request)).to.be.true;
-            expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
           });
         });
 
@@ -327,18 +319,16 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               },
             };
 
-            const mergeQueue = sinon.stub();
-            const pullRequestRepository = { remove: sinon.stub() };
+            const mergeQueue = { unmanagePullRequest: sinon.stub() };
 
             // when
-            await githubController.processWebhook(request, { pullRequestRepository, mergeQueue });
+            await githubController.processWebhook(request, { mergeQueue });
 
             // then
-            expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
+            expect(mergeQueue.unmanagePullRequest).to.be.calledOnceWithExactly({
               number: 123,
               repositoryName,
             });
-            expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
           });
         });
 
@@ -374,8 +364,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               },
             };
 
-            const mergeQueue = sinon.stub();
-            const pullRequestRepository = { save: sinon.stub() };
+            const mergeQueue = { managePullRequest: sinon.stub() };
             const githubService = { isPrLabelledWith: sinon.stub() };
 
             githubService.isPrLabelledWith
@@ -387,14 +376,13 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               })
               .resolves(true);
             // when
-            await githubController.processWebhook(request, { githubService, pullRequestRepository, mergeQueue });
+            await githubController.processWebhook(request, { githubService, mergeQueue });
 
             // then
-            expect(pullRequestRepository.save).to.be.calledOnceWithExactly({
+            expect(mergeQueue.managePullRequest).to.be.calledOnceWithExactly({
               number: prNumber,
               repositoryName,
             });
-            expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName });
           });
         });
       });

--- a/test/unit/build/controllers/merge_test.js
+++ b/test/unit/build/controllers/merge_test.js
@@ -26,23 +26,21 @@ describe('Unit | Controller | Merge', function () {
         payload: { pullRequest: '1024pix/pix/123' },
       };
 
-      const mergeQueue = sinon.stub();
-      const pullRequestRepository = { remove: sinon.stub() };
+      const mergeQueue = { unmanagePullRequest: sinon.stub() };
       const hStub = {
         response: sinon.stub(),
       };
       hStub.response.returns({ code: () => {} });
 
       // when
-      await mergeController.handle(request, hStub, { pullRequestRepository, mergeQueue });
+      await mergeController.handle(request, hStub, { mergeQueue });
 
       // then
-      expect(pullRequestRepository.remove).to.be.calledOnceWithExactly({
+      expect(mergeQueue.unmanagePullRequest).to.be.calledOnceWithExactly({
         number: 123,
         repositoryName: '1024pix/pix',
       });
 
-      expect(mergeQueue).to.be.calledOnceWithExactly({ repositoryName: '1024pix/pix' });
       expect(hStub.response).to.be.calledOnce;
     });
   });

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -1,57 +1,59 @@
 import { expect, sinon } from '../../../test-helper.js';
-import { mergeQueue } from '../../../../build/services/merge-queue.js';
+import { MergeQueue } from '../../../../build/services/merge-queue.js';
 import { config } from '../../../../config.js';
 
 describe('Unit | Build | Services | merge-queue', function () {
-  context('when there is PR in merging', function () {
-    it('should do nothing', async function () {
-      const repositoryName = Symbol('repository-name');
-      const pullRequestRepository = {
-        isAtLeastOneMergeInProgress: sinon.stub(),
-      };
-      pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(true);
+  describe('#manage', function() {
+    context('when there is PR in merging', function () {
+      it('should do nothing', async function () {
+        const repositoryName = Symbol('repository-name');
+        const pullRequestRepository = {
+          isAtLeastOneMergeInProgress: sinon.stub(),
+        };
+        pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(true);
 
-      await mergeQueue({ repositoryName, pullRequestRepository });
+        await new MergeQueue({ pullRequestRepository }).manage({ repositoryName });
 
-      expect(pullRequestRepository.isAtLeastOneMergeInProgress).to.have.been.called;
-    });
-  });
-
-  context('when there is no PR in merging', function () {
-    it('should get oldest pull requests, mark as currently merging and trigger auto-merge', async function () {
-      const repositoryName = 'foo/pix-project';
-      const pr = {
-        number: 1,
-        repositoryName,
-        isMerging: false,
-      };
-      const pullRequestRepository = {
-        isAtLeastOneMergeInProgress: sinon.stub(),
-        getOldest: sinon.stub(),
-        update: sinon.stub(),
-      };
-      pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(false);
-      pullRequestRepository.getOldest.withArgs(repositoryName).resolves(pr);
-
-      const githubService = {
-        triggerWorkflow: sinon.stub(),
-      };
-
-      await mergeQueue({ repositoryName, pullRequestRepository, githubService });
-
-      expect(pullRequestRepository.isAtLeastOneMergeInProgress).to.have.been.called;
-      expect(pullRequestRepository.update).to.have.been.calledWithExactly({
-        number: 1,
-        repositoryName: 'foo/pix-project',
-        isMerging: true,
+        expect(pullRequestRepository.isAtLeastOneMergeInProgress).to.have.been.called;
       });
-      expect(githubService.triggerWorkflow).to.have.been.calledWithExactly({
-        workflow: {
-          id: config.github.automerge.workflowId,
-          repositoryName: config.github.automerge.repositoryName,
-          ref: config.github.automerge.workflowRef,
-        },
-        inputs: { pullRequest: 'foo/pix-project/1' },
+    });
+
+    context('when there is no PR in merging', function () {
+      it('should get oldest pull requests, mark as currently merging and trigger auto-merge', async function () {
+        const repositoryName = 'foo/pix-project';
+        const pr = {
+          number: 1,
+          repositoryName,
+          isMerging: false,
+        };
+        const pullRequestRepository = {
+          isAtLeastOneMergeInProgress: sinon.stub(),
+          getOldest: sinon.stub(),
+          update: sinon.stub(),
+        };
+        pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(false);
+        pullRequestRepository.getOldest.withArgs(repositoryName).resolves(pr);
+
+        const githubService = {
+          triggerWorkflow: sinon.stub(),
+        };
+
+        await new MergeQueue({ pullRequestRepository, githubService }).manage({ repositoryName });
+
+        expect(pullRequestRepository.isAtLeastOneMergeInProgress).to.have.been.called;
+        expect(pullRequestRepository.update).to.have.been.calledWithExactly({
+          number: 1,
+          repositoryName: 'foo/pix-project',
+          isMerging: true,
+        });
+        expect(githubService.triggerWorkflow).to.have.been.calledWithExactly({
+          workflow: {
+            id: config.github.automerge.workflowId,
+            repositoryName: config.github.automerge.repositoryName,
+            ref: config.github.automerge.workflowRef,
+          },
+          inputs: { pullRequest: 'foo/pix-project/1' },
+        });
       });
     });
   });

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -79,4 +79,26 @@ describe('Unit | Build | Services | merge-queue', function () {
       expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
     });
   });
+
+  describe('#unmanagePullRequest', function () {
+    it('should remove pr and call manage method', async function () {
+      const repositoryName = Symbol('repository-name');
+      const pullRequestNumber = Symbol('pull-request-number');
+
+      const pullRequestRepository = {
+        remove: sinon.stub(),
+      };
+
+      const mergeQueue = new MergeQueue({ pullRequestRepository });
+      mergeQueue.manage = sinon.stub();
+
+      await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber });
+
+      expect(pullRequestRepository.remove).to.have.been.calledOnceWithExactly({
+        repositoryName,
+        number: pullRequestNumber,
+      });
+      expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
+    });
+  });
 });

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -3,7 +3,7 @@ import { MergeQueue } from '../../../../build/services/merge-queue.js';
 import { config } from '../../../../config.js';
 
 describe('Unit | Build | Services | merge-queue', function () {
-  describe('#manage', function() {
+  describe('#manage', function () {
     context('when there is PR in merging', function () {
       it('should do nothing', async function () {
         const repositoryName = Symbol('repository-name');
@@ -55,6 +55,28 @@ describe('Unit | Build | Services | merge-queue', function () {
           inputs: { pullRequest: 'foo/pix-project/1' },
         });
       });
+    });
+  });
+
+  describe('#managePullRequest', function () {
+    it('should save pr and call manage method', async function () {
+      const repositoryName = Symbol('repository-name');
+      const pullRequestNumber = Symbol('pull-request-number');
+
+      const pullRequestRepository = {
+        save: sinon.stub(),
+      };
+
+      const mergeQueue = new MergeQueue({ pullRequestRepository });
+      mergeQueue.manage = sinon.stub();
+
+      await mergeQueue.managePullRequest({ repositoryName, number: pullRequestNumber });
+
+      expect(pullRequestRepository.save).to.have.been.calledOnceWithExactly({
+        repositoryName,
+        number: pullRequestNumber,
+      });
+      expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

La merge queue fonctionne uniquement si au préalable nous avons ajouté ou supprimé une PR, pour éviter la charge mentale, nous pouvons tout déléguer au service de merge.

## :gift: Proposition

Déléguer l'ajout et la suppression de PR au service de merge.

## :socks: Remarques

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
