### PR TITLE
[BUGFIX] Corriger le fonctionnement du commit status `check-ra-deployment` avec le label `no-review-app`

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -265,7 +265,7 @@ async function processWebhook(
       await mergeQueue.unmanagePullRequest({ repositoryName, number: request.payload.number, status });
       return handleCloseRA(request);
     }
-    if (request.payload.action === 'labeled' && request.payload.label.name == 'no-review-app') {
+    if (request.payload.action === 'labeled' && request.payload.label.name === 'no-review-app') {
       await handleCloseRA(request);
     }
     if (request.payload.action === 'labeled' && request.payload.label.name === ':rocket: Ready to Merge') {

--- a/build/repositories/review-app-repository.js
+++ b/build/repositories/review-app-repository.js
@@ -37,3 +37,7 @@ export const areAllDeployed = async function ({ repository, prNumber }) {
     .first();
   return count === 0;
 };
+
+export const remove = async function ({ name }) {
+  return knex('review-apps').where({ name }).del();
+};

--- a/test/integration/build/repositories/review-app-repository_test.js
+++ b/test/integration/build/repositories/review-app-repository_test.js
@@ -221,4 +221,37 @@ describe('Integration | Build | Repository | Review App', function () {
       expect(areAllDeployed).to.be.false;
     });
   });
+
+  describe('remove', function () {
+    it('it should remove the review app', async function () {
+      // given
+      const name = 'pix-api-review-pr123';
+      const repository = 'pix';
+      const prNumber = 123;
+      const parentApp = 'pix-api-review';
+
+      await reviewAppRepository.create({ name, repository, prNumber, parentApp });
+
+      // when
+      const result = await reviewAppRepository.remove({ name });
+
+      // then
+      expect(result).to.equal(1);
+      const removedReviewApp = await knex('review-apps').where({ name }).first();
+      expect(removedReviewApp).to.be.undefined;
+    });
+
+    describe('when the review-app does not exist', function () {
+      it('it should not throw an exception', async function () {
+        // given
+        const name = 'unknown-review-app';
+
+        // when
+        const result = await reviewAppRepository.remove({ name });
+
+        // then
+        expect(result).to.equal(0);
+      });
+    });
+  });
 });

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -343,7 +343,7 @@ describe('Integration | Build | Scalingo', function () {
 
           const getPullRequestNock = nock('https://api.github.com')
             .get(`/repos/1024pix/${repository}/pulls/${prNumber}`)
-            .reply(201, { head: { sha } });
+            .reply(200, { head: { sha } });
 
           const addRADeploymentCheckNock = nock('https://api.github.com')
             .post(`/repos/1024pix/${repository}/statuses/${sha}`, {
@@ -398,7 +398,7 @@ describe('Integration | Build | Scalingo', function () {
         const sha = 'a-commit-sha';
         const getPullRequestNock = nock('https://api.github.com')
           .get(`/repos/1024pix/${repository}/pulls/${prNumber}`)
-          .reply(201, { head: { sha } });
+          .reply(200, { head: { sha } });
 
         const addRADeploymentCheckNock = nock('https://api.github.com')
           .post(`/repos/1024pix/${repository}/statuses/${sha}`, {


### PR DESCRIPTION
## :pancakes: Problème
Lors de l'ajout du libellé `no-review-app` après création de la PR, les reviews apps sont supprimés. Cependant, le commit status `check-ra-deployment` n'est pas au courant de cette suppression ce qui empêche le merge de la PR. 

## :bacon: Proposition
Supprimer les RA en base de données et mettre à jour le commit status lorsque l'on supprime des RA.