### PR TITLE
[BUGFIX] Ajouter des checks de commit à propos du status de merge uniquement sur les PR dans la file de merge.

### DIFF
--- a/build/repositories/pull-request-repository.js
+++ b/build/repositories/pull-request-repository.js
@@ -1,5 +1,7 @@
 import { knex } from '../../db/knex-database-connection.js';
 
+class PullRequestNotFoundError extends Error {}
+
 async function save({ number, repositoryName }) {
   return knex('pull_requests').insert({ number, repositoryName }).onConflict().ignore();
 }
@@ -24,4 +26,12 @@ async function remove({ number, repositoryName }) {
   await knex('pull_requests').where({ number, repositoryName }).delete();
 }
 
-export { save, isAtLeastOneMergeInProgress, findNotMerged, update, remove };
+async function get({ number, repositoryName }) {
+  const pullRequest = await knex('pull_requests').where({ number, repositoryName }).first();
+  if (pullRequest === undefined) {
+    throw new PullRequestNotFoundError();
+  }
+  return pullRequest;
+}
+
+export { save, isAtLeastOneMergeInProgress, findNotMerged, update, remove, get, PullRequestNotFoundError };

--- a/test/unit/run/services/merge-queue_test.js
+++ b/test/unit/run/services/merge-queue_test.js
@@ -1,6 +1,8 @@
 import { expect, sinon } from '../../../test-helper.js';
 import { MERGE_STATUS, MERGE_STATUS_DETAILS, MergeQueue } from '../../../../build/services/merge-queue.js';
 import { config } from '../../../../config.js';
+import { PullRequestNotFoundError } from '../../../../build/repositories/pull-request-repository.js';
+import { describe } from 'mocha';
 
 describe('Unit | Build | Services | merge-queue', function () {
   describe('#manage', function () {
@@ -126,46 +128,8 @@ describe('Unit | Build | Services | merge-queue', function () {
   });
 
   describe('#unmanagePullRequest', function () {
-    it('should remove pr and call manage method', async function () {
-      const repositoryName = Symbol('repository-name');
-      const pullRequestNumber = Symbol('pull-request-number');
-
-      const pullRequestRepository = {
-        remove: sinon.stub(),
-      };
-      const githubService = {
-        setMergeQueueStatus: sinon.stub(),
-      };
-
-      const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
-      mergeQueue.manage = sinon.stub();
-
-      await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber, status: MERGE_STATUS.ERROR });
-
-      expect(pullRequestRepository.remove).to.have.been.calledOnceWithExactly({
-        repositoryName,
-        number: pullRequestNumber,
-      });
-      expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
-      expect(githubService.setMergeQueueStatus).to.have.been.calledOnce;
-    });
-
-    const testCases = [
-      {
-        status: MERGE_STATUS.MERGED,
-        checkDescription: MERGE_STATUS_DETAILS.MERGED.description,
-        checkStatus: 'success',
-      },
-      { status: MERGE_STATUS.ERROR, checkDescription: MERGE_STATUS_DETAILS.ERROR.description, checkStatus: 'error' },
-      {
-        status: MERGE_STATUS.ABORTED,
-        checkDescription: MERGE_STATUS_DETAILS.ABORTED.description,
-        checkStatus: 'success',
-      },
-    ];
-
-    testCases.forEach((testCase) => {
-      it(`should update check status when pr status is '${testCase.status}'`, async function () {
+    describe('when pr is not managed', function () {
+      it('should do nothing', async function () {
         const repositoryName = Symbol('repository-name');
         const pullRequestNumber = Symbol('pull-request-number');
 
@@ -177,21 +141,127 @@ describe('Unit | Build | Services | merge-queue', function () {
         };
 
         const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
+        mergeQueue.pullRequestIsManaged = sinon.stub();
         mergeQueue.manage = sinon.stub();
 
-        await mergeQueue.unmanagePullRequest({
+        mergeQueue.pullRequestIsManaged.withArgs({ repositoryName, number: pullRequestNumber }).resolves(false);
+
+        await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber, status: MERGE_STATUS.ERROR });
+
+        expect(pullRequestRepository.remove).to.have.not.been.called;
+        expect(mergeQueue.manage).to.have.not.been.called;
+        expect(githubService.setMergeQueueStatus).to.have.not.been.called;
+      });
+    });
+
+    describe('when pr is managed', function () {
+      it('should remove pr and call manage method', async function () {
+        const repositoryName = Symbol('repository-name');
+        const pullRequestNumber = Symbol('pull-request-number');
+
+        const pullRequestRepository = {
+          remove: sinon.stub(),
+        };
+        const githubService = {
+          setMergeQueueStatus: sinon.stub(),
+        };
+
+        const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
+        mergeQueue.pullRequestIsManaged = sinon.stub();
+        mergeQueue.manage = sinon.stub();
+
+        mergeQueue.pullRequestIsManaged.withArgs({ repositoryName, number: pullRequestNumber }).resolves(true);
+
+        await mergeQueue.unmanagePullRequest({ repositoryName, number: pullRequestNumber, status: MERGE_STATUS.ERROR });
+
+        expect(pullRequestRepository.remove).to.have.been.calledOnceWithExactly({
           repositoryName,
           number: pullRequestNumber,
-          status: testCase.status,
         });
+        expect(mergeQueue.manage).to.have.been.calledOnceWithExactly({ repositoryName });
+        expect(githubService.setMergeQueueStatus).to.have.been.calledOnce;
+      });
 
-        expect(githubService.setMergeQueueStatus).to.have.been.calledOnceWithExactly({
-          status: testCase.checkStatus,
-          repositoryFullName: repositoryName,
-          prNumber: pullRequestNumber,
-          description: testCase.checkDescription,
+      const testCases = [
+        {
+          status: MERGE_STATUS.MERGED,
+          checkDescription: MERGE_STATUS_DETAILS.MERGED.description,
+          checkStatus: 'success',
+        },
+        { status: MERGE_STATUS.ERROR, checkDescription: MERGE_STATUS_DETAILS.ERROR.description, checkStatus: 'error' },
+        {
+          status: MERGE_STATUS.ABORTED,
+          checkDescription: MERGE_STATUS_DETAILS.ABORTED.description,
+          checkStatus: 'success',
+        },
+      ];
+
+      testCases.forEach((testCase) => {
+        it(`should update check status when pr status is '${testCase.status}'`, async function () {
+          const repositoryName = Symbol('repository-name');
+          const pullRequestNumber = Symbol('pull-request-number');
+
+          const pullRequestRepository = {
+            remove: sinon.stub(),
+          };
+          const githubService = {
+            setMergeQueueStatus: sinon.stub(),
+          };
+
+          const mergeQueue = new MergeQueue({ pullRequestRepository, githubService });
+          mergeQueue.pullRequestIsManaged = sinon.stub();
+          mergeQueue.manage = sinon.stub();
+
+          mergeQueue.pullRequestIsManaged.resolves(true);
+
+          await mergeQueue.unmanagePullRequest({
+            repositoryName,
+            number: pullRequestNumber,
+            status: testCase.status,
+          });
+
+          expect(githubService.setMergeQueueStatus).to.have.been.calledOnceWithExactly({
+            status: testCase.checkStatus,
+            repositoryFullName: repositoryName,
+            prNumber: pullRequestNumber,
+            description: testCase.checkDescription,
+          });
         });
       });
+    });
+  });
+
+  describe('#pullRequestIsManaged', function () {
+    it('should return true when pr is managed', async function () {
+      const repositoryName = Symbol('repository-name');
+      const number = Symbol('pull-request-number');
+
+      const pullRequestRepository = {
+        get: sinon.stub(),
+      };
+      pullRequestRepository.get.resolves();
+
+      const mergeQueue = new MergeQueue({ pullRequestRepository });
+
+      const result = await mergeQueue.pullRequestIsManaged({ repositoryName, number });
+
+      expect(result).to.be.true;
+    });
+
+    it('should return false when pr is not managed', async function () {
+      const repositoryName = Symbol('repository-name');
+      const number = Symbol('pull-request-number');
+
+      const pullRequestRepository = {
+        get: sinon.stub(),
+      };
+      pullRequestRepository.get.throws(new PullRequestNotFoundError());
+
+      const mergeQueue = new MergeQueue({ pullRequestRepository });
+
+      const result = await mergeQueue.pullRequestIsManaged({ repositoryName, number });
+
+      expect(result).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, certaines conditions peut nous amener à ajouter un check commit sur une PR alors qu'elle n'a jamais eu la volonté d'être mergée. 

## :gift: Proposition

Ajouter une vérification avant `unmanage` une PR. 

## :socks: Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :santa: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
