### PR TITLE
[FEATURE] Notifier via slack lorsque le déploiement des applications est terminé

### DIFF
--- a/common/repositories/applications-deployment.repository.js
+++ b/common/repositories/applications-deployment.repository.js
@@ -1,0 +1,36 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { config } from '../../config.js';
+
+const TABLE_NAME = 'applications_deployments';
+
+async function createVersion({ version, environment }) {
+  const appWithVersions = config.PIX_APPS.map((app) => {
+    return {
+      version,
+      environment,
+      'app-name': app,
+    };
+  });
+  await knex(TABLE_NAME).insert(appWithVersions);
+}
+
+async function markHasDeployed({ version, environment, app }) {
+  return await knex(TABLE_NAME)
+    .where({ version, 'app-name': app, environment })
+    .update({ 'is-deployed': true, 'deployed-at': new Date() });
+}
+
+async function getByVersionAndEnvironment({ version, environment }) {
+  const rows = await knex(TABLE_NAME).where({ version, environment }).select('app-name', 'is-deployed', 'deployed-at');
+  return rows.map((row) => ({
+    app: row['app-name'],
+    isDeployed: row['is-deployed'],
+    deployedAt: row['deployed-at'],
+  }));
+}
+
+async function removeByVersionAndEnvironment({ version, environment }) {
+  return await knex(TABLE_NAME).where({ version, environment }).del();
+}
+
+export { createVersion, markHasDeployed, getByVersionAndEnvironment, removeByVersionAndEnvironment };

--- a/common/routes/index.js
+++ b/common/routes/index.js
@@ -11,6 +11,11 @@ const routeIndex = [
     path: '/slackviews',
     handler: indexController.getSlackViews,
   },
+  {
+    method: 'POST',
+    path: '/api/application/deployed',
+    handler: indexController.applicationIsDeployed,
+  },
 ];
 
 export default routeIndex;

--- a/common/services/applications-deployment.service.js
+++ b/common/services/applications-deployment.service.js
@@ -1,0 +1,37 @@
+import slackPostMessageService from './slack/surfaces/messages/post-message.js';
+import { config } from '../../config.js';
+import * as applicationsDeployment from '../repositories/applications-deployment.repository.js';
+
+async function addNewVersion({ version, environment }) {
+  if (await _checkIfVersionExists({ version, environment })) {
+    return;
+  }
+  await applicationsDeployment.createVersion({ version, environment });
+}
+
+async function markAppHasDeployed({ app, version, environment }) {
+  await applicationsDeployment.markHasDeployed({ version, environment, app });
+  if (await _checkIfAllApplicationsHasDeployed({ environment, version })) {
+    await slackPostMessageService.postMessage({
+      message: `Bonjour 👋 la mise en ${environment} de toute les applications a bien été effectuée!`,
+      channel: config.slack.releaseChannelId,
+      token: config.slack.releaseBotToken,
+    });
+  }
+}
+
+function isPixApplication(applicationName) {
+  return config.PIX_APPS.includes(applicationName);
+}
+
+export { addNewVersion, markAppHasDeployed, isPixApplication };
+
+async function _checkIfVersionExists({ version, environment }) {
+  const apps = await applicationsDeployment.getByVersionAndEnvironment({ version, environment });
+  return apps.length > 0;
+}
+
+async function _checkIfAllApplicationsHasDeployed({ version, environment }) {
+  const applications = await applicationsDeployment.getByVersionAndEnvironment({ version, environment });
+  return applications.every((app) => app.isDeployed);
+}

--- a/db/migrations/20250603134355_create-table-applications-deployment.js
+++ b/db/migrations/20250603134355_create-table-applications-deployment.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'applications_deployments';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  return await knex.schema.createTable(TABLE_NAME, function (table) {
+    table.string('version').notNullable().comment('The version of application');
+    table.string('environment').comment('The application environment');
+    table.string('app-name').comment('The application name');
+    table.boolean('is-deployed').comment('Indicates if the application is deployed successfully').defaultTo(false);
+    table.datetime('deployed-at').comment('The deployment date').defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function (knex) {
+  return await knex.schema.dropTableIfExists(TABLE_NAME);
+};
+
+export { up, down };

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -2,7 +2,10 @@ import pkg from '../../../package.json' with { type: 'json' };
 const { version } = pkg;
 
 import server from '../../../server.js';
-import { expect, StatusCodes } from '../../test-helper.js';
+import { expect, StatusCodes, sinon } from '../../test-helper.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import slackPostMessageService from '../../../common/services/slack/surfaces/messages/post-message.js';
+import { config } from '../../../config.js';
 
 describe('Acceptance | Common | Index', function () {
   describe('on every route', function () {
@@ -58,6 +61,153 @@ describe('Acceptance | Common | Index', function () {
         url: '/slackviews',
       });
       expect(res.statusCode).to.equal(200);
+    });
+  });
+
+  describe('POST /api/application/deployed', function () {
+    beforeEach(async function () {
+      await knex('applications_deployments').delete();
+      config.authorizationToken = 'helloworld';
+    });
+
+    it('should create a version and mark app deployed', async function () {
+      // given
+      const payload = {
+        type_data: {
+          git_ref: 'v1.0.0',
+          status: 'success',
+        },
+        app_name: 'pix-app',
+      };
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/application/deployed?environment=local&token=helloworld',
+        payload,
+      });
+
+      // then
+      expect(res.statusCode).to.equal(StatusCodes.OK);
+      const pixApp = await knex('applications_deployments')
+        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app' })
+        .first();
+      expect(pixApp['is-deployed']).to.be.true;
+    });
+
+    it('should send notification when all application are deployed', async function () {
+      // given
+      const environment = 'local';
+      const version = 'v1.0.0';
+      for (const application of config.PIX_APPS) {
+        await knex('applications_deployments').insert({
+          environment,
+          version,
+          'app-name': application,
+          'is-deployed': true,
+        });
+      }
+      await knex('applications_deployments')
+        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .update({ 'is-deployed': false });
+      sinon.stub(slackPostMessageService, 'postMessage').resolves(true);
+      const payload = {
+        type_data: {
+          git_ref: version,
+          status: 'success',
+        },
+        app_name: config.PIX_APPS[0],
+      };
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: `/api/application/deployed?environment=${environment}&token=helloworld`,
+        payload,
+      });
+
+      // then
+      expect(res.statusCode).to.equal(StatusCodes.OK);
+      expect(slackPostMessageService.postMessage.calledOnce).to.be.true;
+      const application = await knex('applications_deployments')
+        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .first();
+      expect(application['is-deployed']).to.be.true;
+    });
+
+    it('should return a 422 error if application is not in PIX_APPS', async function () {
+      // given
+      const payload = {
+        type_data: {
+          git_ref: 'v1.0.0',
+          status: 'success',
+        },
+        app_name: 'unknown-app',
+      };
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/application/deployed?environment=local&token=helloworld',
+        payload,
+      });
+
+      // then
+      expect(res.statusCode).to.equal(StatusCodes.UNPROCESSABLE_ENTITY);
+    });
+
+    it('should return a 401 if token is invalid', async function () {
+      // given
+      const payload = {
+        type_data: {
+          git_ref: 'v1.0.0',
+          status: 'success',
+        },
+        app_name: 'pix-app',
+      };
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/application/deployed?environment=local&token=invalid-token',
+        payload,
+      });
+
+      // then
+      expect(res.statusCode).to.equal(StatusCodes.UNAUTHORIZED);
+    });
+
+    it('should return 200 if status is not success', async function () {
+      // given
+      for (const app of config.PIX_APPS) {
+        await knex('applications_deployments').insert({
+          environment: 'local',
+          version: 'v1.0.0',
+          'app-name': app,
+          'is-deployed': false,
+        });
+      }
+      const payload = {
+        type_data: {
+          git_ref: 'v1.0.0',
+          status: 'failure',
+        },
+        app_name: 'pix-app',
+      };
+
+      // when
+      const res = await server.inject({
+        method: 'POST',
+        url: '/api/application/deployed?environment=local&token=helloworld',
+        payload,
+      });
+
+      // then
+      expect(res.statusCode).to.equal(StatusCodes.OK);
+      const pixApp = await knex('applications_deployments')
+        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app' })
+        .first();
+      expect(pixApp['is-deployed']).to.be.false;
     });
   });
 });

--- a/test/integration/common/repositories/applications-deployment.repository.test.js
+++ b/test/integration/common/repositories/applications-deployment.repository.test.js
@@ -1,0 +1,150 @@
+import { expect } from '../../../test-helper.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import * as applicationsDeployment from '../../../../common/repositories/applications-deployment.repository.js';
+import { config } from '../../../../config.js';
+import { describe, beforeEach } from 'mocha';
+
+describe('Integration | Common | Repositories | Applications deployment', function () {
+  beforeEach(async function () {
+    await knex('applications_deployments').del();
+  });
+
+  describe('#createVersion', function () {
+    it('should create version and apps', async function () {
+      // given
+      const environment = 'local';
+      const version = 'v1.0.0';
+
+      // when
+      await applicationsDeployment.createVersion({ environment, version });
+
+      // then
+      const result = await knex('applications_deployments').where({ environment, version });
+      expect(result).to.have.length(config.PIX_APPS.length);
+      config.PIX_APPS.map((app, index) => {
+        expect(result[index]).to.deep.equal({
+          version,
+          environment,
+          'app-name': result[index]['app-name'],
+          'is-deployed': false,
+          'deployed-at': null,
+        });
+      });
+    });
+  });
+
+  describe('#markHasDeployed', function () {
+    it('should mark an app has deployed', async function () {
+      // given
+      const data = {
+        version: 'v1.0.0',
+        'app-name': 'pix-app',
+        environment: 'local',
+      };
+      await knex('applications_deployments').insert(data);
+
+      // when
+      await applicationsDeployment.markHasDeployed({ version: 'v1.0.0', environment: 'local', app: 'pix-app' });
+
+      // then
+      const result = await knex('applications_deployments').where(data).first();
+      expect(result).to.deep.equal({
+        ...data,
+        'is-deployed': true,
+        'deployed-at': result['deployed-at'],
+      });
+    });
+  });
+
+  describe('#getByVersionAndEnvironment', function () {
+    it('should return deployments by version and environment', async function () {
+      // given
+      const data = [
+        {
+          version: 'v1.0.0',
+          'app-name': 'pix-app',
+          environment: 'local',
+          'is-deployed': true,
+          'deployed-at': new Date(),
+        },
+        {
+          version: 'v1.0.0',
+          'app-name': 'pix-app2',
+          environment: 'local',
+          'is-deployed': false,
+          'deployed-at': null,
+        },
+      ];
+      await knex('applications_deployments').insert(data);
+
+      // when
+      const result = await applicationsDeployment.getByVersionAndEnvironment({
+        version: 'v1.0.0',
+        environment: 'local',
+      });
+
+      // then
+      expect(result).to.have.length(2);
+      expect(result).to.deep.equal([
+        {
+          app: 'pix-app',
+          isDeployed: true,
+          deployedAt: result[0]['deployedAt'],
+        },
+        {
+          app: 'pix-app2',
+          isDeployed: false,
+          deployedAt: null,
+        },
+      ]);
+    });
+
+    it('should return an empty list when version not found', async function () {
+      // when
+      const result = await applicationsDeployment.getByVersionAndEnvironment({
+        version: 'v1.0.0',
+        environment: 'local',
+      });
+
+      // then
+      expect(result).to.have.length(0);
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('#removeByVersionAndEnvironment', function () {
+    it('should remove deployments by version and environment', async function () {
+      // given
+      const data = [
+        {
+          version: 'v1.0.0',
+          'app-name': 'pix-app',
+          environment: 'local',
+          'is-deployed': true,
+          'deployed-at': new Date(),
+        },
+        {
+          version: 'v1.0.0',
+          'app-name': 'pix-app2',
+          environment: 'local',
+          'is-deployed': false,
+          'deployed-at': null,
+        },
+      ];
+      await knex('applications_deployments').insert(data);
+
+      // when
+      await applicationsDeployment.removeByVersionAndEnvironment({
+        version: 'v1.0.0',
+        environment: 'local',
+      });
+
+      // then
+      const result = await knex('applications_deployments').where({
+        version: 'v1.0.0',
+        environment: 'local',
+      });
+      expect(result).to.have.length(0);
+    });
+  });
+});

--- a/test/integration/common/services/applications-deployment.service.test.js
+++ b/test/integration/common/services/applications-deployment.service.test.js
@@ -1,0 +1,131 @@
+import { expect, sinon } from '../../../test-helper.js';
+import { knex } from '../../../../db/knex-database-connection.js';
+import * as applicationsDeploymentService from '../../../../common/services/applications-deployment.service.js';
+import { config } from '../../../../config.js';
+import slackPostMessageService from '../../../../common/services/slack/surfaces/messages/post-message.js';
+
+describe('Integration | Common | Services | Applications deployment', function () {
+  const version = 'v1.0.0';
+  const environment = 'local';
+
+  beforeEach(async function () {
+    await knex('applications_deployments').del();
+  });
+
+  describe('#addNewVersion', function () {
+    it('should add a new version successfull', async function () {
+      // when
+      await applicationsDeploymentService.addNewVersion({ environment, version });
+
+      // then
+      const result = await knex('applications_deployments').where({ environment, version });
+      expect(result).to.have.length(config.PIX_APPS.length);
+      config.PIX_APPS.map((app, index) => {
+        expect(result[index]).to.deep.equal({
+          version,
+          environment,
+          'app-name': result[index]['app-name'],
+          'is-deployed': false,
+          'deployed-at': null,
+        });
+      });
+    });
+
+    it('should not create version if always exists', async function () {
+      // given
+      for (const application of config.PIX_APPS) {
+        await knex('applications_deployments').insert({
+          version,
+          environment,
+          'app-name': application,
+        });
+      }
+      await knex('applications_deployments').where({ 'app-name': 'pix-app' }).update({ 'is-deployed': true });
+
+      // when
+      await applicationsDeploymentService.addNewVersion({ environment, version });
+
+      // then
+      const result = await knex('applications_deployments').where({ environment, version });
+      expect(result).to.have.length(config.PIX_APPS.length);
+      const pixApp = await knex('applications_deployments')
+        .where({ environment, version, 'app-name': 'pix-app' })
+        .first();
+      expect(pixApp['is-deployed']).to.be.true;
+    });
+  });
+
+  describe('#markAppHasDeployed', function () {
+    it('should mark app deployed', async function () {
+      // given
+      for (const application of config.PIX_APPS) {
+        await knex('applications_deployments').insert({
+          environment,
+          version,
+          'app-name': application,
+        });
+      }
+      sinon.stub(slackPostMessageService, 'postMessage');
+
+      // when
+      await applicationsDeploymentService.markAppHasDeployed({ app: config.PIX_APPS[0], environment, version });
+
+      // then
+      const app = await knex('applications_deployments')
+        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .first();
+      expect(app['is-deployed']).to.be.true;
+      expect(slackPostMessageService.postMessage).to.not.have.been.called;
+    });
+
+    it('should send notification when all applications are deployed', async function () {
+      // given
+      for (const application of config.PIX_APPS) {
+        await knex('applications_deployments').insert({
+          environment,
+          version,
+          'app-name': application,
+          'is-deployed': true,
+        });
+      }
+      await knex('applications_deployments')
+        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .update({ 'is-deployed': false });
+      sinon.stub(slackPostMessageService, 'postMessage');
+
+      // when
+      await applicationsDeploymentService.markAppHasDeployed({ app: config.PIX_APPS[0], environment, version });
+
+      // then
+      const app = await knex('applications_deployments')
+        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .first();
+      expect(app['is-deployed']).to.be.true;
+      expect(slackPostMessageService.postMessage).to.have.been.called;
+    });
+  });
+
+  describe('#isPixApplication', function () {
+    it('should return true if the applications is from PIX_APPS', function () {
+      // given
+      const applicationName = 'pix-app';
+
+      // when
+      const result = applicationsDeploymentService.isPixApplication(applicationName);
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if the application is not from PIX_APPS', function () {
+      // given
+      const applicationName = 'som-application';
+
+      // when
+      const result = applicationsDeploymentService.isPixApplication(applicationName);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

On souhaiterais savoir lorsque toutes les applications du monorepo sont déployée sur un environnement. Aujourd'hui, on est notifié par Scalingo à la fin du déploiement individuel de chaque app.

## ⛱️ Proposition

Créer une route post qui prend en payload le nom de l'app, le numéro de version et son environnement. Le tout sera sauvegardé en base et lorsque le déploiement de toutes les applications sera terminé, une notification Slack sera envoyée.

## 🌊 Remarques

On était parti à l'origine sur Scalingo qui appelle cette nouvelle route à la fin de chaque déploiement. Cependant, étant donné qu'on ne peux pas choisir les paramètres qu'on souhaite y inclure (environnement par exemple), je pense que la solution idéale est de compléter l'action post-deploy avec un script qui fera un appel à l'url (en variable d'env) avec l'environnement (en variable d'env).
Il faudra faire attention lors des redéploiements

## 🏄 Pour tester

- Installer la RA sur le Slack de teste,
- Faire des appels curl avec toutes les applications,
- Constater à la fin qu'on reçoit une notification indiquant que le déploiement de toutes les applications est terminé.
