### PR TITLE
[FEATURE] pix-epreuves: Lien vers le viewer de composants

### DIFF
--- a/build/templates/pull-request-messages/pix-epreuves.md
+++ b/build/templates/pull-request-messages/pix-epreuves.md
@@ -1,4 +1,5 @@
 Une fois l'application déployée, elle sera accessible aux adresses suivantes :
  - [Viewer](https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/)
+ - [Viewer de composants](https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/components/)
  - [Ancien viewer](https://epreuves-pr{{pullRequestId}}.review.pix.fr/viewer.html)
  - [Stats rollup](https://epreuves-pr{{pullRequestId}}.review.pix.fr/rollup-stats.html)


### PR DESCRIPTION
## 🌸 Problème

On a ajouté un viewer de composants, mais le commentaire de PR ne contient pas de lien vers ce viewer.

## 🌳 Proposition

Ajouter un lien.

## 🐝 Remarques

N/A

## 🤧 Pour tester

N/A