### PR TITLE
[TECH] Retirer les placeholders non utilisés

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -131,10 +131,7 @@ function getMessageTemplate(repositoryName) {
   return messageTemplate;
 }
 
-function getMessage(repositoryName, pullRequestId, scalingoReviewApps, messageTemplate) {
-  const scalingoDashboardUrl = `https://dashboard.scalingo.com/apps/osc-fr1/${scalingoReviewApps[0].appName}-pr${pullRequestId}/environment`;
-  const shortenedRepositoryName = repositoryName.replace('pix-', '');
-  const webApplicationUrl = `https://${shortenedRepositoryName}-pr${pullRequestId}.review.pix.fr`;
+function getMessage(pullRequestId, scalingoReviewApps, messageTemplate) {
   const checkboxesForReviewAppsToBeDeployed = scalingoReviewApps
     .map(({ appName, label, getLinks }) => {
       let links;
@@ -153,8 +150,6 @@ function getMessage(repositoryName, pullRequestId, scalingoReviewApps, messageTe
     .join('\n');
   const message = messageTemplate
     .replaceAll('{{pullRequestId}}', pullRequestId)
-    .replaceAll('{{webApplicationUrl}}', webApplicationUrl)
-    .replaceAll('{{scalingoDashboardUrl}}', scalingoDashboardUrl)
     .replaceAll('{{checkboxesForReviewAppsToBeDeployed}}', checkboxesForReviewAppsToBeDeployed);
   return message;
 }
@@ -530,7 +525,7 @@ async function addMessageToPullRequest(
   dependencies = { githubService: commonGithubService },
 ) {
   const template = getMessageTemplate(repositoryName, true);
-  const message = getMessage(repositoryName, pullRequestNumber, reviewApps, template);
+  const message = getMessage(pullRequestNumber, reviewApps, template);
   await dependencies.githubService.commentPullRequest({
     repositoryName,
     pullRequestId: pullRequestNumber,
@@ -546,7 +541,7 @@ async function updateMessageToPullRequest(
 
   const deploymentRAComment = comments.find((comment) => comment.user.login === 'pix-bot-github');
   const template = getMessageTemplate(repositoryName, true);
-  const message = getMessage(repositoryName, pullRequestNumber, reviewApps, template);
+  const message = getMessage(pullRequestNumber, reviewApps, template);
 
   if (!deploymentRAComment) {
     await dependencies.githubService.commentPullRequest({

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -67,17 +67,16 @@ describe('Unit | Controller | Github', function () {
 
   describe('#getMessage', function () {
     it('replace template placeholders with params', function () {
-      const template = 'Hello, url {{webApplicationUrl}}, {{pullRequestId}} and {{scalingoDashboardUrl}}';
-      expect(
-        githubController.getMessage('pix', '42', [{ appName: 'pix-review' }, { appName: 'pix-review2' }], template),
-      ).to.equal(
-        'Hello, url https://pix-pr42.review.pix.fr, 42 and https://dashboard.scalingo.com/apps/osc-fr1/pix-review-pr42/environment',
-      );
+      const template = 'Choisir les applications à déployer :\n{{checkboxesForReviewAppsToBeDeployed}}';
+      expect(githubController.getMessage('42', [{ appName: 'pix-review' }, { appName: 'pix-review2' }], template)).to
+        .equal(`Choisir les applications à déployer :
+- [ ] [pix](https://pix-review-pr42.osc-fr1.scalingo.io/) | [👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/pix-review-pr42/environment) <!-- pix-review -->
+- [ ] [pix2](https://pix-review2-pr42.osc-fr1.scalingo.io/) | [👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/pix-review2-pr42/environment) <!-- pix-review2 -->`);
     });
 
     it('replace multiple values', function () {
       const template = '{{pullRequestId}}, {{pullRequestId}}';
-      expect(githubController.getMessage('pix', '43', [{ appName: 'pix-review' }], template)).to.equal('43, 43');
+      expect(githubController.getMessage('43', [{ appName: 'pix-review' }], template)).to.equal('43, 43');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

Du code concerne les placesholders `scalingoDashboardUrl` et `webApplicationUrl` or ils ne sont plus utilisés dans les templates (`build/templates/pull-request-messages/`)

## ⛱️ Proposition

Supprimer ce code.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
