### PR TITLE
[FEATURE] Déployer l’application pix-api-maddo-{environment} (PIX-16552)

### DIFF
--- a/config.js
+++ b/config.js
@@ -170,7 +170,7 @@ const configuration = (function () {
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex', 'pix-datawarehouse-data'],
 
-    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api', 'junior', 'audit-logger'],
+    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api', 'api-maddo', 'junior', 'audit-logger'],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
     PIX_TUTOS_REPO_NAME: 'pix-tutos',
     PIX_TUTOS_APP_NAME: 'pix-tutos',

--- a/test/unit/common/services/releases_test.js
+++ b/test/unit/common/services/releases_test.js
@@ -39,7 +39,7 @@ describe('Unit | release', function () {
       // when
       const response = await releasesService.deploy('production', 'v1.0');
       // then
-      expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK', 'OK', 'OK']);
+      expect(response).to.deep.equal(['OK', 'OK', 'OK', 'OK', 'OK', 'OK', 'OK', 'OK']);
     });
 
     it('should ask scalingo to deploy applications', async function () {
@@ -51,13 +51,14 @@ describe('Unit | release', function () {
       // when
       await releasesService.deploy('production', 'v1.0 ');
       // then
-      expect(scalingoClient.deployFromArchive.callCount).to.equal(7);
+      expect(scalingoClient.deployFromArchive.callCount).to.equal(8);
       expect(scalingoClient.deployFromArchive.args).to.deep.equal([
         ['pix-app', 'v1.0'],
         ['pix-certif', 'v1.0'],
         ['pix-admin', 'v1.0'],
         ['pix-orga', 'v1.0'],
         ['pix-api', 'v1.0'],
+        ['pix-api-maddo', 'v1.0'],
         ['pix-junior', 'v1.0'],
         ['pix-audit-logger', 'v1.0'],
       ]);
@@ -73,7 +74,7 @@ describe('Unit | release', function () {
       // when
       await releasesService.deploy('production', tag);
       // then
-      expect(scalingoClient.deployFromArchive.callCount).to.equal(7);
+      expect(scalingoClient.deployFromArchive.callCount).to.equal(8);
       expect(scalingoClient.deployFromArchive.firstCall.args[1]).to.equal('v1.0.0');
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Pix bot gère le déploiement des RAs pix-api-maddo, mais pas le déploiement de pix-api-maddo sur intégration, recette et production.

## :bacon: Proposition

Ajouter api-maddo dans la liste des applications à déployer pour le monorepo.

## 🧃 Remarques

En attente du merge de 1024pix/pix#11354

## :yum: Pour tester

N/A