### PR TITLE
[FEATURE] Déploiement de maddo à la création/mise à jour des reviews app

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -22,7 +22,7 @@ const repositoryToScalingoAppsReview = {
   'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],
-  pix: ['pix-api-review', 'pix-audit-logger-review', 'pix-front-review'],
+  pix: ['pix-api-review', 'pix-api-maddo-review', 'pix-audit-logger-review', 'pix-front-review'],
   pix4pix: ['pix-4pix-front-review', 'pix-4pix-api-review'],
 };
 

--- a/build/repositories/review-app-repository.js
+++ b/build/repositories/review-app-repository.js
@@ -30,6 +30,10 @@ export const markAsFailed = async function ({ name }) {
 };
 
 export const areAllDeployed = async function ({ repository, prNumber }) {
-  const { count } = await knex('review-apps').count().where({ repository, prNumber, isDeployed: false }).first();
+  const { count } = await knex('review-apps')
+    .count()
+    .where({ repository, prNumber, isDeployed: false })
+    .whereNot('name', 'like', '%maddo%')
+    .first();
   return count === 0;
 };

--- a/common/services/github.js
+++ b/common/services/github.js
@@ -61,7 +61,7 @@ function _createOctokit() {
   octokit.hook.error('request', async (error) => {
     logger.error({
       event: 'github',
-      message: error.response.data,
+      message: error.response?.data,
     });
 
     return error;

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -133,7 +133,7 @@ describe('Acceptance | Build | Github', function () {
           });
           expect(res.statusCode).to.equal(StatusCodes.OK);
           expect(res.result).to.eql(
-            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
+            'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 2',
           );
           expect(scalingoAuth.isDone()).to.be.true;
           expect(scalingoDeploy1.isDone()).to.be.true;
@@ -267,10 +267,12 @@ describe('Acceptance | Build | Github', function () {
         const scalingoRAExists1 = getAppNock({ reviewAppName: 'pix-front-review-pr2' });
         const scalingoRAExists2 = getAppNock({ reviewAppName: 'pix-api-review-pr2' });
         const scalingoRAExists3 = getAppNock({ reviewAppName: 'pix-audit-logger-review-pr2' });
+        const scalingoRAExists4 = getAppNock({ reviewAppName: 'pix-api-maddo-review-pr2' });
 
         const scalingoDeploy1 = getManualDeployNock({ reviewAppName: 'pix-front-review-pr2' });
         const scalingoDeploy2 = getManualDeployNock({ reviewAppName: 'pix-api-review-pr2' });
         const scalingoDeploy3 = getManualDeployNock({ reviewAppName: 'pix-audit-logger-review-pr2' });
+        const scalingoDeploy4 = getManualDeployNock({ reviewAppName: 'pix-api-maddo-review-pr2' });
 
         const getPullRequest = getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'my-sha' });
         const addRADeploymentCheck = addRADeploymentCheckNock({ repository: 'pix', sha: 'my-sha', status: 'pending' });
@@ -286,15 +288,17 @@ describe('Acceptance | Build | Github', function () {
         });
         expect(res.statusCode).to.equal(200);
         expect(res.result).to.eql(
-          'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
+          'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 2',
         );
         expect(scalingoAuth.isDone()).to.be.true;
         expect(scalingoRAExists1.isDone()).to.be.true;
         expect(scalingoRAExists2.isDone()).to.be.true;
         expect(scalingoRAExists3.isDone()).to.be.true;
+        expect(scalingoRAExists4.isDone()).to.be.true;
         expect(scalingoDeploy1.isDone()).to.be.true;
         expect(scalingoDeploy2.isDone()).to.be.true;
         expect(scalingoDeploy3.isDone()).to.be.true;
+        expect(scalingoDeploy4.isDone()).to.be.true;
         expect(getPullRequest.isDone()).to.be.true;
         expect(addRADeploymentCheck.isDone()).to.be.true;
       });
@@ -412,7 +416,7 @@ describe('Acceptance | Build | Github', function () {
 
           expect(res.statusCode).to.equal(200);
           expect(res.result).to.eql(
-            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
+            'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 2',
           );
           expect(scalingoAuth.isDone()).to.be.true;
           expect(scalingoRAExists2.isDone()).to.be.true;
@@ -456,11 +460,14 @@ describe('Acceptance | Build | Github', function () {
 
       describe('when Scalingo deploy API returns an error', function () {
         describe('for every deployment', function () {
-          it('responds with 500 and throws an error', async function () {
+          it('responds with 200', async function () {
             const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(201);
             const scalingoRAExists1 = getAppNock({ reviewAppName: 'pix-front-review-pr2' });
             const scalingoRAExists2 = getAppNock({ reviewAppName: 'pix-api-review-pr2' });
             const scalingoRAExists3 = getAppNock({ reviewAppName: 'pix-audit-logger-review-pr2' });
+            const scalingoRAExists4 = getAppNock({ reviewAppName: 'pix-api-maddo-review-pr2' });
+
+            const getPullRequest = getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'my-sha' });
 
             const scalingoDeploy1 = getManualDeployNock({ reviewAppName: 'pix-front-review-pr2', returnCode: 500 });
             const scalingoDeploy2 = getManualDeployNock({ reviewAppName: 'pix-api-review-pr2', returnCode: 500 });
@@ -468,7 +475,8 @@ describe('Acceptance | Build | Github', function () {
               reviewAppName: 'pix-audit-logger-review-pr2',
               returnCode: 500,
             });
-            addRADeploymentCheckNock({ repo: 'pix', sha: 'my-sha' });
+            const scalingoDeploy4 = getManualDeployNock({ reviewAppName: 'pix-api-maddo-review-pr2', returnCode: 500 });
+            addRADeploymentCheckNock({ repository: 'pix', sha: 'my-sha', status: 'pending' });
 
             const res = await server.inject({
               method: 'POST',
@@ -481,18 +489,21 @@ describe('Acceptance | Build | Github', function () {
             });
 
             expect(scalingoAuth.isDone()).to.be.true;
+
             expect(scalingoRAExists1.isDone()).to.be.true;
             expect(scalingoRAExists2.isDone()).to.be.true;
             expect(scalingoRAExists3.isDone()).to.be.true;
+            expect(scalingoRAExists4.isDone()).to.be.true;
             expect(scalingoDeploy1.isDone()).to.be.true;
             expect(scalingoDeploy2.isDone()).to.be.true;
             expect(scalingoDeploy3.isDone()).to.be.true;
-            expect(res.statusCode).to.equal(500);
-            expect(res.result).to.eql({
-              statusCode: 500,
-              error: 'Internal Server Error',
-              message: 'An internal server error occurred',
-            });
+            expect(scalingoDeploy4.isDone()).to.be.true;
+            expect(getPullRequest.isDone()).to.be.true;
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.eql(
+              'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 2',
+            );
           });
         });
 
@@ -501,12 +512,14 @@ describe('Acceptance | Build | Github', function () {
           const scalingoRAExists1 = getAppNock({ reviewAppName: 'pix-front-review-pr2' });
           const scalingoRAExists2 = getAppNock({ reviewAppName: 'pix-api-review-pr2' });
           const scalingoRAExists3 = getAppNock({ reviewAppName: 'pix-audit-logger-review-pr2' });
+          const scalingoRAExists4 = getAppNock({ reviewAppName: 'pix-api-maddo-review-pr2' });
 
           const scalingoDeploy1 = getManualDeployNock({ reviewAppName: 'pix-front-review-pr2', returnCode: 500 });
           const scalingoDeploy2 = getManualDeployNock({ reviewAppName: 'pix-api-review-pr2' });
           const scalingoDeploy3 = getManualDeployNock({
             reviewAppName: 'pix-audit-logger-review-pr2',
           });
+          const scalingoDeploy4 = getManualDeployNock({ reviewAppName: 'pix-api-maddo-review-pr2' });
           const getPullRequest = getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'my-sha' });
           const addRADeploymentCheck = addRADeploymentCheckNock({
             repository: 'pix',
@@ -528,14 +541,16 @@ describe('Acceptance | Build | Github', function () {
           expect(scalingoRAExists1.isDone()).to.be.true;
           expect(scalingoRAExists2.isDone()).to.be.true;
           expect(scalingoRAExists3.isDone()).to.be.true;
+          expect(scalingoRAExists4.isDone()).to.be.true;
           expect(scalingoDeploy1.isDone()).to.be.true;
           expect(scalingoDeploy2.isDone()).to.be.true;
           expect(scalingoDeploy3.isDone()).to.be.true;
+          expect(scalingoDeploy4.isDone()).to.be.true;
           expect(getPullRequest.isDone()).to.be.true;
           expect(addRADeploymentCheck.isDone()).to.be.true;
           expect(res.statusCode).to.equal(200);
           expect(res.result).to.eql(
-            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 2',
+            'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 2',
           );
         });
       });

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -546,9 +546,11 @@ describe('Acceptance | Build | Github', function () {
         // given
         nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.OK);
         getAppNock({ reviewAppName: 'pix-api-review-pr123', returnCode: StatusCodes.OK });
+        getAppNock({ reviewAppName: 'pix-api-maddo-review-pr123', returnCode: StatusCodes.OK });
         getAppNock({ reviewAppName: 'pix-audit-logger-review-pr123', returnCode: StatusCodes.NOT_FOUND });
         getAppNock({ reviewAppName: 'pix-front-review-pr123', returnCode: StatusCodes.OK });
         deleteReviewAppNock({ reviewAppName: 'pix-api-review-pr123' });
+        deleteReviewAppNock({ reviewAppName: 'pix-api-maddo-review-pr123' });
         deleteReviewAppNock({ reviewAppName: 'pix-audit-logger-review-pr123', returnCode: StatusCodes.NOT_FOUND });
         deleteReviewAppNock({ reviewAppName: 'pix-front-review-pr123' });
 
@@ -585,7 +587,7 @@ describe('Acceptance | Build | Github', function () {
         });
 
         expect(response.payload).to.equal(
-          'Closed RA for PR 123 : pix-api-review-pr123, pix-audit-logger-review-pr123 (already closed), pix-front-review-pr123.',
+          'Closed RA for PR 123 : pix-api-review-pr123, pix-api-maddo-review-pr123, pix-audit-logger-review-pr123 (already closed), pix-front-review-pr123.',
         );
       });
     });

--- a/test/integration/build/repositories/review-app-repository_test.js
+++ b/test/integration/build/repositories/review-app-repository_test.js
@@ -151,6 +151,45 @@ describe('Integration | Build | Repository | Review App', function () {
       expect(areAllDeployed).to.be.true;
     });
 
+    it('should return true when all applications but maddo are deployed', async function () {
+      // given
+      const repository = 'pix';
+      const prNumber = 123;
+
+      await reviewAppRepository.create({
+        name: 'other-repo-review-pr1',
+        repository: 'other-repo',
+        prNumber: 1,
+        parentApp: 'other-repo-review',
+      });
+      await reviewAppRepository.create({
+        name: 'pix-api-review-pr123',
+        repository,
+        prNumber,
+        parentApp: 'pix-api-review',
+      });
+      await reviewAppRepository.markAsDeployed({ name: 'pix-api-review-pr123' });
+      await reviewAppRepository.create({
+        name: 'pix-front-review-pr123',
+        repository,
+        prNumber,
+        parentApp: 'pix-front-review',
+      });
+      await reviewAppRepository.markAsDeployed({ name: 'pix-front-review-pr123' });
+      await reviewAppRepository.create({
+        name: 'pix-api-maddo-review-pr123',
+        repository,
+        prNumber,
+        parentApp: 'pix-api-maddo-review',
+      });
+      await reviewAppRepository.markAsFailed({ name: 'pix-api-maddo-review-pr123' });
+
+      // when
+      const areAllDeployed = await reviewAppRepository.areAllDeployed({ repository, prNumber });
+
+      expect(areAllDeployed).to.be.true;
+    });
+
     it('should return false when not all applications are deployed', async function () {
       // given
       const repository = 'pix';

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -638,19 +638,27 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         );
 
         // then
+        expect(deployReviewAppStub.getCall(1).calledWith('pix-api-maddo-review', 3)).to.be.true;
+        expect(disableAutoDeployStub.getCall(1).calledWith('pix-api-maddo-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.getCall(1).calledWith('pix-api-maddo-review-pr3', 'my-branch')).to.be.true;
 
-        expect(deployReviewAppStub.secondCall.calledWith('pix-audit-logger-review', 3)).to.be.true;
-        expect(disableAutoDeployStub.secondCall.calledWith('pix-audit-logger-review-pr3')).to.be.true;
-        expect(deployUsingSCMStub.secondCall.calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
+        expect(deployReviewAppStub.getCall(2).calledWith('pix-audit-logger-review', 3)).to.be.true;
+        expect(disableAutoDeployStub.getCall(2).calledWith('pix-audit-logger-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.getCall(2).calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
 
-        expect(deployReviewAppStub.thirdCall.calledWith('pix-front-review', 3)).to.be.true;
-        expect(disableAutoDeployStub.thirdCall.calledWith('pix-front-review-pr3')).to.be.true;
-        expect(deployUsingSCMStub.thirdCall.calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
+        expect(deployReviewAppStub.getCall(3).calledWith('pix-front-review', 3)).to.be.true;
+        expect(disableAutoDeployStub.getCall(3).calledWith('pix-front-review-pr3')).to.be.true;
+        expect(deployUsingSCMStub.getCall(3).calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
 
         expect(addMessageToPullRequestStub).to.have.been.calledOnceWithExactly(
           {
             repositoryName: 'pix',
-            scalingoReviewApps: ['pix-api-review', 'pix-audit-logger-review', 'pix-front-review'],
+            scalingoReviewApps: [
+              'pix-api-review',
+              'pix-api-maddo-review',
+              'pix-audit-logger-review',
+              'pix-front-review',
+            ],
             pullRequestId: 3,
           },
           { githubService: githubServiceStub },
@@ -706,12 +714,13 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               parentApp: 'pix-api-review',
             }),
           ).to.be.true;
-          expect(deployUsingSCMStub.firstCall.calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
-          expect(deployUsingSCMStub.secondCall.calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
-          expect(deployUsingSCMStub.thirdCall.calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.getCall(0).calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.getCall(1).calledWith('pix-api-maddo-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.getCall(2).calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
+          expect(deployUsingSCMStub.getCall(3).calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
 
           expect(response).to.equal(
-            'Triggered deployment of RA on app pix-api-review, pix-audit-logger-review, pix-front-review with pr 3',
+            'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 3',
           );
         });
       });
@@ -782,7 +791,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
         // then
         expect(response).to.equal(
-          'Closed RA for PR 3 : pix-api-review-pr3, pix-audit-logger-review-pr3 (already closed), pix-front-review-pr3.',
+          'Closed RA for PR 3 : pix-api-review-pr3, pix-api-maddo-review-pr3 (already closed), pix-audit-logger-review-pr3 (already closed), pix-front-review-pr3.',
         );
       });
     });


### PR DESCRIPTION
## :pancakes: Problème

Maddo a été ajouté à l'infrastructure backend de Pix et il est absent des review apps.

## :bacon: Proposition

Déployer maddo avec l'ensemble des app du mono-repo.

## 🧃 Remarques

Le déploiement de maddo n'est pas bloquant et le `check-ra-deployment` ne tient pas compte de son statut de déploiement. 

## :yum: Pour tester

Faire confiance aux tests du repo, le coût des tests fonctionnels étant très important.
