### PR TITLE
[FEATURE] Permettre au webhook de release de déployer sur osc-fr1

### DIFF
--- a/run/controllers/github.js
+++ b/run/controllers/github.js
@@ -26,9 +26,11 @@ async function releaseWebhook(request, repoAppMapping = config.repoAppNames, inj
 }
 
 async function deployFromArchive(appNames, tag, repository, scalingoClient) {
-  const client = await scalingoClient.getInstance('production');
   return Promise.all(
-    appNames.map((appName) => {
+    appNames.map(async (appName) => {
+      const appNameFragment = appName.split('-');
+      const instance = appNameFragment[appNameFragment.length - 1];
+      const client = await scalingoClient.getInstance(instance);
       return client.deployFromArchive(appName, tag, repository, { withEnvSuffix: false });
     }),
   );

--- a/test/unit/run/controllers/github_test.js
+++ b/test/unit/run/controllers/github_test.js
@@ -60,7 +60,7 @@ describe('Unit | Run | Controller | Github', function () {
   });
 
   describe('#releaseWebhook', function () {
-    context('when repo is handle', function () {
+    context('when repo is handled', function () {
       it('should deploy release', async function () {
         // given
         const request = {
@@ -77,28 +77,34 @@ describe('Unit | Run | Controller | Github', function () {
         };
         const deployFromArchive = sinon.stub();
         const injectedConfigurationRepoAppMapping = {
-          'pix-repo-test': ['pix-app-name-production', 'pix-app-name-2-production'],
+          'pix-repo-test': ['pix-app-name-production', 'pix-app-name-2-production', 'pix-app-name-recette'],
         };
         const injectedScalingoClientStub = {
-          getInstance: () => ({
+          getInstance: sinon.spy(() => ({
             deployFromArchive,
-          }),
+          })),
         };
 
         // when
         await githubController.releaseWebhook(request, injectedConfigurationRepoAppMapping, injectedScalingoClientStub);
 
         // then
+        expect(injectedScalingoClientStub.getInstance.firstCall).to.be.calledWith('production');
         expect(deployFromArchive.firstCall).to.be.calledWith('pix-app-name-production', 'v0.1.0', 'pix-repo-test', {
           withEnvSuffix: false,
         });
+        expect(injectedScalingoClientStub.getInstance.secondCall).to.be.calledWith('production');
         expect(deployFromArchive.secondCall).to.be.calledWith('pix-app-name-2-production', 'v0.1.0', 'pix-repo-test', {
+          withEnvSuffix: false,
+        });
+        expect(injectedScalingoClientStub.getInstance.thirdCall).to.be.calledWith('recette');
+        expect(deployFromArchive.thirdCall).to.be.calledWith('pix-app-name-recette', 'v0.1.0', 'pix-repo-test', {
           withEnvSuffix: false,
         });
       });
     });
 
-    context('when repo is not handle', function () {
+    context('when repo is not handled', function () {
       it('should not try to deploy release', async function () {
         // given
         const request = {


### PR DESCRIPTION
## 🌸 Problème
Aujourd'hui, un webhook permet, suite à une release github, de déployer la version releasée d'une ou plusieurs applications. Cependant, le code actuel ne permet de déployer que sur secnum.

## 🌳 Proposition
Permettre au webhook de release de déployer sur osc-fr1.