### PR TITLE
[FEATURE] releaser la version Jira  à la fin du déploiement d'une version en production

### DIFF
--- a/common/services/applications-deployment.service.js
+++ b/common/services/applications-deployment.service.js
@@ -52,7 +52,7 @@ async function _checkIfAllApplicationsHasDeployed({ version, environment }) {
   return applications.every((app) => app.isDeployed);
 }
 
-async function _handleJira(version) {
+export async function _handleJira(version) {
   try {
     const versions = await getVersionList();
     const jiraVersion = versions.find((jiraVersion) => jiraVersion.name === version);
@@ -63,7 +63,7 @@ async function _handleJira(version) {
   } catch (error) {
     logger.error({
       event: 'application deployment service',
-      message: 'Error during jira interraction',
+      message: 'Error during jira interaction',
       job: 'release version on jira',
       stack: 'service',
       data: error,

--- a/common/services/applications-deployment.service.js
+++ b/common/services/applications-deployment.service.js
@@ -1,6 +1,8 @@
 import slackPostMessageService from './slack/surfaces/messages/post-message.js';
 import { config } from '../../config.js';
 import * as applicationsDeployment from '../repositories/applications-deployment.repository.js';
+import { finalize, getVersionList } from './jira.service.js';
+import { logger } from './logger.js';
 
 async function addNewVersion({ version, environment }) {
   if (await _checkIfVersionExists({ version, environment })) {
@@ -17,6 +19,7 @@ async function markAppHasDeployed({ app, version, environment }) {
     switch (environment) {
       case 'production':
         message = `La mise en production de la ${version} a bien été effectuée :rocket: vous pouvez communiquer sur <#${config.slack.releaseComunicationChannelId}>. <!subteam^${config.slack.teamPoId}>`;
+        await _handleJira(version);
         break;
       case 'recette':
         message = `La mise en recette de la ${version} a bien été effectuée, vous pouvez mettre vos messages en :thread: <!subteam^${config.slack.teamPoId}>`;
@@ -47,4 +50,23 @@ async function _checkIfVersionExists({ version, environment }) {
 async function _checkIfAllApplicationsHasDeployed({ version, environment }) {
   const applications = await applicationsDeployment.getByVersionAndEnvironment({ version, environment });
   return applications.every((app) => app.isDeployed);
+}
+
+async function _handleJira(version) {
+  try {
+    const versions = await getVersionList();
+    const jiraVersion = versions.find((jiraVersion) => jiraVersion.name === version);
+    if (jiraVersion) {
+      await finalize(jiraVersion.id);
+      return;
+    }
+  } catch (error) {
+    logger.error({
+      event: 'application deployment service',
+      message: 'Error during jira interraction',
+      job: 'release version on jira',
+      stack: 'service',
+      data: error,
+    });
+  }
 }

--- a/common/services/jira.service.js
+++ b/common/services/jira.service.js
@@ -1,0 +1,66 @@
+import { config } from '../../config.js';
+import { logger } from './logger.js';
+
+const createJiraFetcher = (host, email, apiToken) => {
+  const baseUrl = `${host}/rest/api/3`;
+  const token = btoa(`${email}:${apiToken}`);
+  return ({ path, method, body }) => {
+    return fetch(`${baseUrl}${path}`, {
+      headers: {
+        authorization: `Basic ${token}`,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      method,
+      body,
+    });
+  };
+};
+
+async function getVersionList() {
+  try {
+    const jiraFetcher = createJiraFetcher(config.jira.host, config.jira.userEmail, config.jira.apiToken);
+    const request = await jiraFetcher({ path: `/project/${config.jira.projectId}/versions`, method: 'GET' });
+    if (request.ok) {
+      const data = await request.json();
+      return data;
+    }
+  } catch (error) {
+    logger.error({
+      event: 'Jira release',
+      message: 'An error occurred',
+      job: 'jira service',
+      stack: 'get version list',
+      data: error,
+    });
+    throw error;
+  }
+}
+
+async function finalize(versionId) {
+  try {
+    const jiraFetcher = createJiraFetcher(config.jira.host, config.jira.userEmail, config.jira.apiToken);
+    const request = await jiraFetcher({
+      path: `/version/${versionId}`,
+      method: 'PUT',
+      body: JSON.stringify({
+        released: true,
+        releaseDate: new Date(),
+      }),
+    });
+    if (request.ok) {
+      return true;
+    }
+  } catch (error) {
+    logger.error({
+      event: 'Jira release',
+      message: 'An error occurred',
+      job: 'jira service',
+      stack: 'finalize version',
+      data: error,
+    });
+    throw error;
+  }
+}
+
+export { getVersionList, finalize };

--- a/config.js
+++ b/config.js
@@ -108,6 +108,13 @@ const configuration = (function () {
       teamPoId: process.env.SLACK_TEAM_PO_ID || '',
     },
 
+    jira: {
+      host: process.env.JIRA_HOST,
+      userEmail: process.env.JIRA_USER_EMAIL,
+      apiToken: process.env.JIRA_API_TOKEN,
+      projectId: process.env.JIRA_PROJECT_ID,
+    },
+
     github: {
       token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN,
       owner: process.env.GITHUB_OWNER,

--- a/sample.env
+++ b/sample.env
@@ -559,3 +559,28 @@ SLACK_TEAM_PO_ID=__CHANGE_ME__
 # presence: optional
 # type: string
 SLACK_RELEASE_CHANNEL_COMMUNICATION=__CHANGE_ME__
+
+
+# ======================
+# Jira
+# ======================
+# Jira host
+# The host of the jira instance
+# presence: optional
+# type: string
+JIRA_HOST=__CHANGE_ME__
+# Jira user email
+# The email of the jira account
+# presence: optional
+# type: string
+JIRA_USER_EMAIL=__CHANGE_ME__
+# Jira API token
+# The API token of the jira account
+# presence: optional
+# type: string
+JIRA_API_TOKEN=__CHANGE_ME__
+# Project ID
+# The project ID of the jira project
+# presence: optional
+# type: string
+JIRA_PROJECT_ID=__CHANGE_ME__

--- a/test/integration/common/services/jira.service.test.js
+++ b/test/integration/common/services/jira.service.test.js
@@ -1,0 +1,320 @@
+import { catchErr, expect, sinon } from '../../../test-helper.js';
+import nock from 'nock';
+
+import { getVersionList, finalize } from '../../../../common/services/jira.service.js';
+import { config } from '../../../../config.js';
+import { logger } from '../../../../common/services/logger.js';
+
+describe('Integration | Common | Services | Jira', function () {
+  let loggerStub;
+
+  beforeEach(function () {
+    sinon.stub(config, 'jira').value({
+      host: 'https://test-jira.atlassian.net',
+      userEmail: 'integration-test-user',
+      apiToken: 'integration-test-token',
+      projectId: 'PIX',
+    });
+    loggerStub = sinon.stub(logger, 'error');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    nock.cleanAll();
+  });
+
+  describe('#getVersionList', function () {
+    it('should successfully fetch and return version list from Jira API', async function () {
+      // given
+      const mockVersions = { result: 'test-results' };
+
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('accept', 'application/json')
+        .matchHeader('content-type', 'application/json')
+        .reply(200, mockVersions);
+
+      // when
+      const result = await getVersionList();
+
+      // then
+      expect(result).to.deep.equal(mockVersions);
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle authentication failure gracefully', async function () {
+      // given
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('accept', 'application/json')
+        .matchHeader('content-type', 'application/json')
+        .reply(401, {
+          errorMessages: ['You do not have the permission to see the specified project.'],
+          errors: {},
+        });
+
+      // when
+      const result = await getVersionList();
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle project not found error', async function () {
+      // given
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('accept', 'application/json')
+        .matchHeader('content-type', 'application/json')
+        .reply(404, {
+          errorMessages: ['No project could be found with key PIX.'],
+          errors: {},
+        });
+
+      // when
+      const result = await getVersionList();
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle network timeout and log error', async function () {
+      // given
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .replyWithError({ code: 'ETIMEDOUT', message: 'Request timeout' });
+
+      // when
+      await catchErr(getVersionList)();
+
+      // then
+      expect(loggerStub).to.have.been.calledOnce;
+      expect(loggerStub.firstCall.args[0]).to.deep.include({
+        event: 'Jira release',
+        message: 'An error occurred',
+        job: 'jira service',
+        stack: 'get version list',
+      });
+    });
+
+    it('should handle empty version list', async function () {
+      // given
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('accept', 'application/json')
+        .reply(200, []);
+
+      // when
+      const result = await getVersionList();
+
+      // then
+      expect(result).to.be.an('array').that.is.empty;
+      expect(loggerStub).not.to.have.been.called;
+    });
+  });
+
+  describe('#finalize', function () {
+    it('should successfully finalize a version with current date', async function () {
+      // given
+      const versionId = '10000';
+      const testDate = new Date('2025-06-30T14:30:00.000Z');
+      const dateStub = sinon.stub(global, 'Date').returns(testDate);
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/10000')
+        .reply(200, function (uri, requestBody) {
+          const body = typeof requestBody === 'string' ? JSON.parse(requestBody) : requestBody;
+          expect(body).to.deep.equal({
+            released: true,
+            releaseDate: testDate.toISOString(),
+          });
+          return {
+            self: 'https://test-jira.atlassian.net/rest/api/3/version/10000',
+            id: '10000',
+            name: 'v4.167.0',
+            archived: false,
+            released: true,
+            releaseDate: '2025-06-30',
+            projectId: 10001,
+          };
+        });
+
+      // when
+      const result = await finalize(versionId);
+
+      // then
+      expect(result).to.be.true;
+      expect(loggerStub).not.to.have.been.called;
+      dateStub.restore();
+    });
+
+    it('should handle version not found error', async function () {
+      // given
+      const versionId = '99999';
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/99999')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('content-type', 'application/json')
+        .reply(404, {
+          errorMessages: ['The version with id 99999 does not exist.'],
+          errors: {},
+        });
+
+      // when
+      const result = await finalize(versionId);
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle permission denied error', async function () {
+      // given
+      const versionId = '10000';
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/10000')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('content-type', 'application/json')
+        .reply(403, {
+          errorMessages: ['You do not have permission to edit versions for this project.'],
+          errors: {},
+        });
+
+      // when
+      const result = await finalize(versionId);
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle network connection error and log it', async function () {
+      // given
+      const versionId = '10000';
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/10000')
+        .replyWithError({ code: 'ECONNREFUSED', message: 'Connection refused' });
+
+      // when
+      await catchErr(finalize)(versionId);
+
+      // then
+      expect(loggerStub).to.have.been.calledOnce;
+      expect(loggerStub.firstCall.args[0]).to.deep.include({
+        event: 'Jira release',
+        message: 'An error occurred',
+        job: 'jira service',
+        stack: 'finalize version',
+      });
+    });
+
+    it('should handle malformed response gracefully', async function () {
+      // given
+      const versionId = '10000';
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/10000')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('content-type', 'application/json')
+        .reply(200, 'Invalid JSON response');
+
+      // when
+      const result = await finalize(versionId);
+
+      // then
+      expect(result).to.be.true; // La fonction retourne true si la requête est ok, peu importe le contenu
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle server error (500)', async function () {
+      // given
+      const versionId = '10000';
+
+      nock('https://test-jira.atlassian.net')
+        .put('/rest/api/3/version/10000')
+        .matchHeader('authorization', 'Basic ' + btoa('integration-test-user:integration-test-token'))
+        .matchHeader('content-type', 'application/json')
+        .reply(500, {
+          errorMessages: ['Internal server error'],
+          errors: {},
+        });
+
+      // when
+      const result = await finalize(versionId);
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+  });
+
+  describe('Real-world integration scenarios', function () {
+    it('should handle complete release workflow', async function () {
+      // given - Simuler un workflow complet de release
+      const mockVersions = [
+        {
+          id: '10000',
+          name: 'v4.167.0',
+          released: false,
+          projectId: 10001,
+        },
+        {
+          id: '10001',
+          name: 'v4.168.0',
+          released: true,
+          releaseDate: '2025-06-15',
+          projectId: 10001,
+        },
+      ];
+
+      // Mock getVersionList
+      nock('https://test-jira.atlassian.net').get('/rest/api/3/project/PIX/versions').reply(200, mockVersions);
+
+      // Mock finalize pour la version non releasée
+      nock('https://test-jira.atlassian.net').put('/rest/api/3/version/10000').reply(200, {
+        id: '10000',
+        name: 'v4.167.0',
+        released: true,
+        releaseDate: '2025-06-30',
+        projectId: 10001,
+      });
+
+      // when
+      const versions = await getVersionList();
+      const unreleased = versions.find((v) => !v.released);
+      const finalizeResult = await finalize(unreleased.id);
+
+      // then
+      expect(versions).to.have.lengthOf(2);
+      expect(unreleased.name).to.equal('v4.167.0');
+      expect(finalizeResult).to.be.true;
+      expect(loggerStub).not.to.have.been.called;
+    });
+
+    it('should handle rate limiting from Jira API', async function () {
+      // given
+      nock('https://test-jira.atlassian.net')
+        .get('/rest/api/3/project/PIX/versions')
+        .reply(429, {
+          errorMessages: ['Rate limit exceeded. Try again later.'],
+          errors: {},
+        });
+
+      // when
+      const result = await getVersionList();
+
+      // then
+      expect(result).to.be.undefined;
+      expect(loggerStub).not.to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

On souhaiterais que les tickets soient déplacés automatiquement dans Jira lorsque la mise en production d'une version est faite.

## ⛱️ Proposition

Ajouter un service jira qui va récupérer les version, chercher la version qui vient d'être déployée en prod et appeler l'api de jira pour finaliser la livraison de cette version. La livraison entraînera le déplacement des tickets.

## 🌊 Remarques

J'ai aucune idée de si ça marche.

## 🏄 Pour tester

On tente ?
