### PR TITLE
[FEATURE]: Ajouter une commande slack de release et de déploiement pour l'application pix-securix.

### DIFF
--- a/config.js
+++ b/config.js
@@ -182,6 +182,8 @@ const configuration = (function () {
       'pix-audit-logger',
     ],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
+    PIX_SECURIX_REPO_NAME: 'securix',
+    PIX_SECURIX_APP_NAME: 'pix-securix-production',
     PIX_TUTOS_REPO_NAME: 'pix-tutos',
     PIX_TUTOS_APP_NAME: 'pix-tutos',
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -84,6 +84,15 @@ const slack = {
     };
   },
 
+  createAndDeployPixSecurixRelease(request) {
+    const payload = request.pre.payload;
+    commands.createAndDeployPixSecurixRelease(payload);
+
+    return {
+      text: _getDeployStartedMessage(payload.text, 'PIX Securix'),
+    };
+  },
+
   createAndDeployPixTutosRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixTutosRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -86,6 +86,15 @@ manifest.registerSlashCommand({
 });
 
 manifest.registerSlashCommand({
+  command: '/deploy-pix-securix',
+  path: '/slack/commands/create-and-deploy-pix-securix-release',
+  description: 'Créer une release de Pix Securix',
+  usage_hint: '[patch, minor, major]',
+  should_escape: false,
+  handler: slackbotController.createAndDeployPixSecurixRelease,
+});
+
+manifest.registerSlashCommand({
   command: '/deploy-airflow',
   path: '/slack/commands/deploy-airflow',
   description: 'Déploie la version précisée de Airflow en production',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -210,6 +210,15 @@ async function createAndDeployPixTutosRelease(payload) {
   );
 }
 
+async function createAndDeployPixSecurixRelease(payload) {
+  await _publishAndDeployRelease(
+    config.PIX_SECURIX_REPO_NAME,
+    [config.PIX_SECURIX_APP_NAME],
+    payload.text,
+    payload.response_url,
+  );
+}
+
 async function deployPixApiToPg(payload) {
   const version = payload.text;
   await deployTagUsingSCM(config.PIX_API_TO_PG_APPS_NAME, version);
@@ -231,6 +240,7 @@ export {
   createAndDeployPixLCMS,
   createAndDeployPixSiteRelease,
   createAndDeployPixTutosRelease,
+  createAndDeployPixSecurixRelease,
   createAndDeployPixUI,
   deployAirflow,
   deployDBT,

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -106,6 +106,13 @@ describe('Acceptance | Run | Manifest', function () {
               usage_hint: '[patch, minor, major]',
             },
             {
+              command: '/deploy-pix-securix',
+              description: 'Créer une release de Pix Securix',
+              should_escape: false,
+              url: `http://${hostname}/slack/commands/create-and-deploy-pix-securix-release`,
+              usage_hint: '[patch, minor, major]',
+            },
+            {
               command: '/deploy-airflow',
               description: 'Déploie la version précisée de Airflow en production',
               should_escape: false,

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -13,6 +13,7 @@ import {
   createAndDeployPixLCMS,
   createAndDeployPixSiteRelease,
   createAndDeployPixTutosRelease,
+  createAndDeployPixSecurixRelease,
   createAndDeployPixUI,
   getAndDeployLastVersion,
 } from '../../../../../run/services/slack/commands.js';
@@ -290,6 +291,25 @@ describe('Unit | Run | Services | Slack | Commands', function () {
     it('should publish a new release', function () {
       // then
       sinon.assert.calledWith(releasesService.publishPixRepo, 'pix-tutos', 'minor');
+    });
+
+    it('should deploy the release', function () {
+      // then
+      sinon.assert.calledWith(releasesService.deployPixRepo);
+    });
+  });
+
+  describe('#createAndDeployPixSecurixRelease', function () {
+    beforeEach(async function () {
+      // given
+      const payload = { text: 'minor' };
+      // when
+      await createAndDeployPixSecurixRelease(payload);
+    });
+
+    it('should publish a new release', function () {
+      // then
+      sinon.assert.calledWith(releasesService.publishPixRepo, 'securix', 'minor');
     });
 
     it('should deploy the release', function () {


### PR DESCRIPTION
## 🌸 Problème
Actuellement, il n'y a pas de solution simple pour déployer l'application pix-securix-production.

## 🌳 Proposition
Configurer une commande slack qui permette de créer la release et déployer l'application pix-secruix-production dans la foulée

## 🐝 Remarques


## 🤧 Pour tester

