### PR TITLE
[FEATURE] Ajouter un template de migration pour la db

### DIFF
--- a/db/template.js
+++ b/db/template.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'my_table';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.createTable(TABLE_NAME, (table) => {
+    table.increments('id').primary();
+    table.string('name').notNullable();
+    table.integer('age').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+};
+
+export { up, down };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy:minor": "npm version minor && npm run deploy:tag",
     "deploy:patch": "npm version patch && npm run deploy:tag",
     "deploy:tag": "git push --tags && git push",
-    "db:new-migration": "npx knex --knexfile ./db/knexfile.js  migrate:make $migrationname",
+    "db:new-migration": "npx knex --knexfile ./db/knexfile.js  migrate:make --stub $PWD/db/template.js $migrationname",
     "db:create": "node ./db/create-database.js",
     "db:delete": "node ./db/drop-database.js",
     "db:empty": "node ./db/empty-database.js",


### PR DESCRIPTION
## 🔆 Problème

Lorsqu'on fait un npm run db:new-migration, on a un template avec des fonctions qu'on ne peut pas utiliser en l'état. En effet, on nepeut pas utiliser export.up et export.down. Il faut donc à chaque fois modifier le fichier.

## ⛱️ Proposition

Ajouter un template de migration qui sera appelé lors de la création d'une migration.

## 🌊 Remarques

RAS.

## 🏄 Pour tester

- Créer une migration:
```shell
npm run db:new-migration ma-migration
```
- Constater qu'un fichier a été créé dans db/migrations correspondant au fichier db/template.