### PR TITLE
[BUGFIX] Redeployer la dernière version d'une app comportant un tiret dans son nom

### DIFF
--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -42,7 +42,7 @@ const releasesService = {
 
     const results = await Promise.all(
       config.PIX_APPS.map((pixApp) => {
-        return client.deployFromArchive(`pix-${pixApp}`, sanitizedReleaseTag);
+        return client.deployFromArchive(pixApp, sanitizedReleaseTag);
       }),
     );
 

--- a/config.js
+++ b/config.js
@@ -170,7 +170,16 @@ const configuration = (function () {
     PIX_DATAWAREHOUSE_REPO_NAME: 'pix-db-replication',
     PIX_DATAWAREHOUSE_APPS_NAME: ['pix-datawarehouse', 'pix-datawarehouse-ex', 'pix-datawarehouse-data'],
 
-    PIX_APPS: ['app', 'certif', 'admin', 'orga', 'api', 'api-maddo', 'junior', 'audit-logger'],
+    PIX_APPS: [
+      'pix-app',
+      'pix-certif',
+      'pix-admin',
+      'pix-orga',
+      'pix-api',
+      'pix-api-maddo',
+      'pix-junior',
+      'pix-audit-logger',
+    ],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
     PIX_TUTOS_REPO_NAME: 'pix-tutos',
     PIX_TUTOS_APP_NAME: 'pix-tutos',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -112,31 +112,17 @@ async function _getAndDeployLastVersion({ appName }) {
   const lastReleaseTag = await githubServices.getLatestReleaseTag(config.PIX_REPO_NAME);
   const sanitizedAppName = appName.trim().toLowerCase();
 
-  const appNameParts = sanitizedAppName.split('-');
-  const environment = appNameParts[appNameParts.length - 1];
+  const [, shortAppName, environment] = sanitizedAppName.match(/(.*)-(.*)$/);
 
-  if (!_isAppFromPixRepo({ appName: sanitizedAppName })) {
+  if (!_isAppFromPixRepo({ shortAppName, environment })) {
     throw Error('L‘application doit faire partie du repo Pix');
   }
 
-  const shortAppName = appNameParts[0] + '-' + appNameParts[1];
   await releasesService.deployPixRepo(config.PIX_REPO_NAME, shortAppName, lastReleaseTag, environment);
 }
 
-function _isAppFromPixRepo({ appName }) {
-  const appNameParts = appName.split('-');
-
-  if (appNameParts.length != 3) {
-    return false;
-  }
-
-  const [appNamePrefix, shortAppName, environment] = appName.split('-');
-
-  return (
-    appNamePrefix === 'pix' &&
-    config.PIX_APPS.includes(shortAppName) &&
-    config.PIX_APPS_ENVIRONMENTS.includes(environment)
-  );
+function _isAppFromPixRepo({ shortAppName, environment }) {
+  return config.PIX_APPS.includes(shortAppName) && config.PIX_APPS_ENVIRONMENTS.includes(environment);
 }
 
 async function deployTagUsingSCM(appNames, tag) {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -228,13 +228,13 @@ describe('Unit | Run | Services | Slack | Commands', function () {
   describe('#getAndDeployLastVersion', function () {
     it('should redeploy last version of an app', async function () {
       // given
-      const appName = 'pix-admin-integration';
+      const appName = 'pix-api-maddo-integration';
 
       // when
       await getAndDeployLastVersion({ appName });
 
       // then
-      sinon.assert.calledWith(releasesService.deployPixRepo, 'pix', 'pix-admin', 'v1.0.0', 'integration');
+      sinon.assert.calledWith(releasesService.deployPixRepo, 'pix', 'pix-api-maddo', 'v1.0.0', 'integration');
     });
 
     it('should throw an error if appName is incorrect', async function () {


### PR DESCRIPTION
## :pancakes: Problème

La commande `/deploy-last-version` ne fonctionne pas avec applications qui ont un tiret dans leur nom comme `audit-logger` ou `api-maddo`. 

## :bacon: Proposition

Faire en sorte que la création du `shortAppName` fonctionne

## 🧃 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
