### PR TITLE
[FEATURE] Ignorer les PRs labelisées Hera

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -82,6 +82,10 @@ async function _handleRA(
     return message;
   }
 
+  if (isHera(request)) {
+    return 'Handled by Hera';
+  }
+
   const deployedRA = await deployPullRequest(
     scalingoClient,
     reviewApps,
@@ -109,6 +113,10 @@ async function _handleCloseRA(
 
   if (!reviewApps) {
     return `${repository} is not managed by Pix Bot.`;
+  }
+
+  if (isHera(request)) {
+    return 'Handled by Hera';
   }
 
   let client;
@@ -354,6 +362,10 @@ async function _handleNoRACase(request, githubService) {
   }
 
   return { shouldContinue: true };
+}
+
+function isHera(request) {
+  return request.payload.pull_request.labels.some((label) => label.name === 'Hera');
 }
 
 export {

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -612,6 +612,7 @@ describe('Acceptance | Build | Github', function () {
               },
             },
             merged: false,
+            labels: [],
           },
         };
 

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -606,6 +606,19 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           expect(response).to.equal('No RA for closed PR');
         });
       });
+
+      describe('when the PR is labeled Hera', function () {
+        it('delegates handling RA to Hera', async function () {
+          // given
+          sinon.stub(request.payload.pull_request, 'labels').value([{ name: 'Hera' }]);
+
+          // when
+          const response = await githubController.handleRA(request);
+
+          // then
+          expect(response).to.equal('Handled by Hera');
+        });
+      });
     });
 
     describe('when the Review App creation conditions are met', function () {
@@ -750,6 +763,19 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           },
         },
       };
+    });
+
+    describe('when the PR is labeled Hera', function () {
+      it('delegates handling RA to Hera', async function () {
+        // given
+        sinon.stub(request.payload.pull_request, 'labels').value([{ name: 'Hera' }]);
+
+        // when
+        const response = await githubController.handleCloseRA(request);
+
+        // then
+        expect(response).to.equal('Handled by Hera');
+      });
     });
 
     describe('when the review app is not managed by Pix Bot', function () {


### PR DESCRIPTION
## 🔆 Problème

On veut pouvoir beta tester un nouveau fonctionnement pour les reviews apps.

## ⛱️ Proposition

Ignorer les PRs labelisées Hera.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A