### PR TITLE
[FEATURE] Supprimer les addons postgres provisionnés sur les fronts (monorepo)

### DIFF
--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -278,6 +278,13 @@ class ScalingoClient {
     }
   }
 
+  async removeAddon(appName, providerId) {
+    const addons = await this.client.Addons.for(appName);
+    const addon = addons.find(({ addon_provider }) => addon_provider.id === providerId);
+    if (!addon) return;
+    await this.client.Addons.destroy(appName, addon.id);
+  }
+
   async #getNotifierId(notifierName) {
     let notifiers;
     try {


### PR DESCRIPTION
## 🔆 Problème

Lorsqu’on créé une RA frontend, on a souvent un double déploiement :
 - l’un déclenché par Scalingo avant que la désactivation du déploiement auto soit prise en compte
 - l’autre déclenché manuellement par pix-bot

On souhaite éviter ce double déploiement, et en particulier celui déclenché par Scalingo.

## ⛱️ Proposition

Provisionner un addon Postgres sur les RAs frontend afin de rallonger leur temps de création et de permettre de prendre en compte la désactivation du déploiement auto avant que Scalingo déclenche un premier déploiement.
L’addon est supprimé par pix-bot juste après la création de la RA.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Testé sur 1024pix/pix#13063