### PR TITLE
[FEATURE] Ajouter des astuces au message du dépôt pix-data

### DIFF
--- a/build/templates/pull-request-messages/pix-data.md
+++ b/build/templates/pull-request-messages/pix-data.md
@@ -1,0 +1,9 @@
+Choisir les applications à déployer :
+
+{{checkboxesForReviewAppsToBeDeployed}}
+
+> [!TIP]
+> Pour pouvoir lancer les traitements spark depuis la RA sans avoir modifié de DAG (`data-pipelines/`) ou de Scala (`data-processing/`) il est nécessaire de modifier manuellement la variable d'env `AIRFLOW_VAR_DATA_SPARK_IMAGE_VERSION` (par exemple par `latest`).
+
+> [!TIP]
+> Pour pouvoir lancer les traitements Python (`data-processing-py/`), GX (`data-quality/`) et les tâches Airflow nécessitant du sec-num il est nécessaire d'uitliser l'app **`pix-airflow-preprod`** plutôt que la RA.


### PR DESCRIPTION
## 🔆 Problème

Il y a des subtilités à prendre en compte lors de l'utilisation des RA Airflow.

## ⛱️ Proposition

Ajouter les tips au template du message envoyé sur les PR pix-data.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Déployer pix-bot sur l'intégration, [ouvrir une PR sur pix-data ](https://github.com/1024pix/pix-data/pull/968)avec le label `pix-bot-integration` vérifier le message.
