### PR TITLE
[TECH] Fermeture de PR Hera

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -120,10 +120,6 @@ async function _handleCloseRA(
     return `${repository} is not managed by Pix Bot.`;
   }
 
-  if (isHera(request.payload.pull_request)) {
-    return 'Handled by Hera';
-  }
-
   let client;
   const closedRA = [];
 

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -916,19 +916,6 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
       };
     });
 
-    describe('when the PR is labeled Hera', function () {
-      it('delegates handling RA to Hera', async function () {
-        // given
-        sinon.stub(request.payload.pull_request, 'labels').value([{ name: 'Hera' }]);
-
-        // when
-        const response = await githubController.handleCloseRA(request);
-
-        // then
-        expect(response).to.equal('Handled by Hera');
-      });
-    });
-
     describe('when the review app is not managed by Pix Bot', function () {
       it('should not try to close the review app', async function () {
         // given


### PR DESCRIPTION
## 🔆 Problème

L’événement de fermeture de PR n’était pas géré.

## ⛱️ Proposition

Gérer les fermeture de PR Hera de la même manière que les autres PRs.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Fermer une PR Hera avec des applis cochées.
