### PR TITLE
[TECH] Supprimer la colonne `review-apps.isDeployed`

### DIFF
--- a/db/migrations/20250725102927_remove-review-apps-isdeployed.js
+++ b/db/migrations/20250725102927_remove-review-apps-isdeployed.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'review-apps';
+const COLUMN_NAME = 'isDeployed';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+const down = async function () {};
+
+export { up, down };


### PR DESCRIPTION
## 🔆 Problème

La colonne `review-apps.isDeployed` n’est plus utilisée.

## ⛱️ Proposition

Supprimer la colonne.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A