### PR TITLE
[BUGFIX] Utiliser le nom complet des applications pour le déploiement

### DIFF
--- a/common/controllers/index.js
+++ b/common/controllers/index.js
@@ -44,7 +44,7 @@ const controllers = {
     const environment = request.query.environment;
     const app = request.payload.app_name;
     const version = request.payload.type_data.git_ref;
-    if (!applicationsDeploymentService.isPixApplication(app)) {
+    if (!applicationsDeploymentService.isPixApplication({ applicationName: app, environment })) {
       return h.response().code(422);
     } else if (request.payload.type_data.status !== 'success') {
       return h.response().code(200);

--- a/common/repositories/applications-deployment.repository.js
+++ b/common/repositories/applications-deployment.repository.js
@@ -8,7 +8,7 @@ async function createVersion({ version, environment }) {
     return {
       version,
       environment,
-      'app-name': app,
+      'app-name': `${app}-${environment}`,
     };
   });
   await knex(TABLE_NAME).insert(appWithVersions);

--- a/common/services/applications-deployment.service.js
+++ b/common/services/applications-deployment.service.js
@@ -20,8 +20,8 @@ async function markAppHasDeployed({ app, version, environment }) {
   }
 }
 
-function isPixApplication(applicationName) {
-  return config.PIX_APPS.includes(applicationName);
+function isPixApplication({ applicationName, environment }) {
+  return config.PIX_APPS.map((app) => `${app}-${environment}`).includes(applicationName);
 }
 
 export { addNewVersion, markAppHasDeployed, isPixApplication };

--- a/test/acceptance/common/index_test.js
+++ b/test/acceptance/common/index_test.js
@@ -77,7 +77,7 @@ describe('Acceptance | Common | Index', function () {
           git_ref: 'v1.0.0',
           status: 'success',
         },
-        app_name: 'pix-app',
+        app_name: 'pix-app-local',
       };
 
       // when
@@ -90,7 +90,7 @@ describe('Acceptance | Common | Index', function () {
       // then
       expect(res.statusCode).to.equal(StatusCodes.OK);
       const pixApp = await knex('applications_deployments')
-        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app' })
+        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app-local' })
         .first();
       expect(pixApp['is-deployed']).to.be.true;
     });
@@ -103,7 +103,7 @@ describe('Acceptance | Common | Index', function () {
         await knex('applications_deployments').insert({
           environment,
           version,
-          'app-name': application,
+          'app-name': `${application}-${environment}`,
           'is-deployed': true,
         });
       }
@@ -116,7 +116,7 @@ describe('Acceptance | Common | Index', function () {
           git_ref: version,
           status: 'success',
         },
-        app_name: config.PIX_APPS[0],
+        app_name: `${config.PIX_APPS[0]}-${environment}`,
       };
 
       // when
@@ -130,7 +130,7 @@ describe('Acceptance | Common | Index', function () {
       expect(res.statusCode).to.equal(StatusCodes.OK);
       expect(slackPostMessageService.postMessage.calledOnce).to.be.true;
       const application = await knex('applications_deployments')
-        .where({ environment, version, 'app-name': config.PIX_APPS[0] })
+        .where({ environment, version, 'app-name': `${config.PIX_APPS[0]}-${environment}` })
         .first();
       expect(application['is-deployed']).to.be.true;
     });
@@ -163,7 +163,7 @@ describe('Acceptance | Common | Index', function () {
           git_ref: 'v1.0.0',
           status: 'success',
         },
-        app_name: 'pix-app',
+        app_name: 'pix-app-local',
       };
 
       // when
@@ -183,7 +183,7 @@ describe('Acceptance | Common | Index', function () {
         await knex('applications_deployments').insert({
           environment: 'local',
           version: 'v1.0.0',
-          'app-name': app,
+          'app-name': `${app}-local`,
           'is-deployed': false,
         });
       }
@@ -192,7 +192,7 @@ describe('Acceptance | Common | Index', function () {
           git_ref: 'v1.0.0',
           status: 'failure',
         },
-        app_name: 'pix-app',
+        app_name: 'pix-app-local',
       };
 
       // when
@@ -205,7 +205,7 @@ describe('Acceptance | Common | Index', function () {
       // then
       expect(res.statusCode).to.equal(StatusCodes.OK);
       const pixApp = await knex('applications_deployments')
-        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app' })
+        .where({ environment: 'local', version: 'v1.0.0', 'app-name': 'pix-app-local' })
         .first();
       expect(pixApp['is-deployed']).to.be.false;
     });

--- a/test/integration/common/repositories/applications-deployment.repository.test.js
+++ b/test/integration/common/repositories/applications-deployment.repository.test.js
@@ -25,7 +25,7 @@ describe('Integration | Common | Repositories | Applications deployment', functi
         expect(result[index]).to.deep.equal({
           version,
           environment,
-          'app-name': result[index]['app-name'],
+          'app-name': `${result[index]['app-name']}`,
           'is-deployed': false,
           'deployed-at': null,
         });

--- a/test/integration/common/services/applications-deployment.service.test.js
+++ b/test/integration/common/services/applications-deployment.service.test.js
@@ -108,10 +108,10 @@ describe('Integration | Common | Services | Applications deployment', function (
   describe('#isPixApplication', function () {
     it('should return true if the applications is from PIX_APPS', function () {
       // given
-      const applicationName = 'pix-app';
+      const applicationName = 'pix-app-local';
 
       // when
-      const result = applicationsDeploymentService.isPixApplication(applicationName);
+      const result = applicationsDeploymentService.isPixApplication({ applicationName, environment: 'local' });
 
       // then
       expect(result).to.be.true;


### PR DESCRIPTION
## 🔆 Problème

Scalingo envoie le nom complèt des applications, tel que pix-api-recettte ou pix-app-recette. Or on utilisait la config de pix-bot avec la variable PIX_APPS qui ne contient que la liste des applications sans sufix.

## ⛱️ Proposition

Inclure le sufix dans le nom des apps et dans les checks.

## 🌊 Remarques

Rajouter les variables:
- RELEASE_CHANNEL_ID: l'identifiant du channel où il faudrat publier les messages sur la release.