### PR TITLE
[FEATURE] Ajout de la colonne lastDeploymentId dans review-apps

### DIFF
--- a/db/migrations/20250731152627_add-review-apps-last-deployment-id.js
+++ b/db/migrations/20250731152627_add-review-apps-last-deployment-id.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'review-apps';
+const COLUMN_NAME = 'lastDeploymentId';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME).nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+}


### PR DESCRIPTION
## 🔆 Problème

On souhaite pouvoir identifier le dernier déploiement lancé pour une review app.

## ⛱️ Proposition

Ajouter la colonne lastDeploymentId dans la table review-apps.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
