### PR TITLE
[TECH] Renommer `pix-data-api-pix` en `pix-api-to-pg`

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -13,7 +13,7 @@ const repositoryToScalingoAppsReview = {
   'pix-api-data': ['pix-api-data-integration'],
   'pix-bot': ['pix-bot-review'],
   'pix-data': ['pix-airflow-review'],
-  'pix-data-api-pix': ['pix-data-api-pix-integration'],
+  'pix-api-to-pg': ['pix-data-api-pix-integration'],
   'pix-db-replication': ['pix-datawarehouse-integration'],
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],


### PR DESCRIPTION
## :pancakes: Problème
Il y a plusieurs semaines/mois le repository `pix-data-api-pix` a été renommé en `pix-api-to-pg` mais cela n'a pas été effectué dans Pix Bot. Il semblerait que les RA ne soient plus créées depuis.

## :bacon: Proposition
Renommer `pix-data-api-pix` en `pix-api-to-pg`