### PR TITLE
[BUGFIX] Ajouter MaDDo dans le message Github pix-bot

### DIFF
--- a/build/templates/pull-request-messages/pix.md
+++ b/build/templates/pull-request-messages/pix.md
@@ -8,9 +8,11 @@ Une fois les applications déployées, elles seront accessibles via les liens su
   * [Junior](https://junior-pr{{pullRequestId}}.review.pix.fr)
   * [Admin](https://admin-pr{{pullRequestId}}.review.pix.fr)
   * [API](https://api-pr{{pullRequestId}}.review.pix.fr/api/)
+  * [API MaDDo](https://pix-api-maddo-review-pr{{pullRequestId}}.osc-fr1.scalingo.io/api/)
   * [Audit Logger](https://pix-audit-logger-review-pr{{pullRequestId}}.osc-fr1.scalingo.io/api/)
 
 Les variables d'environnement seront accessibles via les liens suivants :
   * [scalingo front](https://dashboard.scalingo.com/apps/osc-fr1/pix-front-review-pr{{pullRequestId}}/environment)
   * [scalingo api](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-review-pr{{pullRequestId}}/environment)
+  * [scalingo api-maddo](https://dashboard.scalingo.com/apps/osc-fr1/pix-api-maddo-review-pr{{pullRequestId}}/environment)
   * [scalingo audit-logger](https://dashboard.scalingo.com/apps/osc-fr1/pix-audit-logger-review-pr{{pullRequestId}}/environment)


### PR DESCRIPTION
## :pancakes: Problème

MaDDo n’apparait pas dans le message posté par PixBot sur les PRs.

## :bacon: Proposition

Ajouter MaDDo dans le template de message.

## 🧃 Remarques

N/A

## :yum: Pour tester

N/A