### PR TITLE
[TECH] Commenter le code vérifiant que le build de la version releasée a bien fonctionné avant de MEP

### DIFF
--- a/run/services/tasks/release-production.js
+++ b/run/services/tasks/release-production.js
@@ -12,23 +12,23 @@ async function run({ repository, dependencies = { github: githubService, _postMe
   });
   try {
     const releaseTag = await dependencies.github.getLatestReleaseTag();
-    const buildStatus = await dependencies.github.isBuildStatusOK({ tagName: releaseTag.trim().toLowerCase() });
-    if (!buildStatus) {
-      logger.info({
-        event: 'release production',
-        message: `Build status is not OK for ${repository} release in production.`,
-      });
-      await dependencies._postMessage(
-        "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
-      );
-      return;
-    }
+    // const buildStatus = await dependencies.github.isBuildStatusOK({ tagName: releaseTag.trim().toLowerCase() });
+    // if (!buildStatus) {
+    //   logger.info({
+    //     event: 'release production',
+    //     message: `Build status is not OK for ${repository} release in production.`,
+    //   });
+    //   await dependencies._postMessage(
+    //     "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
+    //   );
+    //   return;
+    // }
     const { authorizeDeployment, blockReason } = await dependencies.getStatus({ repositoryName: 'pix' });
     if (!authorizeDeployment) {
       await dependencies._postMessage(`Rappel: la Mise en production est bloquée. Motif: ${blockReason}`);
       return;
     }
-    await dependencies._postMessage(`Hello :salut_main: Je lanse la mise en production de la ${releaseTag} !`);
+    await dependencies._postMessage(`Hello :salut_main: Je lance la mise en production de la ${releaseTag} !`);
     dependencies.releasesService.deploy(dependencies.releasesService.environments.production, releaseTag);
   } catch (error) {
     logger.error({

--- a/test/unit/run/services/tasks/release-production_test.js
+++ b/test/unit/run/services/tasks/release-production_test.js
@@ -31,10 +31,10 @@ describe('Unit | Run | Services | Tasks | Release production', function () {
 
       // then
       expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
-      expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+      // expect(dependencies.github.isBuildStatusOK).to.have.been.called;
       expect(dependencies.getStatus).to.have.been.calledWith({ repositoryName: 'pix' });
       expect(dependencies._postMessage).to.have.been.calledWith(
-        'Hello :salut_main: Je lanse la mise en production de la v1.0.0 !',
+        'Hello :salut_main: Je lance la mise en production de la v1.0.0 !',
       );
       expect(dependencies.releasesService.deploy).to.have.been.calledWith('production', 'v1.0.0');
     });
@@ -51,11 +51,11 @@ describe('Unit | Run | Services | Tasks | Release production', function () {
 
         // then
         expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
-        expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+        // expect(dependencies.github.isBuildStatusOK).to.have.been.called;
         expect(dependencies._postMessage).to.have.been.calledWith(
           "Impossible de lancer la mise en production. Veuillez consulter les logs pour plus d'informations",
         );
-        expect(dependencies.getStatus).to.not.have.been.called;
+        // expect(dependencies.getStatus).to.not.have.been.called;
         expect(dependencies.releasesService.deploy).to.not.have.been.called;
       });
     });
@@ -74,7 +74,7 @@ describe('Unit | Run | Services | Tasks | Release production', function () {
 
         // then
         expect(dependencies.github.getLatestReleaseTag).to.have.been.called;
-        expect(dependencies.github.isBuildStatusOK).to.have.been.called;
+        // expect(dependencies.github.isBuildStatusOK).to.have.been.called;
         expect(dependencies.getStatus).to.have.been.calledWith({ repositoryName: 'pix' });
         expect(dependencies._postMessage).to.have.been.calledWith(
           'Rappel: la Mise en production est bloquée. Motif: Maintenance',


### PR DESCRIPTION
## 🔆 Problème
Aujourd'hui, nous vérifions avant de MEP que la version releasée a bien build (comme cela est fait actuellement par la MEP via Slack). Nous avons cependant deux problèmes:
- Cette vérification n'a jamais fonctionné pour la MEP via Slack (méthode asychrone sans await).
- Le commit de release ne déclenche pas de build ([skip-ci] dans le commit)

## ⛱️ Proposition
Nous avons choisi de commenter le code afin de débloquer les MEP automatisées avant de trouver une solution plus pérenne.