### PR TITLE
[TECH] Modifier l'application template pour les review apps de pix-db-replication

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -14,7 +14,7 @@ const repositoryToScalingoAppsReview = {
   'pix-bot': ['pix-bot-review'],
   'pix-data': ['pix-airflow-review'],
   'pix-api-to-pg': ['pix-data-api-pix-integration'],
-  'pix-db-replication': ['pix-datawarehouse-integration'],
+  'pix-db-replication': ['pix-datawarehouse-review'],
   'pix-db-stats': ['pix-db-stats-review'],
   'pix-editor': ['pix-lcms-review'],
   'pix-epreuves': ['pix-epreuves-review'],


### PR DESCRIPTION
## 🔆 Problème
Aujourd'hui, nous déployons les review apps de `pix-db-replication`  depuis `pix-datawarehouse-integration` ce qui ne suit pas ce qui est fait sur les autres repository. Une application `pix-datawarehouse-review` a été créée afin de servir d'application template pour les review apps.  

## ⛱️ Proposition
Déployer les review apps de  `pix-db-replication` depuis `pix-datawarehouse-review`.

## 🌊 Remarques
Suite au merge de cette PR il faudra peut être redéployer les review apps actuelles depuis `pix-datawarehouse-review`.