### PR TITLE
[FEATURE] Autoriser ou non les mises en production (PIX-16839)

### DIFF
--- a/common/repositories/release-settings.repository.js
+++ b/common/repositories/release-settings.repository.js
@@ -1,0 +1,20 @@
+import { knex } from '../../db/knex-database-connection.js';
+
+const TABLE_NAME = 'release-settings';
+async function getStatus({ repositoryName, environment = 'production' }) {
+  const result = await knex(TABLE_NAME).where({ repositoryName, environment }).first();
+  return result;
+}
+
+async function updateStatus({ repositoryName, environment, authorizeDeployment, reason = null }) {
+  if (authorizeDeployment) {
+    return await knex(TABLE_NAME)
+      .where({ repositoryName, environment })
+      .update({ authorizeDeployment, blockReason: null, blockDate: null });
+  }
+  await knex(TABLE_NAME)
+    .where({ repositoryName, environment })
+    .update({ authorizeDeployment, blockReason: reason, blockDate: new Date() });
+}
+
+export { getStatus, updateStatus };

--- a/db/migrations/20250305093326_add-release-settings-table.js
+++ b/db/migrations/20250305093326_add-release-settings-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'release-settings';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('repositoryName').notNullable().comment('The name of repository for example pix-mono-repo');
+    table.string('environment').notNullable().comment('The environment of the repository');
+    table.boolean('authorizeDeployment').defaultTo(true).comment('Authorize deployment to the environment');
+    table.string('blockReason').defaultTo(null).comment('The reason why deployment is blocked');
+    table.dateTime('blockDate').comment('The date when deployment was blocked').defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/run/services/slack/shortcuts.js
+++ b/run/services/slack/shortcuts.js
@@ -11,7 +11,8 @@ const shortcuts = {
 
   openViewCreateAppOnScalingoSelectionCallbackId: createAppOnScalingoModal.callbackId,
 
-  openViewDeployReleaseTagSelection(payload) {
+  async openViewDeployReleaseTagSelection(payload) {
+    const data = await deployReleaseTagSelectionModal.getView(payload.trigger_id);
     const options = {
       method: 'POST',
       url: openViewUrl,
@@ -19,7 +20,7 @@ const shortcuts = {
         'content-type': 'application/json',
         authorization: `Bearer ${config.slack.botToken}`,
       },
-      data: deployReleaseTagSelectionModal.getView(payload.trigger_id),
+      data,
     };
     return axios(options);
   },

--- a/test/acceptance/run/slack_test.js
+++ b/test/acceptance/run/slack_test.js
@@ -11,9 +11,15 @@ import {
 import dayjs from 'dayjs';
 import { config } from '../../../config.js';
 import { AutomaticRule } from '../../../run/models/AutomaticRule.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
 describe('Acceptance | Run | Slack', function () {
   describe('POST /run/slack/interactive-endpoint', function () {
+    beforeEach(async function () {
+      await knex('release-settings').delete();
+      await knex('release-settings').insert({ repositoryName: 'pix', environment: 'production' });
+    });
+
     it('responds with 204', async function () {
       const body = {
         type: 'view_closed',

--- a/test/integration/common/repositories/release-settings.repository.test.js
+++ b/test/integration/common/repositories/release-settings.repository.test.js
@@ -1,0 +1,102 @@
+import * as releaseSettingsRepository from '../../../../common/repositories/release-settings.repository.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import { expect, sinon } from '../../../test-helper.js';
+import { describe } from 'mocha';
+
+const TABLE_NAME = 'release-settings';
+describe('integration | repositories | action-active', function () {
+  beforeEach(async function () {
+    await knex(TABLE_NAME).delete();
+  });
+
+  describe('#getStatus', function () {
+    it('should return the status when is ok', async function () {
+      // given
+      const repositoryName = 'repository-name';
+      const environment = 'production';
+      await knex(TABLE_NAME).insert({ repositoryName, environment });
+
+      // when
+      const status = await releaseSettingsRepository.getStatus({ repositoryName, environment });
+
+      // then
+      expect(status).to.deep.equal({
+        repositoryName,
+        environment,
+        authorizeDeployment: true,
+        blockReason: null,
+        blockDate: null,
+      });
+    });
+
+    it('should return the status when is not ok', async function () {
+      // given
+      const repositoryName = 'repository-name';
+      const environment = 'production';
+      const authorizeDeployment = false;
+      const blockReason = 'block-reason';
+      const blockDate = new Date();
+      await knex(TABLE_NAME).insert({ repositoryName, environment, authorizeDeployment, blockReason, blockDate });
+
+      // when
+      const status = await releaseSettingsRepository.getStatus({ repositoryName, environment });
+
+      // then
+      expect(status).to.deep.equal({ repositoryName, environment, authorizeDeployment, blockReason, blockDate });
+    });
+  });
+
+  describe('#updateStatus', () => {
+    it('should update the status of deployment authorization', async function () {
+      // given
+      const repositoryName = 'repository-name';
+      const environment = 'production';
+      const authorizeDeployment = false;
+      const blockReason = 'block-reason';
+      const blockDate = new Date();
+      await knex(TABLE_NAME).insert({ repositoryName, environment, authorizeDeployment, blockReason, blockDate });
+
+      // when
+      await releaseSettingsRepository.updateStatus({ repositoryName, environment, authorizeDeployment: true });
+
+      // then
+      const status = await knex(TABLE_NAME).where({ repositoryName, environment }).first();
+      expect(status).to.deep.equal({
+        repositoryName,
+        environment,
+        authorizeDeployment: true,
+        blockReason: null,
+        blockDate: null,
+      });
+    });
+
+    it('should update status and refuse deployment', async function () {
+      // given
+      // stub Date class
+      const now = new Date();
+      sinon.useFakeTimers(now);
+      const repositoryName = 'repository-name';
+      const environment = 'production';
+      const authorizeDeployment = true;
+      await knex(TABLE_NAME).insert({ repositoryName, environment, authorizeDeployment });
+
+      // when
+      await releaseSettingsRepository.updateStatus({
+        repositoryName,
+        environment,
+        authorizeDeployment: false,
+        reason: 'block-reason',
+      });
+
+      // then
+      const status = await knex(TABLE_NAME).where({ repositoryName, environment }).first();
+      expect(status).to.deep.equal({
+        repositoryName,
+        environment,
+        authorizeDeployment: false,
+        blockReason: 'block-reason',
+        blockDate: new Date(),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

On se dirige vers un système de mep automatique. Or, on a besoin de pouvoir bloquer ces mep à tout moment.

## :bacon: Proposition

- Créer une table avec 4 colones (repositoryName, environment, authorizeDeployment, blockReason),
- Créer un repo,
- Ajuster le service d'envoie de release pour qu'il check si autorizeProd est sur true.

## 🧃 Remarques

Il faudra ensuite rajouter un endpoint pour avoir une commande faisant basculer l'authorisation.

## :yum: Pour tester
#### Lorsque les mep(s) sont autorisées
- Se rendre sur le slack de teste,
- Dans le chanel tech-releases, faire la commande pour déployer une mep /mep/deployer en s'assurant d'utiliser celle marquée avec pix-bot run pr 527,

#### Modifier l'autorisation
- Exécutez ces commandes dans votre terminal pour modifier la valeur d'autorisation:
```shell
scalingo -a pix-bot-review-pr527 psql-console
```
Puis
```sql
UPDATE "release-settings" SET "authorizeDeployment" = false, "blockReason" = 'vous avez réussi!!!!' WHERE "repositoryName" = 'pix';
```

#### Lorsque les mep(s) ne sont pas autorisées
- Se rendre sur le slack de teste dans le chanel tech-releases,
- Exécuter la commande /mep/deployer... en s'assurant qu'il s'agit de celle de pix-bot run pr 527,
- Constater qu'on a un message informant du bloquage avec la raison qu'on a entré en base.