### PR TITLE
[FEATURE] Amélioration du check-ra-deployment

### DIFF
--- a/build/repositories/review-app-repository.js
+++ b/build/repositories/review-app-repository.js
@@ -1,15 +1,30 @@
 import { knex } from '../../db/knex-database-connection.js';
 
-export const create = async function ({ name, repository, prNumber, parentApp }) {
-  await knex('review-apps').insert({ name, repository, prNumber, parentApp }).onConflict('name').merge({
-    createdAt: new Date(),
-    status: 'pending',
-  });
+export const create = async function ({ name, repository, prNumber, parentApp, deploymentId: lastDeploymentId }) {
+  await knex('review-apps')
+    .insert({ name, repository, prNumber, parentApp, lastDeploymentId })
+    .onConflict('name')
+    .merge({
+      createdAt: new Date(),
+      status: 'pending',
+      lastDeploymentId,
+    });
 };
 
-export async function setStatus({ name, status }) {
-  const [result] = await knex('review-apps').update({ status }).where({ name }).returning(['repository', 'prNumber']);
-  return result;
+export async function get(name) {
+  return knex
+    .select('name', 'repository', 'prNumber', 'status', 'lastDeploymentId')
+    .from('review-apps')
+    .where({ name })
+    .first();
+}
+
+export async function setStatusPending({ name, deploymentId }) {
+  await knex('review-apps').update({ status: 'pending', lastDeploymentId: deploymentId }).where({ name });
+}
+
+export async function setStatusSettled({ name, status }) {
+  await knex('review-apps').update({ status, lastDeploymentId: null }).where({ name });
 }
 
 export const remove = async function ({ name }) {

--- a/common/services/scalingo-client.js
+++ b/common/services/scalingo-client.js
@@ -49,16 +49,17 @@ class ScalingoClient {
     return `${scalingoApp} ${releaseTag} has been deployed`;
   }
 
-  async deployUsingSCM(scalingoApp, releaseTag) {
+  async deployUsingSCM(scalingoApp, ref) {
     try {
-      await this.client.SCMRepoLinks.manualDeploy(scalingoApp, releaseTag);
-    } catch (e) {
-      logger.error({ event, message: e, data: { scalingoApp, releaseTag } });
-      throw new Error(`Unable to deploy ${scalingoApp} ${releaseTag}`, { cause: e });
-    }
+      const deployment = await this.client.SCMRepoLinks.manualDeploy(scalingoApp, ref);
 
-    logger.info({ event, message: `Deployment has been requested`, data: { scalingoApp, releaseTag } });
-    return `Deployment of ${scalingoApp} ${releaseTag} has been requested`;
+      logger.info({ event, message: `Deployment has been requested`, data: { scalingoApp, ref } });
+
+      return deployment.id;
+    } catch (e) {
+      logger.error({ event, message: e, data: { scalingoApp, ref } });
+      throw new Error(`Unable to deploy ${scalingoApp} ${ref}`, { cause: e });
+    }
   }
 
   async getAppInfo(target) {

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -1113,7 +1113,7 @@ function addRADeploymentCheckNock({ repository, sha, status }) {
 function deployReviewAppNock({ reviewAppName, branch = 'my-branch', returnCode = StatusCodes.OK }) {
   return nock('https://scalingo.reviewApps')
     .post(`/v1/apps/${reviewAppName}/scm_repo_link/manual_deploy`, { branch: branch })
-    .reply(returnCode);
+    .reply(returnCode, { deployment: { id: 'deployment-id' } });
 }
 
 function disableAutoDeployNock({ reviewAppName, returnCode = StatusCodes.CREATED }) {

--- a/test/integration/run/services/slack/commands_test.js
+++ b/test/integration/run/services/slack/commands_test.js
@@ -16,7 +16,7 @@ describe('Integration | Run | Services | Slack | Commands', function () {
 
       const nockCall = nock('https://scalingo.production')
         .post(`/v1/apps/pix-airflow-production/scm_repo_link/manual_deploy`, deploymentPayload)
-        .reply(200, {});
+        .reply(200, { deployment: { id: 'deployment-id' } });
 
       await commands.deployAirflow(commandPayload);
 
@@ -39,10 +39,10 @@ describe('Integration | Run | Services | Slack | Commands', function () {
 
       const nockCallA = nock('https://scalingo.production')
         .post(`/v1/apps/pix-dbt-production/scm_repo_link/manual_deploy`, deploymentPayload)
-        .reply(200, {});
+        .reply(200, { deployment: { id: 'deployment-id-a' } });
       const nockCallB = nock('https://scalingo.production')
         .post(`/v1/apps/pix-dbt-external-production/scm_repo_link/manual_deploy`, deploymentPayload)
-        .reply(200, {});
+        .reply(200, { deployment: { id: 'deployment-id-b' } });
 
       await commands.deployDBT(commandPayload);
 
@@ -66,7 +66,7 @@ describe('Integration | Run | Services | Slack | Commands', function () {
 
       const nockCall = nock('https://scalingo.production')
         .post(`/v1/apps/pix-api-to-pg-production/scm_repo_link/manual_deploy`, deploymentPayload)
-        .reply(200, {});
+        .reply(200, { deployment: { id: 'deployment-id' } });
 
       await commands.deployPixApiToPg(commandPayload);
 

--- a/test/unit/common/services/scalingo-client_test.js
+++ b/test/unit/common/services/scalingo-client_test.js
@@ -176,7 +176,14 @@ describe('Scalingo client', function () {
     });
 
     it('should deploy an application for a given tag', async function () {
-      await scalingoClient.deployUsingSCM('pix-app-production', 'v1.0');
+      // given
+      manualDeployStub.resolves({ id: 'deployment-id' });
+
+      // when
+      const result = await scalingoClient.deployUsingSCM('pix-app-production', 'v1.0');
+
+      // then
+      expect(result).to.equal('deployment-id');
       expect(manualDeployStub).to.have.been.calledOnceWithExactly('pix-app-production', 'v1.0');
     });
 


### PR DESCRIPTION
## 🔆 Problème

Le check-ra-deployment passe vert trop tôt quand on fait des déploiements rapprochés (2 pushs successifs par ex.).

## ⛱️ Proposition

Changer le status de la RA en BdD seulement si l’appel de webhook concerne le dernier déploiement.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
