### PR TITLE
[REVERT] Revenir à l'ancien template pour Pix exploit

### DIFF
--- a/build/templates/pull-request-messages/pix-exploit.md
+++ b/build/templates/pull-request-messages/pix-exploit.md
@@ -1,4 +1,2 @@
-Une fois les applications déployées, elles seront accessible via:
-- [L'interface](https://pix-exploit-front-review-pr{{pullRequestId}}.osc-fr1.scalingo.io),
-- [L'api](https://pix-exploit-api-review-pr{{pullRequestId}}.osc-fr1.scalingo.io)
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-exploit-review-pr{{pullRequestId}}.osc-fr1.scalingo.io
 Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-review-pr{{pullRequestId}}/environment

--- a/build/templates/pull-request-messages/pix-exploit.md
+++ b/build/templates/pull-request-messages/pix-exploit.md
@@ -1,6 +1,4 @@
 Une fois les applications déployées, elles seront accessible via:
 - [L'interface](https://pix-exploit-front-review-pr{{pullRequestId}}.osc-fr1.scalingo.io),
 - [L'api](https://pix-exploit-api-review-pr{{pullRequestId}}.osc-fr1.scalingo.io)
-Les variables d'environnement seront accessibles sur scalingo sur:
-- [L'interface](https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-front-review-pr{{pullRequestId}}/environment)
-- [L'api](https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-api-review-pr{{pullRequestId}}/environment)
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-exploit-review-pr{{pullRequestId}}/environment


### PR DESCRIPTION
## 🌸 Problème

On avait modifié le template de Pix exploit pour inclure les liens vers les applications back et front. Or, on a décidé de tout mettre dans une seule application. Cela ne présente donc plus d'intérêt d'avoir plusieurs liens.

## 🌳 Proposition

Revert les 2 commits faisant les modifications.