### PR TITLE
[TECH] Suprimer les références à l'app pix-front-review dépréciée

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -62,7 +62,6 @@ const repositoryToScalingoAppsReview = {
         { label: 'API', href: `https://api-pr${pullRequestNumber}.review.pix.fr/api/` },
       ],
     },
-    { appName: 'pix-front-review', isHidden: true },
     {
       appName: 'pix-app-review',
       getLinks: (pullRequestNumber) => [
@@ -137,7 +136,6 @@ function getMessage(repositoryName, pullRequestId, scalingoReviewApps, messageTe
   const shortenedRepositoryName = repositoryName.replace('pix-', '');
   const webApplicationUrl = `https://${shortenedRepositoryName}-pr${pullRequestId}.review.pix.fr`;
   const checkboxesForReviewAppsToBeDeployed = scalingoReviewApps
-    .filter(({ isHidden }) => !isHidden)
     .map(({ appName, label, getLinks }) => {
       let links;
       if (getLinks) {

--- a/sample.env
+++ b/sample.env
@@ -347,7 +347,7 @@ SCALINGO_TOKEN_REVIEW_APPS=__CHANGE_ME__
 # presence: optionnal
 # type: String (review apps names, separated by ',')
 # default: none
-#IGNORED_REVIEW_APPS=pix-api-review-pr925,pix-front-review-pr925,pix-api-review-pr994,pix-front-review-pr994
+#IGNORED_REVIEW_APPS=pix-api-review-pr925,pix-admin-review-pr925,pix-api-review-pr994,pix-admin-review-pr994
 
 # ======================
 # A11Y

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -332,12 +332,12 @@ describe('Acceptance | Build | Github', function () {
           };
           const scalingoAuth = nock('https://auth.scalingo.com').post('/v1/tokens/exchange').reply(StatusCodes.OK);
           await knex('review-apps').insert({
-            name: 'pix-front-review-pr2',
+            name: 'pix-admin-review-pr2',
             repository: 'pix',
             prNumber: 2,
-            parentApp: 'pix-front-review',
+            parentApp: 'pix-admin-review',
           });
-          const scalingoDeploy = deployReviewAppNock({ reviewAppName: 'pix-front-review-pr2' });
+          const scalingoDeploy = deployReviewAppNock({ reviewAppName: 'pix-admin-review-pr2' });
           const getPullRequest = getPullRequestNock({ repository: 'pix', prNumber: 2, sha: 'my-sha' });
           const addRADeploymentCheck = addRADeploymentCheckNock({
             repository: 'pix',
@@ -570,10 +570,8 @@ describe('Acceptance | Build | Github', function () {
           getAppNock({ reviewAppName: 'pix-api-review-pr123', returnCode: StatusCodes.OK });
           getAppNock({ reviewAppName: 'pix-api-maddo-review-pr123', returnCode: StatusCodes.OK });
           getAppNock({ reviewAppName: 'pix-audit-logger-review-pr123', returnCode: StatusCodes.NOT_FOUND });
-          getAppNock({ reviewAppName: 'pix-front-review-pr123', returnCode: StatusCodes.OK });
           deleteReviewAppNock({ reviewAppName: 'pix-api-review-pr123' });
           deleteReviewAppNock({ reviewAppName: 'pix-api-maddo-review-pr123' });
-          deleteReviewAppNock({ reviewAppName: 'pix-front-review-pr123' });
 
           const body = {
             action: 'closed',
@@ -611,7 +609,7 @@ describe('Acceptance | Build | Github', function () {
           expect(nock.isDone()).to.be.true;
 
           expect(response.payload).to.equal(
-            'Closed RA for PR 123 : pix-api-review-pr123, pix-front-review-pr123, pix-app-review-pr123 (already closed), pix-orga-review-pr123 (already closed), pix-certif-review-pr123 (already closed), pix-junior-review-pr123 (already closed), pix-admin-review-pr123 (already closed), pix-api-maddo-review-pr123, pix-audit-logger-review-pr123 (already closed).',
+            'Closed RA for PR 123 : pix-api-review-pr123, pix-app-review-pr123 (already closed), pix-orga-review-pr123 (already closed), pix-certif-review-pr123 (already closed), pix-junior-review-pr123 (already closed), pix-admin-review-pr123 (already closed), pix-api-maddo-review-pr123, pix-audit-logger-review-pr123 (already closed).',
           );
         });
       });

--- a/test/integration/build/scalingo_test.js
+++ b/test/integration/build/scalingo_test.js
@@ -287,7 +287,7 @@ describe('Integration | Build | Scalingo', function () {
           parentApp: 'pix-api-review',
         });
         await knex('review-apps').insert({
-          name: 'pix-front-review-pr123',
+          name: 'pix-admin-review-pr123',
           repository: 'pix',
           prNumber: 123,
           parentApp: 'pix-api-review',
@@ -330,7 +330,7 @@ describe('Integration | Build | Scalingo', function () {
           const prNumber = 123;
           await knex('review-apps').insert({ name: appName, repository, prNumber, parentApp: 'pix-api-review' });
           await knex('review-apps').insert({
-            name: 'pix-front-review-pr123',
+            name: 'pix-admin-review-pr123',
             repository,
             prNumber,
             parentApp: 'pix-api-review',
@@ -390,7 +390,7 @@ describe('Integration | Build | Scalingo', function () {
           parentApp: 'pix-api-review',
         });
         await knex('review-apps').insert({
-          name: 'pix-front-review-pr123',
+          name: 'pix-admin-review-pr123',
           repository,
           prNumber,
           parentApp: 'pix-api-review',

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -729,7 +729,7 @@ describe('Unit | Controller | Github', function () {
         const updateCheckRADeployment = sinon.stub().resolves();
 
         reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(true);
-        reviewAppExistsStub.withArgs('pix-front-review-pr3').resolves(true);
+        reviewAppExistsStub.withArgs('pix-admin-review-pr3').resolves(true);
         reviewAppExistsStub.withArgs('pix-audit-logger-review-pr3').resolves(false);
 
         // when
@@ -741,7 +741,7 @@ describe('Unit | Controller | Github', function () {
 
         // then
         expect(response).to.equal(
-          'Closed RA for PR 3 : pix-api-review-pr3, pix-front-review-pr3, pix-app-review-pr3 (already closed), pix-orga-review-pr3 (already closed), pix-certif-review-pr3 (already closed), pix-junior-review-pr3 (already closed), pix-admin-review-pr3 (already closed), pix-api-maddo-review-pr3 (already closed), pix-audit-logger-review-pr3 (already closed).',
+          'Closed RA for PR 3 : pix-api-review-pr3, pix-app-review-pr3 (already closed), pix-orga-review-pr3 (already closed), pix-certif-review-pr3 (already closed), pix-junior-review-pr3 (already closed), pix-admin-review-pr3, pix-api-maddo-review-pr3 (already closed), pix-audit-logger-review-pr3 (already closed).',
         );
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
@@ -765,7 +765,7 @@ describe('Unit | Controller | Github', function () {
         const updateCheckRADeployment = sinon.stub().resolves();
 
         reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(true);
-        reviewAppExistsStub.withArgs('pix-front-review-pr3').resolves(true);
+        reviewAppExistsStub.withArgs('pix-admin-review-pr3').resolves(true);
         reviewAppExistsStub.withArgs('pix-audit-logger-review-pr3').resolves(false);
 
         // when
@@ -777,7 +777,7 @@ describe('Unit | Controller | Github', function () {
 
         // then
         expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-api-review-pr3' })).to.be.true;
-        expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-front-review-pr3' })).to.be.true;
+        expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-admin-review-pr3' })).to.be.true;
         expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-audit-logger-review-pr3' })).to.be.true;
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
@@ -804,7 +804,7 @@ describe('Unit | Controller | Github', function () {
         const updateCheckRADeployment = sinon.stub().resolves();
 
         reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(true);
-        reviewAppExistsStub.withArgs('pix-front-review-pr3').resolves(true);
+        reviewAppExistsStub.withArgs('pix-admin-review-pr3').resolves(true);
         reviewAppExistsStub.withArgs('pix-audit-logger-review-pr3').resolves(false);
 
         // when
@@ -819,8 +819,8 @@ describe('Unit | Controller | Github', function () {
         expect(deleteReviewAppStub.calledWith('pix-api-review-pr3')).to.be.true;
         expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-audit-logger-review-pr3' })).to.be.true;
         expect(deleteReviewAppStub.calledWith('pix-audit-logger-review-pr3')).to.be.false;
-        expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-front-review-pr3' })).to.be.true;
-        expect(deleteReviewAppStub.calledWith('pix-front-review-pr3')).to.be.true;
+        expect(reviewAppRepositoryStub.remove.calledWith({ name: 'pix-admin-review-pr3' })).to.be.true;
+        expect(deleteReviewAppStub.calledWith('pix-admin-review-pr3')).to.be.true;
         expect(updateCheckRADeployment).to.have.been.calledWith({
           repositoryName: 'pix',
           pullRequestNumber: 3,
@@ -845,7 +845,7 @@ describe('Unit | Controller | Github', function () {
           });
 
           reviewAppExistsStub.withArgs('pix-api-review-pr3').resolves(true);
-          reviewAppExistsStub.withArgs('pix-front-review-pr3').resolves(true);
+          reviewAppExistsStub.withArgs('pix-admin-review-pr3').resolves(true);
 
           // when
           await githubController.handleCloseRA(request, {
@@ -1274,7 +1274,7 @@ Removed review apps: pix-api-maddo-review-pr123`);
         };
         const comment = `Choisir les applications à déployer :
 
-- [] Fronts <!-- pix-front-review -->
+- [] Admin <!-- pix-admin-review -->
 - [X] API <!-- pix-api-review -->
 - [X] API MaDDo <!-- pix-api-maddo-review -->
 - [ ] Audit Logger <!-- pix-audit-logger-review -->


### PR DESCRIPTION
## 🔆 Problème

Du code concerne ou fait référence à `pix-front-review` qui est dépréciée depuis le découpage en plusieurs apps. 
Toutes les PR utilisant cette app ont été mergées.

## ⛱️ Proposition

Supprimer ce code et les références à l'app.

## 🌊 Remarques

L'app peut-être supprimée côté Scalingo.

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
