### PR TITLE
[BUGFIX] Ajouter les liens des variables d'environnement pour les pr de pix exploit (PIX-17107)

### DIFF
--- a/build/templates/pull-request-messages/pix-exploit.md
+++ b/build/templates/pull-request-messages/pix-exploit.md
@@ -1,4 +1,6 @@
 Une fois les applications déployées, elles seront accessible via:
 - [L'interface](https://pix-exploit-front-review-pr{{pullRequestId}}.osc-fr1.scalingo.io),
 - [L'api](https://pix-exploit-api-review-pr{{pullRequestId}}.osc-fr1.scalingo.io)
-Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-review-pr{{pullRequestId}}/environment
+Les variables d'environnement seront accessibles sur scalingo sur:
+- [L'interface](https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-front-review-pr{{pullRequestId}}/environment)
+- [L'api](https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-api-review-pr{{pullRequestId}}/environment)


### PR DESCRIPTION
## :pancakes: Problème

On a oublié de mettre les liens vers les variables d'environnement de Pix exploit dans les templates de RA.

## :bacon: Proposition

On les rajoutes!!!!
## 🧃 Remarques

RAS