### PR TITLE
[BUGFIX] Laisser Scalingo faire le premier déploiement

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -612,6 +612,7 @@ async function handleHeraPullRequestSynchronize(
 
   for (const app of existingApps) {
     await dependencies.reviewAppRepo.setStatus({ name: app.name, status: 'pending' });
+    if (app.autodeployEnabled) continue;
     await client.deployUsingSCM(app.name, ref);
   }
 
@@ -802,8 +803,6 @@ async function createReviewApp(
     parentApp,
   });
   await client.deployReviewApp(parentApp, pullRequestNumber);
-  await client.disableAutoDeploy(reviewAppName);
-  await client.deployUsingSCM(reviewAppName, ref);
 }
 
 async function removeReviewApp({ reviewAppName }, dependencies = { scalingoClient: ScalingoClient, reviewAppRepo }) {

--- a/build/repositories/review-app-repository.js
+++ b/build/repositories/review-app-repository.js
@@ -8,8 +8,7 @@ export const create = async function ({ name, repository, prNumber, parentApp })
 };
 
 export async function setStatus({ name, status }) {
-  const [result] = await knex('review-apps').update({ status }).where({ name }).returning(['repository', 'prNumber']);
-  return result;
+  await knex('review-apps').update({ status }).where({ name });
 }
 
 export const remove = async function ({ name }) {
@@ -18,8 +17,16 @@ export const remove = async function ({ name }) {
 
 export const listForPullRequest = async function ({ repository, prNumber }) {
   return knex
-    .select('name', 'parentApp', 'status')
+    .select('name', 'parentApp', 'status', 'autodeployEnabled')
     .from('review-apps')
     .where({ repository, prNumber })
     .orderBy('parentApp');
 };
+
+export async function get(name) {
+  return knex.select('repository', 'prNumber', 'autodeployEnabled').from('review-apps').where({ name }).first();
+}
+
+export async function setAutodeployEnabled({ name, autodeployEnabled }) {
+  await knex('review-apps').update({ autodeployEnabled }).where({ name });
+}

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -1563,8 +1563,6 @@ Removed review apps: pix-api-maddo-review-pr123`);
         const scalingoClientInstance = {
           reviewAppExists: sinon.stub().resolves(false),
           deployReviewApp: sinon.stub().resolves(),
-          disableAutoDeploy: sinon.stub().resolves(),
-          deployUsingSCM: sinon.stub().resolves(),
         };
         const scalingoClient = {
           getInstance: sinon.stub().resolves(scalingoClientInstance),
@@ -1585,8 +1583,6 @@ Removed review apps: pix-api-maddo-review-pr123`);
           parentApp,
         });
         expect(scalingoClientInstance.deployReviewApp).to.have.been.calledWithExactly(parentApp, pullRequestNumber);
-        expect(scalingoClientInstance.disableAutoDeploy).to.have.been.calledWithExactly(reviewAppName);
-        expect(scalingoClientInstance.deployUsingSCM).to.have.been.calledWithExactly(reviewAppName, ref);
       });
     });
 


### PR DESCRIPTION
## 🔆 Problème

Le déploiement automatique pour une RA est activé à la création d'une RA avant d'être désactivé. Il arrive qu'un premier déploiement lancé par Scalingo débute avant que le paramètre soit désactivé (il semblerait que ce soit le cas lorsqu'il n'y a pas d'addons à créer à la création de la RA).

## ⛱️ Proposition

Laisser Scalingo réaliser le premier déploiement et désactiver le déploiement automatique à la fin de ce déploiement.

## 🌊 Remarques

Nous désactivons le déploiement automatique car lorsqu'il est activé Scalingo réalise de nombreux appels à Github et nous atteignons la limite, pour faire face à ça les déploiements sont gérés par pix-bot.

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
