### PR TITLE
[FEATURE] Utiliser le nouveau nom de domaine du viewer pix-epreuves

### DIFF
--- a/build/templates/pull-request-messages/pix-epreuves.md
+++ b/build/templates/pull-request-messages/pix-epreuves.md
@@ -1,5 +1,5 @@
 Une fois l'application déployée, elle sera accessible aux adresses suivantes :
- - [Viewer](https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/)
- - [Viewer de composants](https://epreuves-viewer.review.pix.fr/pr{{pullRequestId}}/components/)
+ - [Viewer](https://epreuves-viewer.pix.digital/pr{{pullRequestId}}/)
+ - [Viewer de composants](https://epreuves-viewer.pix.digital/pr{{pullRequestId}}/components/)
  - [Ancien viewer](https://epreuves-pr{{pullRequestId}}.review.pix.fr/viewer.html)
  - [Stats rollup](https://epreuves-pr{{pullRequestId}}.review.pix.fr/rollup-stats.html)


### PR DESCRIPTION
## 🌸 Problème

Le viewer d’épreuves a changé de nom de domaine.

## 🌳 Proposition

Mettre à jour le nom de domaine dans le template de commentaire de PR pix-epreuves.

## 🐝 Remarques

N/A

## 🤧 Pour tester

N/A
