### PR TITLE
[BUGFIX] Corriger le déploiement de la dernière release de pix-exploit en production

### DIFF
--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -227,7 +227,7 @@ async function deployPixApiToPg(payload) {
 
 async function deployPixExploitRelease() {
   const releaseTag = await github.getLatestReleaseTag(config.PIX_EXPLOIT_REPO_NAME);
-  await deployTagUsingSCM(config.PIX_EXPLOIT_APP_NAME, releaseTag);
+  await deployTagUsingSCM([config.PIX_EXPLOIT_APP_NAME], releaseTag);
 }
 
 async function unlockRelease(payload) {


### PR DESCRIPTION
## 🔆 Problème
Actuellement, la commande de déploiement de la dernière release de pix-exploit en production génère une erreur car la méthode `deployTagUsingSCM` s'attend à un tableau d'applications et non pas à une application unique.

## ⛱️ Proposition
Corriger le déploiement de la dernière release de pix-exploit en production.