### PR TITLE
[FEATURE] Envoyer un message à la fin du déploiment des applications

### DIFF
--- a/common/controllers/index.js
+++ b/common/controllers/index.js
@@ -1,6 +1,7 @@
 import pkg from '../../package.json' with { type: 'json' };
 const { description, name, version } = pkg;
 
+import * as deploymentNotifier from '../services/deployment-notifier.js';
 import releasePublicationConfirmationModal from '../../build/services/slack/surfaces/modals/publish-release/release-publication-confirmation.js';
 import releaseTypeSelectionModal from '../../build/services/slack/surfaces/modals/publish-release/release-type-selection.js';
 import releaseDeploymentConfirmationModal from '../../run/services/slack/surfaces/modals/deploy-release/release-deployment-confirmation.js';
@@ -33,6 +34,12 @@ const controllers = {
         return `<a href="${view.getPreviewUrl()}">View ${name}</a>`;
       })
       .join('<br>');
+  },
+
+  newAppDeployed(request, h) {
+    const { appName, tag } = request.payload;
+    deploymentNotifier.run({ tag, appName });
+    return h.response().code(200);
   },
 };
 

--- a/common/repositories/deployments.repository.js
+++ b/common/repositories/deployments.repository.js
@@ -1,0 +1,29 @@
+import { knex } from '../../db/knex-database-connection.js';
+const TABLE_NAME = 'deployments';
+
+async function isFromMonoRepo(appName) {
+  return await knex.schema.hasColumn(TABLE_NAME, appName);
+}
+
+async function addDeployment({ tag, app }) {
+  await knex(TABLE_NAME)
+    .where({ tag })
+    .update({ [app]: true });
+}
+
+async function createTag(tagName) {
+  const exists = await knex(TABLE_NAME).where({ tag: tagName }).first();
+  if (!exists) {
+    await knex(TABLE_NAME).insert({ tag: tagName });
+  }
+}
+
+async function removedeployments(tag) {
+  await knex(TABLE_NAME).where({ tag }).delete();
+}
+
+async function getAppStateByTag(tag) {
+  return await knex(TABLE_NAME).where({ tag }).first();
+}
+
+export { isFromMonoRepo, addDeployment, createTag, removedeployments, getAppStateByTag };

--- a/common/routes/index.js
+++ b/common/routes/index.js
@@ -11,6 +11,11 @@ const routeIndex = [
     path: '/slackviews',
     handler: indexController.getSlackViews,
   },
+  {
+    method: 'POST',
+    path: '/deployment-succeeded',
+    handler: indexController.newAppDeployed,
+  },
 ];
 
 export default routeIndex;

--- a/common/services/deployment-notifier.js
+++ b/common/services/deployment-notifier.js
@@ -1,0 +1,28 @@
+import * as deployments from '../repositories/deployments.repository.js';
+import postMessage from './slack/surfaces/messages/post-message.js';
+
+async function run({ tag, appName }) {
+  const app = appName.split('-').slice(0, -1).join('-');
+  const isFromMonorepo = await deployments.isFromMonoRepo(app);
+  const environment = appName.split('-').slice(-1)[0];
+  if (!isFromMonorepo) return;
+  await deployments.createTag(tag);
+  await deployments.addDeployment({ tag, app });
+  let allIsDeployed = false;
+  const apps = await deployments.getAppStateByTag(tag);
+  for (const app of apps) {
+    if (!app) {
+      allIsDeployed = false;
+      break;
+    }
+  }
+  if (allIsDeployed) {
+    await postMessage({
+      channel: config.slack.releaseChannelId,
+      token: config.slack.releaseBotToken,
+      message: `Le déploiement de la version ${tag} est terminé sur l'environnement de ${environment}`,
+    });
+  }
+}
+
+export { run };

--- a/db/migrations/20250530075719_create-deployments-table.js
+++ b/db/migrations/20250530075719_create-deployments-table.js
@@ -1,5 +1,5 @@
 const TABLE_NAME = 'deployments';
-const APPLICATIONS = ['pix-app', 'pix-orga', 'pix-admin', 'pix-certif', 'pix-junior', 'audit-logger'];
+const APPLICATIONS = ['pix-app', 'pix-orga', 'pix-admin', 'pix-certif', 'pix-junior', 'pix-audit-logger', 'pix-api'];
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }

--- a/db/migrations/20250530075719_create-deployments-table.js
+++ b/db/migrations/20250530075719_create-deployments-table.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'deployments';
+const APPLICATIONS = ['pix-app', 'pix-orga', 'pix-admin', 'pix-certif', 'pix-junior', 'audit-logger'];
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('tag').comment('Deployment tag, e.g., v1.0.0').primary();
+    APPLICATIONS.map((application) => {
+      table.boolean(application).defaultTo(false).comment(`The deployment of ${application}`);
+    });
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -3,6 +3,7 @@ const { version } = pkg;
 
 import server from '../../../server.js';
 import { expect, StatusCodes } from '../../test-helper.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
 describe('Acceptance | Common | Index', function () {
   describe('on every route', function () {
@@ -58,6 +59,25 @@ describe('Acceptance | Common | Index', function () {
         url: '/slackviews',
       });
       expect(res.statusCode).to.equal(200);
+    });
+  });
+
+  describe('POST /deployment-succeeded', function () {
+    it('should return 200 code http', async function () {
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/deployment-succeeded',
+        payload: {
+          appName: 'pix-api-local',
+          tag: 'V1.0.0',
+        },
+      });
+
+      // then
+      expect(res.statusCode).to.equal(200);
+      const result = await knex('deployments').where({ tag: 'V1.0.0' }).first();
+      expect(result['pix-api']).to.be.true;
     });
   });
 });

--- a/test/integration/common/repositories/deployments.repository.test.js
+++ b/test/integration/common/repositories/deployments.repository.test.js
@@ -1,0 +1,87 @@
+import * as deployments from '../../../../common/repositories/deployments.repository.js';
+import { expect } from '../../../test-helper.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+
+describe('Integration | Common | Repository | Deployments', function () {
+  beforeEach(async function () {
+    await knex('deployments').delete();
+  });
+
+  describe('#isFromMonorepo', function () {
+    it('should return true if app name is from table', async function () {
+      // given
+      const appName = 'pix-app';
+
+      // when
+      const result = await deployments.isFromMonoRepo(appName);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if app name is not from table', async function () {
+      // given
+      const appName = 'non-existing-app';
+
+      // when
+      const result = await deployments.isFromMonoRepo(appName);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#addDeployment', function () {
+    it('should toggle the variable for app and not create tag', async function () {
+      // given
+      await knex('deployments').insert({ tag: 'V1.0.0' });
+
+      // when
+      await deployments.addDeployment({ tag: 'V1.0.0', app: 'pix-app' });
+
+      // then
+      const apps = await knex('deployments').where({ tag: 'V1.0.0' }).first();
+      expect(apps['pix-app']).to.be.true;
+    });
+  });
+
+  describe('#createTag', function () {
+    it('should create a tag', async function () {
+      // when
+      await deployments.createTag('V1.0.0');
+
+      // then
+      const tag = await knex('deployments').where({ tag: 'V1.0.0' }).first();
+      expect(tag).to.exist;
+    });
+  });
+
+  describe('#removedeployments', function () {
+    it('should remove deployments by tag', async function () {
+      // given
+      await knex('deployments').insert({ tag: 'V1.0.0', 'pix-app': true });
+
+      // when
+      await deployments.removedeployments('V1.0.0');
+
+      // then
+      const tag = await knex('deployments').where({ tag: 'V1.0.0' }).first();
+      expect(tag).to.be.undefined;
+    });
+  });
+
+  describe('#getAppStateByTag', function () {
+    it('should return the app state by tag', async function () {
+      // given
+      await knex('deployments').insert({ tag: 'V1.0.0', 'pix-app': true, 'pix-orga': false });
+
+      // when
+      const result = await deployments.getAppStateByTag('V1.0.0');
+
+      // then
+      expect(result).to.exist;
+      expect(result['pix-app']).to.be.true;
+      expect(result['pix-orga']).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

On souhaiterais savoir lorsque le déploiement complèt des applications est terminé.

## 🌳 Proposition

- [X] Ajouter une table avec la liste des application, une colone pour le tag,
- [X] Ajouter un repository pour gérer cette table,
- [X] Créer un service qui manage le tout et enverra une notification lorsque la ligne sera rempli,
- [X] Ajouter un endpoint et une méthode dans le controller pour appeler ce service.

## 🐝 Remarques

Il faudra ajouter un script côté mono-repo pour faire les requêtes à la fin du déploiement.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
