### PR TITLE
[FEATURE] Éviter de récupérer les infos de la PR quand pas nécessaire

### DIFF
--- a/common/services/github.js
+++ b/common/services/github.js
@@ -557,7 +557,11 @@ const github = {
       repositoryName = request.payload.repository.full_name;
       prNumber = request.payload.check_suite.pull_requests[0].number;
     } else if (eventName === 'issue_comment') {
-      if (!request.payload.issue.pull_request) {
+      if (
+        !request.payload.issue.pull_request ||
+        request.payload.comment.user.login !== 'pix-bot-github' ||
+        request.payload.action === 'created'
+      ) {
         return undefined;
       }
       repositoryName = request.payload.repository.full_name;

--- a/test/unit/build/services/github_test.js
+++ b/test/unit/build/services/github_test.js
@@ -896,11 +896,17 @@ describe('Unit | Build | github-test', function () {
         it('returns undefined', async function () {
           // given
           const payload = {
+            action: 'edited',
             repository: {
               full_name: repositoryName,
             },
             issue: {
               number: prNumber,
+            },
+            comment: {
+              user: {
+                login: 'pix-bot-github',
+              },
             },
           };
 
@@ -913,15 +919,75 @@ describe('Unit | Build | github-test', function () {
       });
 
       describe('when issue_comment is associated to a pull request', function () {
+        describe('when comment doesn’t belong to pix-bot', function () {
+          it('returns undefined', async function () {
+            // given
+            const payload = {
+              action: 'edited',
+              repository: {
+                full_name: repositoryName,
+              },
+              issue: {
+                pull_request: {},
+                number: prNumber,
+              },
+              comment: {
+                user: {
+                  login: 'Gudsfile',
+                },
+              },
+            };
+
+            // when
+            const result = await githubService.getPullRequestForEvent('issue_comment', { payload });
+
+            // then
+            expect(result).to.be.undefined;
+          });
+        });
+
+        describe('when action is created', function () {
+          it('returns undefined', async function () {
+            // given
+            const payload = {
+              action: 'created',
+              repository: {
+                full_name: repositoryName,
+              },
+              issue: {
+                pull_request: {},
+                number: prNumber,
+              },
+              comment: {
+                user: {
+                  login: 'pix-bot-github',
+                },
+              },
+            };
+
+            // when
+            const result = await githubService.getPullRequestForEvent('issue_comment', { payload });
+
+            // then
+            expect(result).to.be.undefined;
+          });
+        });
+
         it('returns data for given repository and PR number', async function () {
           // given
           const payload = {
+            action: 'edited',
             repository: {
               full_name: repositoryName,
             },
             issue: {
               pull_request: {},
               number: prNumber,
+            },
+            comment: {
+              user: {
+                login: 'pix-bot-github',
+              },
             },
           };
           const response = {


### PR DESCRIPTION
## 🔆 Problème

On récupère les infos de la PR trop souvent (notamment sur pix-bot-integration).

## ⛱️ Proposition

Mettre plus de vérification avant de récupérer les infos :
 - vérifier que l’auteur du commentaire est de pix-bot
 - vérifier que c’est une création de commentaire

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
