### PR TITLE
[BUGFIX] Corriger le déploiement de securix

### DIFF
--- a/config.js
+++ b/config.js
@@ -183,7 +183,7 @@ const configuration = (function () {
     ],
     PIX_APPS_ENVIRONMENTS: ['integration', 'recette', 'production'],
     PIX_SECURIX_REPO_NAME: 'securix',
-    PIX_SECURIX_APP_NAME: 'pix-securix-production',
+    PIX_SECURIX_APP_NAME: 'pix-securix',
     PIX_TUTOS_REPO_NAME: 'pix-tutos',
     PIX_TUTOS_APP_NAME: 'pix-tutos',
     PIX_AIRFLOW_APP_NAME: 'pix-airflow-production',


### PR DESCRIPTION
## 🌸 Problème
Actuellement, le déploiement de securix en production définit l'application cible comme pix-securix-production. Cependent, le suffixe -production est ajouté en dur dans la méthode de déploiement. 

## 🌳 Proposition
- Retirer le suffixe -production dans la configuration car il sera rajouté par le code.