### PR TITLE
[FEATURE] Mettre à jour le check de commit lorsqu'une PR n'est plus managée par la merge queue

### DIFF
--- a/build/controllers/merge.js
+++ b/build/controllers/merge.js
@@ -1,4 +1,4 @@
-import { mergeQueue } from '../services/merge-queue.js';
+import { MERGE_STATUS, mergeQueue } from '../services/merge-queue.js';
 import { config } from '../../config.js';
 import Boom from '@hapi/boom';
 
@@ -12,7 +12,11 @@ const mergeController = {
     const { pullRequest } = request.payload;
     const [organisation, repository, pullRequestNumber] = pullRequest.split('/');
     const repositoryName = `${organisation}/${repository}`;
-    await dependencies.mergeQueue.unmanagePullRequest({ repositoryName, number: Number(pullRequestNumber) });
+    await dependencies.mergeQueue.unmanagePullRequest({
+      repositoryName,
+      number: Number(pullRequestNumber),
+      status: MERGE_STATUS.ERROR,
+    });
     return h.response().code(204);
   },
 };

--- a/build/services/merge-queue.js
+++ b/build/services/merge-queue.js
@@ -3,6 +3,18 @@ import { config } from '../../config.js';
 import * as pullRequestRepository from '../repositories/pull-request-repository.js';
 import githubService from '../../common/services/github.js';
 
+export const MERGE_STATUS = {
+  ABORTED: 'ABORTED',
+  ERROR: 'ERROR',
+  MERGED: 'MERGED',
+};
+
+export const MERGE_STATUS_DETAILS = {
+  ABORTED: { description: 'Merge plus géré', checkStatus: 'success' },
+  ERROR: { description: 'Error, merci de visiter la liste des essais', checkStatus: 'error' },
+  MERGED: { description: '', checkStatus: 'success' },
+};
+
 export class MergeQueue {
   #pullRequestRepository;
   #githubService;
@@ -64,7 +76,15 @@ export class MergeQueue {
     await this.manage({ repositoryName });
   }
 
-  async unmanagePullRequest({ repositoryName, number }) {
+  async unmanagePullRequest({ repositoryName, number, status }) {
+    const statusDetails = MERGE_STATUS_DETAILS[status];
+    await this.#githubService.setMergeQueueStatus({
+      status: statusDetails.checkStatus,
+      description: statusDetails.description,
+      repositoryFullName: repositoryName,
+      prNumber: number,
+    });
+
     await this.#pullRequestRepository.remove({
       repositoryName,
       number,

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -359,7 +359,7 @@ async function _getPullRequestsDetailsByCommitShas({ repoOwner, repoName, commit
   return pullRequestsForCommitShaFilteredDetails;
 }
 
-async function createCommitStatus({ context, repo, pull_number, description, state }) {
+async function createCommitStatus({ context, repo, pull_number, description, state, target_url }) {
   const owner = '1024pix';
   const octokit = _createOctokit();
 
@@ -373,6 +373,7 @@ async function createCommitStatus({ context, repo, pull_number, description, sta
     repo,
     sha,
     state,
+    target_url,
   });
 
   const startedAt = response.data.started_at;
@@ -389,6 +390,7 @@ async function setMergeQueueStatus({ repositoryFullName, prNumber, status, descr
     pull_number: prNumber,
     state: status,
     description,
+    target_url: 'https://github.com/1024pix/pix-actions/actions/workflows/auto-merge-dispatch.yml',
   });
 }
 

--- a/test/acceptance/build/merge_test.js
+++ b/test/acceptance/build/merge_test.js
@@ -1,5 +1,5 @@
 import server from '../../../server.js';
-import { expect } from '../../test-helper.js';
+import { expect, nock } from '../../test-helper.js';
 import { knex } from '../../../db/knex-database-connection.js';
 import { describe } from 'mocha';
 import { config } from '../../../config.js';
@@ -28,6 +28,14 @@ describe('Acceptance | Build | Merge', function () {
       it('responds with 200 and remove PR in database', async function () {
         await knex('pull_requests').insert({ repositoryName: '1024pix/pix-test', number: 1 });
         const body = { pullRequest: '1024pix/pix-test/1' };
+        const prHeadCommit = 'sha1';
+        nock('https://api.github.com')
+          .get('/repos/1024pix/pix-test/pulls/1')
+          .reply(200, { head: { sha: prHeadCommit } });
+
+        nock('https://api.github.com')
+          .post(`/repos/1024pix/pix-test/statuses/${prHeadCommit}`)
+          .reply(201, { started_at: '2024-01-01' });
 
         const res = await server.inject({
           method: 'POST',

--- a/test/unit/build/controllers/merge_test.js
+++ b/test/unit/build/controllers/merge_test.js
@@ -1,6 +1,7 @@
 import { catchErr, expect, sinon } from '../../../test-helper.js';
 import mergeController from '../../../../build/controllers/merge.js';
 import { config } from '../../../../config.js';
+import { MERGE_STATUS } from '../../../../build/services/merge-queue.js';
 
 describe('Unit | Controller | Merge', function () {
   describe('#handle', function () {
@@ -39,6 +40,7 @@ describe('Unit | Controller | Merge', function () {
       expect(mergeQueue.unmanagePullRequest).to.be.calledOnceWithExactly({
         number: 123,
         repositoryName: '1024pix/pix',
+        status: MERGE_STATUS.ERROR,
       });
 
       expect(hStub.response).to.be.calledOnce;

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -621,6 +621,7 @@ describe('Unit | Build | github-test', function () {
           context: 'merge-queue-status',
           state: 'pending',
           description: 'fuu',
+          target_url: 'https://github.com/1024pix/pix-actions/actions/workflows/auto-merge-dispatch.yml',
         };
 
         const createCheckNock = nock('https://api.github.com')

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -150,12 +150,19 @@ describe('Unit | Build | Services | merge-queue', function () {
       expect(githubService.setMergeQueueStatus).to.have.been.calledOnce;
     });
 
-
     const testCases = [
-      { status: MERGE_STATUS.MERGED, checkDescription: MERGE_STATUS_DETAILS.MERGED.description, checkStatus: 'success' },
+      {
+        status: MERGE_STATUS.MERGED,
+        checkDescription: MERGE_STATUS_DETAILS.MERGED.description,
+        checkStatus: 'success',
+      },
       { status: MERGE_STATUS.ERROR, checkDescription: MERGE_STATUS_DETAILS.ERROR.description, checkStatus: 'error' },
-      { status: MERGE_STATUS.ABORTED, checkDescription: MERGE_STATUS_DETAILS.ABORTED.description, checkStatus: 'success' },
-    ]
+      {
+        status: MERGE_STATUS.ABORTED,
+        checkDescription: MERGE_STATUS_DETAILS.ABORTED.description,
+        checkStatus: 'success',
+      },
+    ];
 
     testCases.forEach((testCase) => {
       it(`should update check status when pr status is '${testCase.status}'`, async function () {

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -1,5 +1,5 @@
 import { expect, sinon } from '../../../test-helper.js';
-import { MergeQueue } from '../../../../build/services/merge-queue.js';
+import { MERGE_STATUS, MERGE_STATUS_DETAILS, MergeQueue } from '../../../../build/services/merge-queue.js';
 import { config } from '../../../../config.js';
 
 describe('Unit | Build | Services | merge-queue', function () {
@@ -133,17 +133,58 @@ describe('Unit | Build | Services | merge-queue', function () {
       const pullRequestRepository = {
         remove: sinon.stub(),
       };
+      const githubService = {
+        setMergeQueueStatus: sinon.stub(),
+      };
 
-      const mergeQueue = new MergeQueue({ pullRequestRepository });
+      const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
       mergeQueue.manage = sinon.stub();
 
-      await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber });
+      await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber, status: MERGE_STATUS.ERROR });
 
       expect(pullRequestRepository.remove).to.have.been.calledOnceWithExactly({
         repositoryName,
         number: pullRequestNumber,
       });
       expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
+      expect(githubService.setMergeQueueStatus).to.have.been.calledOnce;
+    });
+
+
+    const testCases = [
+      { status: MERGE_STATUS.MERGED, checkDescription: MERGE_STATUS_DETAILS.MERGED.description, checkStatus: 'success' },
+      { status: MERGE_STATUS.ERROR, checkDescription: MERGE_STATUS_DETAILS.ERROR.description, checkStatus: 'error' },
+      { status: MERGE_STATUS.ABORTED, checkDescription: MERGE_STATUS_DETAILS.ABORTED.description, checkStatus: 'success' },
+    ]
+
+    testCases.forEach((testCase) => {
+      it(`should update check status when pr status is '${testCase.status}'`, async function () {
+        const repositoryName = Symbol('repository-name');
+        const pullRequestNumber = Symbol('pull-request-number');
+
+        const pullRequestRepository = {
+          remove: sinon.stub(),
+        };
+        const githubService = {
+          setMergeQueueStatus: sinon.stub(),
+        };
+
+        const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
+        mergeQueue.manage = sinon.stub();
+
+        await mergeQueue.unmanagePullRequest({
+          repositoryName,
+          number: pullRequestNumber,
+          status: testCase.status,
+        });
+
+        expect(githubService.setMergeQueueStatus).to.have.been.calledOnceWithExactly({
+          status: testCase.checkStatus,
+          repositoryFullName: repositoryName,
+          prNumber: pullRequestNumber,
+          description: testCase.checkDescription,
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, le commit status ne se met pas à jour lorsque la pr est mergée, en échec ou autres.

## :gift: Proposition

Mettre à jour le status 

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
