### PR TITLE
[FEATURE] Déployer pix-exploit depuis pix-bot

### DIFF
--- a/config.js
+++ b/config.js
@@ -210,6 +210,9 @@ const configuration = (function () {
     PIX_DBT_APPS_NAME: ['pix-dbt-production', 'pix-dbt-external-production'],
     PIX_API_TO_PG_APPS_NAME: ['pix-api-to-pg-production'],
 
+    PIX_EXPLOIT_REPO_NAME: 'pix-exploit',
+    PIX_EXPLOIT_APP_NAME: 'pix-exploit-production',
+
     repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING) || {},
   };
 

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -177,6 +177,14 @@ const slack = {
     }
   },
 
+  async deployPixExploitRelease() {
+    commands.deployPixExploitRelease();
+
+    return {
+      text: 'Commande de déploiement sur la production bien reçue.',
+    };
+  },
+
   async unlockRelease(request) {
     const payload = request.pre.payload;
     commands.unlockRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -121,6 +121,14 @@ manifest.registerSlashCommand({
   handler: slackbotController.deployDBT,
 });
 
+manifest.registerSlashCommand({
+  command: '/deploy-pix-exploit',
+  path: '/slack/commands/deploy-pix-exploit-release',
+  description: 'Déploie la dernière release de pix-exploit en production',
+  should_escape: false,
+  handler: slackbotController.deployPixExploitRelease,
+});
+
 manifest.registerShortcut({
   name: 'MEP/Déployer une version',
   type: 'global',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -7,6 +7,7 @@ import slackPostMessageService from '../../../common/services/slack/surfaces/mes
 import { config } from '../../../config.js';
 import { deploy } from '../deploy.js';
 import { updateStatus } from '../../../common/repositories/release-settings.repository.js';
+import github from '../../../common/services/github.js';
 
 function sendResponse(responseUrl, text) {
   axios.post(
@@ -224,6 +225,11 @@ async function deployPixApiToPg(payload) {
   await deployTagUsingSCM(config.PIX_API_TO_PG_APPS_NAME, version);
 }
 
+async function deployPixExploitRelease() {
+  const releaseTag = await github.getLatestReleaseTag(config.PIX_EXPLOIT_REPO_NAME);
+  await deployTagUsingSCM(config.PIX_EXPLOIT_APP_NAME, releaseTag);
+}
+
 async function unlockRelease(payload) {
   await updateStatus({ repositoryName: 'pix', environment: 'production', authorizeDeployment: true });
   const message = `La mise en production a été débloquée par <@${payload.user_id}> 😅 il est de nouveau possible de la lancer.`;
@@ -244,6 +250,7 @@ export {
   createAndDeployPixUI,
   deployAirflow,
   deployDBT,
+  deployPixExploitRelease,
   deployPixApiToPg,
   getAndDeployLastVersion,
   unlockRelease,

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -134,6 +134,12 @@ describe('Acceptance | Run | Manifest', function () {
               usage_hint: '/deploy-dbt $version',
             },
             {
+              command: '/deploy-pix-exploit',
+              url: `http://${hostname}/slack/commands/deploy-pix-exploit-release`,
+              description: 'Déploie la dernière release de pix-exploit en production',
+              should_escape: false,
+            },
+            {
               command: '/deploy-pix-api-to-pg',
               description: 'Déploie la version précisée de pix-api-to-pg en production',
               should_escape: false,


### PR DESCRIPTION
## 🔆 Problème

On a besoin de passer par Scalingo pour déployer les tags de pix-exploit en production.

## ⛱️ Proposition

Ajouter une commande pix-bot pour déployer le dernier tag sur l'environnement de production.

## 🌊 Remarques

Il faudra ajouter la commande à pix-bot-run.

## 🏄 Pour tester

TESTE effectué en local.
