### PR TITLE
[FEATURE] Utiliser le workflow de release sur Pix-bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  repository_dispatch:
+    types: [ 'deploy' ]
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - uses: 1024pix/pix-actions/release@main
+        id: semantic
+        with:
+          changelogTitle: "# Pix Bot Changelog"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_RELEASE_ACTION_TOKEN }}

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -75,12 +75,11 @@ const slack = {
     };
   },
 
-  createAndDeployPixBotRelease(request) {
-    const payload = request.pre.payload;
-    commands.createAndDeployPixBotRelease(payload);
+  createAndDeployPixBotRelease() {
+    commands.createAndDeployPixBotRelease();
 
     return {
-      text: _getDeployStartedMessage(payload.text, 'PIX Bot'),
+      text: 'Commande de déploiement de Pix-bot bien reçu.',
     };
   },
 

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -53,7 +53,6 @@ manifest.registerSlashCommand({
   command: '/deploy-pix-bot',
   path: '/slack/commands/create-and-deploy-pix-bot-release',
   description: 'Releaser et déployer pix-bot-run et pix-bot-build',
-  usage_hint: '[patch, minor, major]',
   should_escape: false,
   handler: slackbotController.createAndDeployPixBotRelease,
 });

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -7,7 +7,6 @@ import slackPostMessageService from '../../../common/services/slack/surfaces/mes
 import { config } from '../../../config.js';
 import { deploy } from '../deploy.js';
 import { updateStatus } from '../../../common/repositories/release-settings.repository.js';
-import github from '../../../common/services/github.js';
 
 function sendResponse(responseUrl, text) {
   axios.post(
@@ -180,13 +179,14 @@ async function createAndDeployPixDatawarehouse(payload) {
   );
 }
 
-async function createAndDeployPixBotRelease(payload) {
-  await _publishAndDeployReleaseWithAppsByEnvironment(
-    config.PIX_BOT_REPO_NAME,
-    config.PIX_BOT_APPS,
-    payload.text,
-    payload.response_url,
-  );
+async function createAndDeployPixBotRelease() {
+  await githubServices.triggerWorkflow({
+    workflow: {
+      id: 'release.yml',
+      repositoryName: config.PIX_BOT_REPO_NAME,
+      ref: 'main',
+    },
+  });
 }
 
 async function getAndDeployLastVersion({ appName }) {

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -81,7 +81,6 @@ describe('Acceptance | Run | Manifest', function () {
               command: '/deploy-pix-bot',
               url: `http://${hostname}/slack/commands/create-and-deploy-pix-bot-release`,
               description: 'Releaser et déployer pix-bot-run et pix-bot-build',
-              usage_hint: '[patch, minor, major]',
               should_escape: false,
             },
             {

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -7,7 +7,6 @@ import ScalingoClient from '../../../../../common/services/scalingo-client.js';
 import {
   createAndDeployDbStats,
   createAndDeployEmberTestingLibrary,
-  createAndDeployPixBotRelease,
   createAndDeployPixDatawarehouse,
   createAndDeployPixLCMS,
   createAndDeployPixSiteRelease,
@@ -175,34 +174,6 @@ describe('Unit | Run | Services | Slack | Commands', function () {
     it('should deploy the release on minimal', function () {
       // then
       sinon.assert.calledWith(client.deployFromArchive, 'pix-lcms-minimal-production', 'v1.0.0');
-    });
-  });
-
-  describe('#createAndDeployPixBotRelease', function () {
-    let client;
-
-    beforeEach(async function () {
-      // given
-      client = { deployFromArchive: sinon.spy() };
-      sinon.stub(ScalingoClient, 'getInstance').resolves(client);
-      const payload = { text: 'minor' };
-      // when
-      await createAndDeployPixBotRelease(payload);
-    });
-
-    it('should publish a new release', function () {
-      // then
-      sinon.assert.calledWith(releasesService.publishPixRepo, 'pix-bot', 'minor');
-    });
-
-    it('should deploy the release for pix-bot-build', function () {
-      // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-build-production', 'v1.0.0');
-    });
-
-    it('should deploy the release for pix-bot-run', function () {
-      // then
-      sinon.assert.calledWith(client.deployFromArchive, 'pix-bot-run-production', 'v1.0.0');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

On est obligé de faire le déploiement de pix-bot manuellement sur Slack. 

## ⛱️ Proposition

Mettre en place le workflow qui tag et déploie les releases à chaques push sur main.

## 🌊 Remarques

Il faudra ajouter sur le dépôt:
- PIX_SERVICE_RELEASE_ACTION_TOKEN sur GitHub avec le token permettant de faire des releases,
- Mettre à jour la variable REPO_APP_NAMES_MAPPING avec {"pix-bot": ["pix-bot-build-production","pix-bot-run-production"]}

## 🏄 Pour tester

Merger et admirer!
