### PR TITLE
[BUGFIX] Gérer le check-ra-deployment correctement lors d’un synchronize

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -190,6 +190,7 @@ async function deployPullRequest(
     try {
       const reviewAppExists = await client.reviewAppExists(reviewAppName);
       if (reviewAppExists) {
+        await reviewAppRepository.setStatus({ name: reviewAppName, status: 'pending' });
         await client.deployUsingSCM(reviewAppName, ref);
       } else {
         await reviewAppRepository.create({ name: reviewAppName, repository, prNumber: prId, parentApp: appName });

--- a/build/repositories/review-app-repository.js
+++ b/build/repositories/review-app-repository.js
@@ -7,27 +7,10 @@ export const create = async function ({ name, repository, prNumber, parentApp })
   });
 };
 
-export const markAsDeployed = async function ({ name }) {
-  const result = await knex('review-apps')
-    .update({ status: 'success' })
-    .where({ name })
-    .returning(['repository', 'prNumber']);
-  if (result.length === 0) {
-    throw new Error(`${name} doesn't exist.`);
-  }
-  return result[0];
-};
-
-export const markAsFailed = async function ({ name }) {
-  const result = await knex('review-apps')
-    .update({ status: 'failure' })
-    .where({ name })
-    .returning(['repository', 'prNumber']);
-  if (result.length === 0) {
-    throw new Error(`${name} doesn't exist.`);
-  }
-  return result[0];
-};
+export async function setStatus({ name, status }) {
+  const [result] = await knex('review-apps').update({ status }).where({ name }).returning(['repository', 'prNumber']);
+  return result;
+}
 
 export const areAllDeployed = async function ({ repository, prNumber }) {
   const { count } = await knex('review-apps')

--- a/test/integration/build/repositories/review-app-repository_test.js
+++ b/test/integration/build/repositories/review-app-repository_test.js
@@ -1,4 +1,4 @@
-import { catchErr, expect } from '../../../test-helper.js';
+import { expect } from '../../../test-helper.js';
 import * as reviewAppRepository from '../../../../build/repositories/review-app-repository.js';
 import { knex } from '../../../../db/knex-database-connection.js';
 
@@ -63,13 +63,14 @@ describe('Integration | Build | Repository | Review App', function () {
     });
   });
 
-  describe('markAsDeployed', function () {
-    it('should set isDeployed to true and return repository and prNumber', async function () {
+  describe('setStatus', function () {
+    it('sets status and return repository and prNumber', async function () {
       // given
       const name = 'pix-api-review-pr123';
       const repository = 'pix';
       const prNumber = 123;
       const parentApp = 'pix-api-review';
+      const status = 'success';
 
       await knex('review-apps').insert({
         name,
@@ -79,56 +80,24 @@ describe('Integration | Build | Repository | Review App', function () {
       });
 
       // when
-      const result = await reviewAppRepository.markAsDeployed({ name });
+      const result = await reviewAppRepository.setStatus({ name, status });
 
-      const updatedReviewApp = await knex('review-apps').where({ name }).first();
-      expect(updatedReviewApp.status).to.equal('success');
-      expect(result.repository).to.equal(repository);
-      expect(result.prNumber).to.equal(prNumber);
-    });
-
-    describe('when review app does not exist', function () {
-      it('should throw an Error', async function () {
-        // when
-        const name = 'does-not-exist';
-        const error = await catchErr(reviewAppRepository.markAsDeployed)({ name });
-
-        expect(error.message).to.equal(`${name} doesn't exist.`);
-      });
-    });
-  });
-
-  describe('markAsFailed', function () {
-    it('should set isDeployed to false and return repository and prNumber', async function () {
-      // given
-      const name = 'pix-api-review-pr123';
-      const repository = 'pix';
-      const prNumber = 123;
-      const parentApp = 'pix-api-review';
-
-      await knex('review-apps').insert({
-        name,
+      expect(result).to.deep.equal({
         repository,
         prNumber,
-        parentApp,
       });
-
-      // when
-      const result = await reviewAppRepository.markAsFailed({ name });
-
       const updatedReviewApp = await knex('review-apps').where({ name }).first();
-      expect(updatedReviewApp.status).to.equal('failure');
-      expect(result.repository).to.equal(repository);
-      expect(result.prNumber).to.equal(prNumber);
+      expect(updatedReviewApp).to.have.property('status', 'success');
     });
 
     describe('when review app does not exist', function () {
-      it('should throw an Error', async function () {
+      it('returns undefined', async function () {
         // when
         const name = 'does-not-exist';
-        const error = await catchErr(reviewAppRepository.markAsFailed)({ name });
+        const status = 'success';
+        const result = await reviewAppRepository.setStatus({ name, status });
 
-        expect(error.message).to.equal(`${name} doesn't exist.`);
+        expect(result).to.be.undefined;
       });
     });
   });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -884,6 +884,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           };
           const reviewAppRepositoryStub = {
             create: sinon.stub(),
+            setStatus: sinon.stub(),
           };
 
           scalingoClientStub.getInstance = sinon.stub().returns({
@@ -903,20 +904,35 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           );
 
           // then
-          expect(deployReviewAppStub.calledOnceWithExactly('pix-api-review', 3)).to.be.true;
-          expect(disableAutoDeployStub.calledOnceWithExactly('pix-api-review-pr3')).to.be.true;
-          expect(
-            reviewAppRepositoryStub.create.calledWith({
-              name: 'pix-api-review-pr3',
-              repository: 'pix',
-              prNumber: 3,
-              parentApp: 'pix-api-review',
-            }),
-          ).to.be.true;
-          expect(deployUsingSCMStub.getCall(0).calledWith('pix-api-review-pr3', 'my-branch')).to.be.true;
-          expect(deployUsingSCMStub.getCall(1).calledWith('pix-api-maddo-review-pr3', 'my-branch')).to.be.true;
-          expect(deployUsingSCMStub.getCall(2).calledWith('pix-audit-logger-review-pr3', 'my-branch')).to.be.true;
-          expect(deployUsingSCMStub.getCall(3).calledWith('pix-front-review-pr3', 'my-branch')).to.be.true;
+          expect(deployReviewAppStub).to.have.been.calledOnceWithExactly('pix-api-review', 3);
+          expect(disableAutoDeployStub).to.have.been.calledOnceWithExactly('pix-api-review-pr3');
+          expect(reviewAppRepositoryStub.create).to.have.been.calledOnceWithExactly({
+            name: 'pix-api-review-pr3',
+            repository: 'pix',
+            prNumber: 3,
+            parentApp: 'pix-api-review',
+          });
+
+          expect(reviewAppRepositoryStub.setStatus.getCall(0)).to.have.been.calledWithExactly({
+            name: 'pix-api-maddo-review-pr3',
+            status: 'pending',
+          });
+          expect(reviewAppRepositoryStub.setStatus.getCall(1)).to.have.been.calledWithExactly({
+            name: 'pix-audit-logger-review-pr3',
+            status: 'pending',
+          });
+          expect(reviewAppRepositoryStub.setStatus.getCall(2)).to.have.been.calledWithExactly({
+            name: 'pix-front-review-pr3',
+            status: 'pending',
+          });
+
+          expect(deployUsingSCMStub.getCall(0)).to.have.been.calledWithExactly('pix-api-review-pr3', 'my-branch');
+          expect(deployUsingSCMStub.getCall(1)).to.have.been.calledWithExactly('pix-api-maddo-review-pr3', 'my-branch');
+          expect(deployUsingSCMStub.getCall(2)).to.have.been.calledWithExactly(
+            'pix-audit-logger-review-pr3',
+            'my-branch',
+          );
+          expect(deployUsingSCMStub.getCall(3)).to.have.been.calledWithExactly('pix-front-review-pr3', 'my-branch');
 
           expect(response).to.equal(
             'Triggered deployment of RA on app pix-api-review, pix-api-maddo-review, pix-audit-logger-review, pix-front-review with pr 3',


### PR DESCRIPTION
## 🔆 Problème

Lors d’un synchronize, le déploiement des RAs est re-déclenché, mais le status (anciennement isDeployed) n’est pas correctement réinitialisé à pending en BdD.
Par conséquent, lors de la réception des événements de fin de déploiement de Scalingo, le status de check-ra-deployment n’est pas correctement calculé.

Autre problème :
Lorsque le webhook Scalingo appelle pix-bot-build-production pour une RA gérée par pix-bot-integration ou vice versa, cela provoque une erreur 500 car le RA n’existe pas en BdD.

## ⛱️ Proposition

Réinitialiser le status en BdD lors du synchronize.

Ne pas faire d’erreur 500 lorsque le webhook Scalingo appelle pour une RA inconnue en BdD.

## 🌊 Remarques

Cette PR ne concerne que l’ancien fonctionnement (hors Hera).

## 🏄 Pour tester

N/A