### PR TITLE
[FEATURE] Indiquer dans les PRs qu'elles sont en cours de merge

### DIFF
--- a/build/repositories/pull-request-repository.js
+++ b/build/repositories/pull-request-repository.js
@@ -12,8 +12,8 @@ async function isAtLeastOneMergeInProgress(repositoryName) {
   return Boolean(isAtLeastOneMergeInProgress);
 }
 
-async function getOldest(repositoryName) {
-  return knex('pull_requests').where({ isMerging: false, repositoryName }).orderBy('createdAt', 'asc').first();
+async function findNotMerged(repositoryName) {
+  return knex('pull_requests').where({ isMerging: false, repositoryName }).orderBy('createdAt', 'asc');
 }
 
 async function update({ number, repositoryName, isMerging }) {
@@ -24,4 +24,4 @@ async function remove({ number, repositoryName }) {
   await knex('pull_requests').where({ number, repositoryName }).delete();
 }
 
-export { save, isAtLeastOneMergeInProgress, getOldest, update, remove };
+export { save, isAtLeastOneMergeInProgress, findNotMerged, update, remove };

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -38,6 +38,22 @@ export class MergeQueue {
         pullRequest: `${nextMergingPr.repositoryName}/${nextMergingPr.number}`,
       },
     });
+
+    await this.#githubService.setMergeQueueStatus({
+      status: 'pending',
+      description: 'En cours de merge',
+      repositoryFullName: repositoryName,
+      prNumber: pr[0].number,
+    });
+
+    for (let i = 1; i < pr.length; i++) {
+      await this.#githubService.setMergeQueueStatus({
+        status: 'pending',
+        description: `${i + 1}/${pr.length} dans la file d'attente`,
+        repositoryFullName: repositoryName,
+        prNumber: pr[i].number,
+      });
+    }
   }
 
   async managePullRequest({ repositoryName, number }) {

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -682,6 +682,15 @@ describe('Acceptance | Build | Github', function () {
             })
             .reply(200, {});
 
+          const prHeadCommit = 'aaaa';
+          const getPullRequestNock = nock('https://api.github.com')
+            .get(`/repos/1024pix/pix/pulls/123`)
+            .reply(200, { head: { sha: prHeadCommit } });
+
+          const createCheckNock = nock('https://api.github.com')
+            .post(`/repos/${body.repository.full_name}/statuses/${prHeadCommit}`)
+            .reply(201, { started_at: '2024-01-01' });
+
           const response = await server.inject({
             method: 'POST',
             url: '/github/webhook',
@@ -694,6 +703,8 @@ describe('Acceptance | Build | Github', function () {
 
           expect(checkUserBelongsToPixNock.isDone()).to.be.true;
           expect(callGitHubAction.isDone()).to.be.true;
+          expect(getPullRequestNock.isDone()).to.be.true;
+          expect(createCheckNock.isDone()).to.be.true;
           expect(response.statusCode).equal(200);
         });
 
@@ -739,6 +750,16 @@ describe('Acceptance | Build | Github', function () {
               inputs: { pullRequest: `1024pix/pix/${body.number}` },
             })
             .reply(200, {});
+
+          const prHeadCommit = 'aaaa';
+          nock('https://api.github.com')
+            .get(`/repos/1024pix/pix/pulls/123`)
+            .reply(200, { head: { sha: prHeadCommit } })
+            .persist();
+
+          nock('https://api.github.com')
+            .post(`/repos/${body.repository.full_name}/statuses/${prHeadCommit}`)
+            .reply(201, { started_at: '2024-01-01' });
 
           const secondPRForSameRepo = 567;
           const shouldNotBeCalled = nock('https://api.github.com/')

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -36,6 +36,7 @@ describe('Unit | Build | Services | merge-queue', function () {
 
         const githubService = {
           triggerWorkflow: sinon.stub(),
+          setMergeQueueStatus: sinon.stub(),
         };
 
         await new MergeQueue({ pullRequestRepository, githubService }).manage({ repositoryName });
@@ -53,6 +54,50 @@ describe('Unit | Build | Services | merge-queue', function () {
             ref: config.github.automerge.workflowRef,
           },
           inputs: { pullRequest: 'foo/pix-project/1' },
+        });
+      });
+
+      it('should create commit status for each pending pull request', async function () {
+        const repositoryName = 'foo/pix-project';
+        const prs = [
+          {
+            number: 1,
+            repositoryName,
+            isMerging: false,
+          },
+          {
+            number: 2,
+            repositoryName,
+            isMerging: false,
+          },
+        ];
+        const pullRequestRepository = {
+          isAtLeastOneMergeInProgress: sinon.stub(),
+          findNotMerged: sinon.stub(),
+          update: sinon.stub(),
+        };
+        pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(false);
+        pullRequestRepository.findNotMerged.withArgs(repositoryName).resolves(prs);
+
+        const githubService = {
+          triggerWorkflow: sinon.stub(),
+          setMergeQueueStatus: sinon.stub(),
+        };
+
+        await new MergeQueue({ pullRequestRepository, githubService }).manage({ repositoryName });
+
+        expect(githubService.setMergeQueueStatus).to.have.been.calledTwice;
+        expect(githubService.setMergeQueueStatus.firstCall).to.have.been.calledWithExactly({
+          status: 'pending',
+          description: 'En cours de merge',
+          repositoryFullName: repositoryName,
+          prNumber: 1,
+        });
+        expect(githubService.setMergeQueueStatus.secondCall).to.have.been.calledWithExactly({
+          status: 'pending',
+          description: "2/2 dans la file d'attente",
+          repositoryFullName: repositoryName,
+          prNumber: 2,
         });
       });
     });

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -19,7 +19,7 @@ describe('Unit | Build | Services | merge-queue', function () {
     });
 
     context('when there is no PR in merging', function () {
-      it('should get oldest pull requests, mark as currently merging and trigger auto-merge', async function () {
+      it('should find not merged pull requests, mark latest as currently merging and trigger auto-merge', async function () {
         const repositoryName = 'foo/pix-project';
         const pr = {
           number: 1,
@@ -28,11 +28,11 @@ describe('Unit | Build | Services | merge-queue', function () {
         };
         const pullRequestRepository = {
           isAtLeastOneMergeInProgress: sinon.stub(),
-          getOldest: sinon.stub(),
+          findNotMerged: sinon.stub(),
           update: sinon.stub(),
         };
         pullRequestRepository.isAtLeastOneMergeInProgress.withArgs(repositoryName).resolves(false);
-        pullRequestRepository.getOldest.withArgs(repositoryName).resolves(pr);
+        pullRequestRepository.findNotMerged.withArgs(repositoryName).resolves([pr]);
 
         const githubService = {
           triggerWorkflow: sinon.stub(),


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, depuis la gestion de la merge queue par Pix Bot, nous n'avons pas d'information visuelle sur l'état d'avancement de la PR.

## :gift: Proposition

Ajouter un check_status qui se met à jour pour indiquer l'avancement de la PR dans la file, et rassurer les développeurs.## :gift: Proposition

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
