### PR TITLE
[BUGFIX] Utiliser le bon level de log au moment des releases

### DIFF
--- a/common/services/releases.js
+++ b/common/services/releases.js
@@ -89,7 +89,7 @@ const releasesService = {
 async function _runScriptWithArgument(scriptFileName, exec, ...args) {
   const scriptsDirectory = `${process.cwd()}/scripts`;
   const { stdout, stderr } = await exec(`${scriptsDirectory}/${scriptFileName} ${args.join(' ')}`);
-  logger.error({ event: 'release', message: `stdout: ${stdout}` });
+  logger.info({ event: 'release', message: `stdout: ${stdout}` });
   const lastLine = stdout.split('\n').slice(-2, -1).pop();
   logger.error({ event: 'release', message: `stderr: ${stderr}` });
   return lastLine;


### PR DESCRIPTION
## 🔆 Problème

Lors du refacto pour utiliser un logger pour Pix Bot, un `console.log` s'est vu devenir un `logger.error`, alors qu'il s'agit de la sortie standard. 

## ⛱️ Proposition

Repasser le log en level `info`. 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
