### PR TITLE
[TECH] Ajouter pix-exploit-front-review et renommer pix-exploit-review

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -18,7 +18,7 @@ const repositoryToScalingoAppsReview = {
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],
   'pix-epreuves': ['pix-epreuves-review'],
-  'pix-exploit': ['pix-exploit-review'],
+  'pix-exploit': ['pix-exploit-api-review', 'pix-exploit-front-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],


### PR DESCRIPTION
## :pancakes: Problème
Nous avons besoin d'ajouter une application front à pix-exploit.

## :bacon: Proposition
Ajouter pix-exploit-front-review et renommer pix-exploit-review en pix-exploit-api-review