### PR TITLE
[FEATURE] Lancer la mise en production automatiquement

### DIFF
--- a/common/services/slack/surfaces/messages/post-message.js
+++ b/common/services/slack/surfaces/messages/post-message.js
@@ -2,12 +2,18 @@ import { config } from '../../../../../config.js';
 import { httpAgent } from '../../../../http-agent.js';
 import { logger } from '../../../logger.js';
 
-async function postMessage({ message, attachments, channel = '#tech-releases', injectedHttpAgent = httpAgent }) {
+async function postMessage({
+  message,
+  attachments,
+  channel = '#tech-releases',
+  injectedHttpAgent = httpAgent,
+  token = config.slack.botToken,
+}) {
   const url = 'https://slack.com/api/chat.postMessage';
 
   const headers = {
     'content-type': 'application/json',
-    authorization: `Bearer ${config.slack.botToken}`,
+    authorization: `Bearer ${token}`,
   };
   const payload = {
     channel: channel,

--- a/config.js
+++ b/config.js
@@ -99,6 +99,8 @@ const configuration = (function () {
       botToken: process.env.SLACK_BOT_TOKEN,
       webhookUrlForReporting: process.env.SLACK_WEBHOOK_URL_FOR_REPORTING,
       blockedAccessesChannelId: process.env.SLACK_BLOCKED_ACCESSES_CHANNEL_ID,
+      releaseBotToken: process.env.RELEASE_BOT_TOKEN,
+      releaseChannelId: process.env.RELEASE_CHANNEL_ID,
     },
 
     github: {
@@ -150,6 +152,8 @@ const configuration = (function () {
       monorepoReleaseSchedule: process.env.MONOREPO_RELEASE_SCHEDULE,
       monorepoReleaseRepository: process.env.MONOREPO_RELEASE_REPOSITORY,
       monorepoReleaseBranch: process.env.MONOREPO_RELEASE_BRANCH,
+      monorepoReleaseProductionEnabled: isFeatureEnabled(process.env.FT_MONOREPO_RELEASE_PRODUCTION),
+      monorepoReleaseProductionSchedule: process.env.MONOREPO_RELEASE_PRODUCTION_SCHEDULE,
     },
 
     PIX_REPO_NAME: 'pix',

--- a/run/services/tasks.js
+++ b/run/services/tasks.js
@@ -1,6 +1,7 @@
 import { config } from '../../config.js';
 import * as taskAutoScaleWeb from './tasks/autoscale-web.js';
 import * as taskRelease from './tasks/release.js';
+import * as taskReleaseProduction from './tasks/release-production.js';
 
 class Task {
   constructor({ name, enabled, schedule, job, params }) {
@@ -48,6 +49,15 @@ const tasks = [
     params: {
       repository: config.tasks.monorepoReleaseRepository,
       branch: config.tasks.monorepoReleaseBranch,
+    },
+  }),
+  new Task({
+    name: 'monorepoReleaseProduction',
+    enabled: config.tasks.monorepoReleaseProductionEnabled,
+    schedule: config.tasks.monorepoReleaseProductionSchedule,
+    job: taskReleaseProduction,
+    params: {
+      repository: config.tasks.monorepoReleaseRepository,
     },
   }),
 ];

--- a/run/services/tasks/release-production.js
+++ b/run/services/tasks/release-production.js
@@ -1,0 +1,55 @@
+import { logger } from '../../../common/services/logger.js';
+import githubService from '../../../common/services/github.js';
+import postMessage from '../../../common/services/slack/surfaces/messages/post-message.js';
+import { getStatus } from '../../../common/repositories/release-settings.repository.js';
+import { config } from '../../../config.js';
+import releasesService from '../../../common/services/releases.js';
+
+async function run({ repository, dependencies = { github: githubService, _postMessage, getStatus, releasesService } }) {
+  logger.info({
+    event: 'release production',
+    message: `Starting ${repository} release in production.`,
+  });
+  try {
+    const releaseTag = await dependencies.github.getLatestReleaseTag();
+    const buildStatus = await dependencies.github.isBuildStatusOK({ tagName: releaseTag.trim().toLowerCase() });
+    if (!buildStatus) {
+      logger.info({
+        event: 'release production',
+        message: `Build status is not OK for ${repository} release in production.`,
+      });
+      await dependencies._postMessage(
+        "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
+      );
+      return;
+    }
+    const { authorizeDeployment, blockReason } = await dependencies.getStatus({ repositoryName: 'pix' });
+    if (!authorizeDeployment) {
+      await dependencies._postMessage(`Rappel: la Mise en production est bloquée. Motif: ${blockReason}`);
+      return;
+    }
+    await dependencies._postMessage(
+      `🚨 La mise en production de la ${releaseTag} commence. Merci de surveiller son bon déroulement.`,
+    );
+    dependencies.releasesService.deploy(dependencies.releasesService.environments.production, releaseTag);
+  } catch (error) {
+    logger.error({
+      event: 'release production',
+      message: `Error while starting ${repository} release in production.`,
+      error,
+    });
+    dependencies._postMessage(
+      "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
+    );
+  }
+}
+
+export { run };
+
+function _postMessage(message) {
+  return postMessage({
+    message,
+    token: config.slack.releaseBotToken,
+    channel: config.slack.releaseChannelId,
+  });
+}

--- a/sample.env
+++ b/sample.env
@@ -515,3 +515,34 @@ MONOREPO_RELEASE_REPOSITORY=
 # type: string
 # sample: dev
 MONOREPO_RELEASE_BRANCH=
+
+# Monorepo production ft
+#
+# Whether or not the monorepo release is enabled for production
+#
+# presence: optional
+# type: boolean
+FT_MONOREPO_RELEASE_PRODUCTION=false
+
+# Monorepo release production scheduler
+#
+# Date time at which monorepo release will be launched for production
+#
+# presence: optional
+# type: string
+# sample: "0 0 8 * * *"
+MONOREPO_RELEASE_PRODUCTION_SCHEDULE=
+
+# Release Bot token
+#
+# Use for production messages
+# presence: optional
+# type: string
+RELEASE_BOT_TOKEN=__CHANGE_ME__
+
+# Release channel id
+#
+# The channel where organizations informations must published
+# presence: optional
+# type: string
+RELEASE_CHANNEL_ID=__CHANGE_ME__

--- a/test/unit/run/services/tasks/release-production_test.js
+++ b/test/unit/run/services/tasks/release-production_test.js
@@ -1,0 +1,86 @@
+import { run } from '../../../../../run/services/tasks/release-production.js';
+import { sinon, expect } from '../../../../test-helper.js';
+
+describe('Unit | Run | Services | Tasks | Release production', function () {
+  let dependencies;
+
+  beforeEach(function () {
+    dependencies = {
+      github: {
+        getLatestReleaseTag: sinon.stub().resolves('V1.0.0'),
+        isBuildStatusOK: sinon.stub(),
+      },
+      _postMessage: sinon.stub(),
+      getStatus: sinon.stub(),
+      releasesService: {
+        deploy: sinon.stub(),
+        environments: {
+          production: 'production',
+        },
+      },
+    };
+  });
+
+  describe('run without errors', function () {
+    it('should get tag, check status and deploy with a notification', async function () {
+      // given
+      dependencies.getStatus.resolves({ authorizeDeployment: true });
+      dependencies.github.isBuildStatusOK.resolves(true);
+      // when
+      await run({ repository: 'my-repository', dependencies });
+
+      // then
+      expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
+      expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+      expect(dependencies.getStatus).to.have.been.calledWith({ repositoryName: 'pix' });
+      expect(dependencies._postMessage).to.have.been.calledWith(
+        `🚨 La mise en production de la V1.0.0 commence. Merci de surveiller son bon déroulement.`,
+      );
+      expect(dependencies.releasesService.deploy).to.have.been.calledWith('production', 'V1.0.0');
+    });
+  });
+
+  describe('errors', function () {
+    describe('status build is not ok', function () {
+      it('should post a message with some informations', async function () {
+        // given
+        dependencies.github.isBuildStatusOK.resolves(false);
+
+        // when
+        await run({ repository: 'my-repository', dependencies });
+
+        // then
+        expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
+        expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+        expect(dependencies._postMessage).to.have.been.calledWith(
+          "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
+        );
+        expect(dependencies.getStatus).to.not.have.been.called;
+        expect(dependencies.releasesService.deploy).to.not.have.been.called;
+      });
+    });
+
+    describe('release production is blocked', function () {
+      it('should post message for release blocked', async function () {
+        // given
+        dependencies.github.isBuildStatusOK.resolves(true);
+        dependencies.getStatus.resolves({
+          authorizeDeployment: false,
+          blockReason: 'Maintenance',
+        });
+
+        // when
+        await run({ repository: 'my-repository', dependencies });
+
+        // then
+        expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
+        expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+        expect(dependencies.getStatus).to.have.been.calledWith({ repositoryName: 'pix' });
+        expect(dependencies._postMessage).to.have.been.calledWith(
+          'Rappel: la Mise en production est bloquée. Motif: Maintenance',
+        );
+        expect(dependencies.releasesService.deploy).to.not.have.been.called;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

Maintenant que la mise en recette se fait toute seule. On souhaiterais pouvoir automatiser également la mise en production.

## 🌳 Proposition

Ajouter une tâche de mise en production du dernier tag.

## 🐝 Remarques

Le tag déployé est le dernier créé sur Github.

## 🤧 Pour tester

@MathieuGilet ?