### PR TITLE
[BUGFIX] Mettre à jour le commit status check-ra-deployment lorsque le label no-review-app est ajouté à la création de la PR.

### DIFF
--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -200,6 +200,9 @@ describe('Acceptance | Build | Github', function () {
 
         it('responds with 200 and do nothing for a pr labelled with no-review-app', async function () {
           body.pull_request.labels = [{ name: 'no-review-app' }];
+          getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'sha' });
+          addRADeploymentCheckNock({ repository: 'pix', sha: 'sha', status: 'success' });
+
           const res = await server.inject({
             method: 'POST',
             url: '/github/webhook',
@@ -211,6 +214,7 @@ describe('Acceptance | Build | Github', function () {
           });
           expect(res.statusCode).to.equal(200);
           expect(res.result).to.eql('RA disabled for this PR');
+          expect(nock.isDone());
         });
 
         describe('when Scalingo API client throws an error', function () {
@@ -367,8 +371,11 @@ describe('Acceptance | Build | Github', function () {
         expect(res.result).to.eql('Ignoring edited action');
       });
 
-      it('responds with 200 and do nothing for a pr labelled with no-review-app', async function () {
+      it('responds with 200 and update check-ra-deployment for a pr labelled with no-review-app', async function () {
         body.pull_request.labels = [{ name: 'no-review-app' }];
+        getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'sha' });
+        addRADeploymentCheckNock({ repository: 'pix', sha: 'sha', status: 'success' });
+
         const res = await server.inject({
           method: 'POST',
           url: '/github/webhook',
@@ -380,6 +387,7 @@ describe('Acceptance | Build | Github', function () {
         });
         expect(res.statusCode).to.equal(200);
         expect(res.result).to.eql('RA disabled for this PR');
+        expect(nock.isDone());
       });
 
       describe('when RA does not already exist', function () {

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -579,16 +579,19 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       });
 
       describe('when there is a no-review-app label on the PR', function () {
-        it('should not create a Review App', async function () {
+        it('should not create a Review App and update check-ra-deployment check', async function () {
           // given
-          request.payload.label = { name: 'no-review-app' };
           sinon.stub(request.payload.pull_request, 'labels').value([{ name: 'no-review-app' }]);
+          const githubServiceMock = { addRADeploymentCheck: sinon.stub() };
 
           // when
-          const response = await githubController.handleRA(request);
+          const response = await githubController.handleRA(request, null, null, githubServiceMock);
 
           // then
           expect(response).to.equal('RA disabled for this PR');
+          expect(
+            githubServiceMock.addRADeploymentCheck.calledWith({ repository: 'pix', prNumber: 3, status: 'success' }),
+          ).to.be.true;
         });
       });
 


### PR DESCRIPTION
## :pancakes: Problème
Lorsque le label `no-review-app` est ajouté à la création de la PR, github envoie l'event `pull_request` avec l'action 'opened'. Dans le traitement qui est effectué, nous ne faisons rien si le label `no-review-app` est présent. Cependant, nous ne mettons pas à jour le commit status `check-ra-deployment` ce qui bloque le merge de la PR.   

## :bacon: Proposition
Mettre à jour le commit status `check-ra-deployment` lorsque le label `no-review-app` est ajouté à la création de la PR.