### PR TITLE
[FEATURE] Donner accès aux statistiques rollup sur les RAs pix-epreuves

### DIFF
--- a/build/templates/pull-request-messages/pix-epreuves.md
+++ b/build/templates/pull-request-messages/pix-epreuves.md
@@ -1,3 +1,4 @@
 Une fois l'application déployée, elle sera accessible aux adresses suivantes :
- - Viewer : https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/
- - Embeds : https://epreuves-pr{{pullRequestId}}.review.pix.fr/viewer.html
+ - [Viewer](https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/)
+ - [Ancien viewer](https://epreuves-pr{{pullRequestId}}.review.pix.fr/viewer.html)
+ - [Stats rollup](https://epreuves-pr{{pullRequestId}}.review.pix.fr/rollup-stats.html)


### PR DESCRIPTION
## :pancakes: Problème

On souhaite donner accès aux stats rollup sur les review apps pix-epreuves.

## :bacon: Proposition

Ajouter un lien vers la page des stats rollup.

## 🧃 Remarques

N/A

## :yum: Pour tester

N/A