### PR TITLE
[BUGFIX] Gérer le cas où la pullRequest est undefined lors d'un event d'édition d'issue comment (TECHDAYS)

### DIFF
--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -1027,6 +1027,32 @@ describe('Unit | Controller | Github', function () {
   });
 
   describe('#handleIssueComment', function () {
+    describe('when comment doesn’t belong to Pix Bot', function () {
+      it('should return appropriate message', async function () {
+        const pullRequest = undefined;
+
+        const request = {
+          payload: {
+            repository: {
+              full_name: '@1024pix/pix',
+            },
+            issue: {
+              pull_request: {},
+              number: 123,
+            },
+            comment: {
+              user: {
+                login: 'pix-bot-dummy',
+              },
+            },
+          },
+        };
+
+        const result = await githubController.handleIssueComment({ request, pullRequest });
+        expect(result).equal('The conditions for editing an issue comment are not met.');
+      });
+    });
+
     describe('when review apps are not configured for repository', function () {
       it('should return message Repository is not managed by Pix Bot', async function () {
         const pullRequest = {


### PR DESCRIPTION
## 🔆 Problème

<img width="959" height="427" alt="Capture d’écran 2025-08-01 à 15 14 28" src="https://github.com/user-attachments/assets/e988f5eb-19aa-4b56-ab18-1cdf7ee9260f" />


## ⛱️ Proposition

Gérer le cas où la pullRequest est `undefined` lors d'un event d'édition d'issue comment.

## 🌊 Remarques

https://github.com/1024pix/pix-bot/pull/624 cette PR est à l'origine du bug.
On passe volontairement pullRequest en `undefined` car on ne souhaite pas appeler github pour récupérer des infos si : 
- si ce n'est pas une pull request, 
- si l'auteur du commentaire n'est pas pix-bot-github
- à la création d'un commentaire
