### PR TITLE
[TECH] Ajouter la configuration pour déployer les RA de pix-nina

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -19,6 +19,7 @@ const repositoryToScalingoAppsReview = {
   'pix-editor': ['pix-lcms-review'],
   'pix-epreuves': ['pix-epreuves-review'],
   'pix-exploit': ['pix-exploit-review'],
+  'pix-nina': ['pix-nina-review'],
   'pix-site': ['pix-site-review', 'pix-pro-review'],
   'pix-tutos': ['pix-tutos-review'],
   'pix-ui': ['pix-ui-review'],

--- a/build/templates/pull-request-messages/pix-nina.md
+++ b/build/templates/pull-request-messages/pix-nina.md
@@ -1,0 +1,2 @@
+Une fois l'application déployée, elle sera accessible à cette adresse https://pix-nina-review-pr{{pullRequestId}}.osc-fr1.scalingo.io
+Les variables d'environnement seront accessibles sur scalingo https://dashboard.scalingo.com/apps/osc-fr1/pix-nina-review-pr{{pullRequestId}}/environment


### PR DESCRIPTION
## 🔆 Problème
Actuellement, pix-nina est utilisé en local et sur les RA mais la configuration permettant de déployer automatiquement ses RA n'existe pas.

## ⛱️ Proposition
Ajouter la configuration pour déployer les RA de pix-nina