### PR TITLE
[BUGFIX] Mettre à jour l'emoji du message de lancement de MEP (PIX-18553)

### DIFF
--- a/run/services/tasks/release-production.js
+++ b/run/services/tasks/release-production.js
@@ -28,7 +28,7 @@ async function run({ repository, dependencies = { github: githubService, _postMe
       await dependencies._postMessage(`Rappel: la Mise en production est bloquée. Motif: ${blockReason}`);
       return;
     }
-    await dependencies._postMessage(`Hello :salut_main: Je lance la mise en production de la ${releaseTag} !`);
+    await dependencies._postMessage(`Hello :wave: Je lance la mise en production de la ${releaseTag} !`);
     dependencies.releasesService.deploy(dependencies.releasesService.environments.production, releaseTag);
   } catch (error) {
     logger.error({

--- a/test/unit/run/services/tasks/release-production_test.js
+++ b/test/unit/run/services/tasks/release-production_test.js
@@ -34,7 +34,7 @@ describe('Unit | Run | Services | Tasks | Release production', function () {
       // expect(dependencies.github.isBuildStatusOK).to.have.been.called;
       expect(dependencies.getStatus).to.have.been.calledWith({ repositoryName: 'pix' });
       expect(dependencies._postMessage).to.have.been.calledWith(
-        'Hello :salut_main: Je lance la mise en production de la v1.0.0 !',
+        'Hello :wave: Je lance la mise en production de la v1.0.0 !',
       );
       expect(dependencies.releasesService.deploy).to.have.been.calledWith('production', 'v1.0.0');
     });


### PR DESCRIPTION
## 🔆 Problème

Lors de l'envoie du message pour informer de la mep, on utilisait :salut_main: qui ne fonctionne pas à tous les coups.

## ⛱️ Proposition

Utiliser l'écriture Slack officielle qui est 👋.