### PR TITLE
[FEATURE] Création de la colonne autodeployEnabled dans la table review-apps

### DIFF
--- a/db/migrations/20250730091229_add-review-apps-autodeploy-enabled.js
+++ b/db/migrations/20250730091229_add-review-apps-autodeploy-enabled.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'review-apps';
+const COLUMN_NAME = 'autodeployEnabled';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).notNullable().defaultTo(true);
+  });
+  await knex(TABLE_NAME).update({ [COLUMN_NAME]: false });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## 🔆 Problème

On veut gérer plus finement la désactivation de l’auto deploy sur les review apps.

## ⛱️ Proposition

Ajouter une colonne permettant de savoir si l’auto deploy est désactivé ou non pour une review app donnée.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A