### PR TITLE
[TECH] Refactorer createCommitStatus

### DIFF
--- a/build/controllers/scalingo.js
+++ b/build/controllers/scalingo.js
@@ -74,7 +74,7 @@ const scalingo = {
     const event = 'review-app-deploy';
     const appName = request.payload.app_name;
     const type = request.payload.type;
-    const { status, deployment_type: deploymentType } = request.payload.type_data;
+    const { status, deployment_type: deploymentType, git_ref: sha } = request.payload.type_data;
 
     logger.info({
       event,
@@ -111,7 +111,7 @@ const scalingo = {
         message: `Changing check-ra-deployment status to failure`,
         data: { repository, prNumber },
       });
-      await updateCheckRADeployment({ repositoryName: repository, pullRequestNumber: prNumber });
+      await updateCheckRADeployment({ repositoryName: repository, pullRequestNumber: prNumber, sha });
       return h.response().code(200);
     }
 
@@ -124,7 +124,7 @@ const scalingo = {
 
     const { repository, prNumber } = reviewApp;
 
-    await updateCheckRADeployment({ repositoryName: repository, pullRequestNumber: prNumber });
+    await updateCheckRADeployment({ repositoryName: repository, pullRequestNumber: prNumber, sha });
 
     return h.response().code(200);
   },

--- a/build/usecases/updateCheckRADeployment.js
+++ b/build/usecases/updateCheckRADeployment.js
@@ -3,7 +3,7 @@ import commonGithubService from '../../common/services/github.js';
 import { logger } from '../../common/services/logger.js';
 
 export async function updateCheckRADeployment(
-  { repositoryName, pullRequestNumber },
+  { repositoryName, pullRequestNumber, sha },
   dependencies = { reviewAppRepo, githubService: commonGithubService },
 ) {
   const reviewApps = await dependencies.reviewAppRepo.listForPullRequest({
@@ -28,5 +28,6 @@ export async function updateCheckRADeployment(
     repository: repositoryName,
     prNumber: pullRequestNumber,
     status,
+    sha,
   });
 }

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -296,14 +296,11 @@ describe('Integration | Build | Scalingo', function () {
           type_data: {
             status: 'success',
             deployment_type: 'deployment',
+            git_ref: 'abc123',
           },
           app_name: appName,
           type: 'deployment',
         };
-        const getPullRequestNock = nock('https://api.github.com')
-          .get(`/repos/1024pix/pix/pulls/123`)
-          .reply(200, { head: { sha: 'abc123' } });
-
         const addRADeploymentCheckNock = nock('https://api.github.com')
           .post(`/repos/1024pix/pix/statuses/abc123`, {
             context: 'check-ra-deployment',
@@ -322,7 +319,6 @@ describe('Integration | Build | Scalingo', function () {
         expect(response.statusCode).to.equal(200);
         const reviewApp = await knex('review-apps').where({ name: appName }).first();
         expect(reviewApp.status).to.equal('success');
-        expect(getPullRequestNock.isDone()).to.be.true;
         expect(addRADeploymentCheckNock.isDone()).to.be.true;
       });
 
@@ -350,10 +346,6 @@ describe('Integration | Build | Scalingo', function () {
 
           const sha = 'a-commit-sha';
 
-          const getPullRequestNock = nock('https://api.github.com')
-            .get(`/repos/1024pix/${repository}/pulls/${prNumber}`)
-            .reply(200, { head: { sha } });
-
           const addRADeploymentCheckNock = nock('https://api.github.com')
             .post(`/repos/1024pix/${repository}/statuses/${sha}`, {
               context: 'check-ra-deployment',
@@ -365,6 +357,7 @@ describe('Integration | Build | Scalingo', function () {
             type_data: {
               status: 'success',
               deployment_type: 'deployment',
+              git_ref: sha,
             },
             app_name: appName,
             type: 'deployment',
@@ -379,7 +372,6 @@ describe('Integration | Build | Scalingo', function () {
 
           // then
           expect(response.statusCode).to.equal(200);
-          expect(getPullRequestNock.isDone()).to.be.true;
           expect(addRADeploymentCheckNock.isDone()).to.be.true;
         });
       });
@@ -405,9 +397,6 @@ describe('Integration | Build | Scalingo', function () {
         });
 
         const sha = 'a-commit-sha';
-        const getPullRequestNock = nock('https://api.github.com')
-          .get(`/repos/1024pix/${repository}/pulls/${prNumber}`)
-          .reply(200, { head: { sha } });
 
         const addRADeploymentCheckNock = nock('https://api.github.com')
           .post(`/repos/1024pix/${repository}/statuses/${sha}`, {
@@ -420,6 +409,7 @@ describe('Integration | Build | Scalingo', function () {
           type_data: {
             status: 'build-error',
             deployment_type: 'deployment',
+            git_ref: sha,
           },
           app_name: appName,
           type: 'deployment',
@@ -436,7 +426,6 @@ describe('Integration | Build | Scalingo', function () {
         expect(response.statusCode).to.equal(200);
         const reviewApp = await knex('review-apps').where({ name: appName }).first();
         expect(reviewApp.status).to.equal('failure');
-        expect(getPullRequestNock.isDone()).to.be.true;
         expect(addRADeploymentCheckNock.isDone()).to.be.true;
       });
     });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -709,6 +709,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               name: 'pix',
               fork: false,
             },
+            sha: 'abc123',
           },
         },
       },
@@ -752,9 +753,12 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
 
           // then
           expect(response).to.equal('RA disabled for this PR');
-          expect(
-            githubServiceMock.addRADeploymentCheck.calledWith({ repository: 'pix', prNumber: 3, status: 'success' }),
-          ).to.be.true;
+          expect(githubServiceMock.addRADeploymentCheck).to.have.been.calledWith({
+            repository: 'pix',
+            prNumber: 3,
+            status: 'success',
+            sha: 'abc123',
+          });
         });
       });
 
@@ -947,6 +951,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
                 name: 'pix',
                 fork: false,
               },
+              sha: 'abc123',
             },
           },
         },
@@ -1008,6 +1013,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
           pullRequestNumber: 3,
+          sha: 'abc123',
         });
       });
 
@@ -1043,6 +1049,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
           pullRequestNumber: 3,
+          sha: 'abc123',
         });
       });
     });
@@ -1084,6 +1091,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
           pullRequestNumber: 3,
+          sha: 'abc123',
         });
       });
 
@@ -1117,6 +1125,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
           expect(updateCheckRADeployment).to.have.been.calledWith({
             repositoryName: 'pix',
             pullRequestNumber: 3,
+            sha: 'abc123',
           });
         });
       });
@@ -1179,6 +1188,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               repo: {
                 name: 'pix',
               },
+              sha: 'abc123',
             },
           },
         },
@@ -1201,6 +1211,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         repository: 'pix',
         prNumber: 123,
         status: 'success',
+        sha: 'abc123',
       });
     });
   });
@@ -1433,6 +1444,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
               fork: false,
             },
             ref: 'branche-a-deployer',
+            sha: 'abc123',
           },
           state: 'open',
           labels: [{ name: 'Hera' }],
@@ -1476,6 +1488,7 @@ Les variables d'environnement seront accessibles sur scalingo https://dashboard.
         expect(updateCheckRADeployment).to.have.been.calledWithExactly({
           repositoryName: 'pix',
           pullRequestNumber: 123,
+          sha: 'abc123',
         });
         expect(result).equal(`Created review apps: pix-front-review-pr123
 Removed review apps: pix-api-maddo-review-pr123`);
@@ -1662,6 +1675,7 @@ Removed review apps: pix-api-maddo-review-pr123`);
               repo: {
                 name: 'pix',
               },
+              sha: 'abc123',
             },
           },
         },
@@ -1711,6 +1725,7 @@ Removed review apps: pix-api-maddo-review-pr123`);
       expect(updateCheckRADeployment).to.have.been.calledOnceWithExactly({
         repositoryName: 'pix',
         pullRequestNumber: 123,
+        sha: 'abc123',
       });
     });
   });
@@ -1726,6 +1741,7 @@ Removed review apps: pix-api-maddo-review-pr123`);
               repo: {
                 name: 'pix',
               },
+              sha: 'abc123',
             },
           },
         },
@@ -1748,6 +1764,7 @@ Removed review apps: pix-api-maddo-review-pr123`);
         repository: 'pix',
         prNumber: 123,
         status: 'success',
+        sha: 'abc123',
       });
     });
   });

--- a/test/unit/build/usecases/updateCheckRADeployment_test.js
+++ b/test/unit/build/usecases/updateCheckRADeployment_test.js
@@ -7,6 +7,7 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       // given
       const repositoryName = 'pix';
       const pullRequestNumber = 123;
+      const sha = 'abc123';
       const reviewAppRepo = {
         listForPullRequest: sinon
           .stub()
@@ -17,13 +18,14 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       };
 
       // when
-      await updateCheckRADeployment({ repositoryName, pullRequestNumber }, { reviewAppRepo, githubService });
+      await updateCheckRADeployment({ repositoryName, pullRequestNumber, sha }, { reviewAppRepo, githubService });
 
       // then
       expect(githubService.addRADeploymentCheck).to.have.been.calledOnceWithExactly({
         repository: repositoryName,
         prNumber: pullRequestNumber,
         status: 'failure',
+        sha,
       });
     });
   });
@@ -33,6 +35,7 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       // given
       const repositoryName = 'pix';
       const pullRequestNumber = 123;
+      const sha = 'abc123';
       const reviewAppRepo = {
         listForPullRequest: sinon
           .stub()
@@ -43,13 +46,14 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       };
 
       // when
-      await updateCheckRADeployment({ repositoryName, pullRequestNumber }, { reviewAppRepo, githubService });
+      await updateCheckRADeployment({ repositoryName, pullRequestNumber, sha }, { reviewAppRepo, githubService });
 
       // then
       expect(githubService.addRADeploymentCheck).to.have.been.calledOnceWithExactly({
         repository: repositoryName,
         prNumber: pullRequestNumber,
         status: 'pending',
+        sha,
       });
     });
   });
@@ -59,6 +63,7 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       // given
       const repositoryName = 'pix';
       const pullRequestNumber = 123;
+      const sha = 'abc123';
       const reviewAppRepo = {
         listForPullRequest: sinon
           .stub()
@@ -69,13 +74,14 @@ describe('Unit | Usecases | #updateCheckRADeployment', function () {
       };
 
       // when
-      await updateCheckRADeployment({ repositoryName, pullRequestNumber }, { reviewAppRepo, githubService });
+      await updateCheckRADeployment({ repositoryName, pullRequestNumber, sha }, { reviewAppRepo, githubService });
 
       // then
       expect(githubService.addRADeploymentCheck).to.have.been.calledOnceWithExactly({
         repository: repositoryName,
         prNumber: pullRequestNumber,
         status: 'success',
+        sha,
       });
     });
   });


### PR DESCRIPTION
## 🔆 Problème
A chaque fois que createCommitStatus est appelé, un appel à l'API GitHub est fait alors que ce n'est pas nécessaire. Cet appel n'est fait que pour récupérer le sha ; or on a d'autres moyens pour récupérer cette donnée.

## ⛱️ Proposition
On ne va chercher la pull request via l'API GitHub que si le sha n'est pas renseigné à l'appel de createCommitStatus.

## 🏄 Pour tester
Créer une PR et tester le déploiement.