### PR TITLE
[FEATURE] Suppression de la commande slack `/publish-pix-ui`

### DIFF
--- a/config.js
+++ b/config.js
@@ -185,7 +185,6 @@ const configuration = (function () {
     PIX_API_DATA_APPS: {
       production: ['pix-api-data-production'],
     },
-    PIX_UI_REPO_NAME: 'pix-ui',
     PIX_EMBER_TESTING_LIBRARY_REPO_NAME: 'ember-testing-library',
     PIX_DB_STATS_REPO_NAME: 'pix-db-stats',
     PIX_DB_STATS_APPS_NAME: ['pix-db-stats'],

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -48,15 +48,6 @@ const slack = {
     };
   },
 
-  createAndDeployPixUIRelease(request) {
-    const payload = request.pre.payload;
-    commands.createAndDeployPixUI(payload);
-
-    return {
-      text: _getDeployStartedMessage(payload.text, 'PIX UI'),
-    };
-  },
-
   createAndDeployPixLCMSRelease(request) {
     const payload = request.pre.payload;
     commands.createAndDeployPixLCMS(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -13,15 +13,6 @@ manifest.registerSlashCommand({
 });
 
 manifest.registerSlashCommand({
-  command: '/publish-pix-ui',
-  path: '/slack/commands/create-and-deploy-pix-ui-release',
-  description: 'Crée une release de Pix-UI et la déploie sur les Github pages !',
-  usage_hint: '[patch, minor, major]',
-  should_escape: false,
-  handler: slackbotController.createAndDeployPixUIRelease,
-});
-
-manifest.registerSlashCommand({
   command: '/deploy-ember-testing-library',
   path: '/slack/commands/create-and-deploy-ember-testing-library-release',
   description: 'Crée une release de Ember-testing-library',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -41,22 +41,6 @@ function _isReleaseTypeInvalid(releaseType) {
   return !['major', 'minor', 'patch'].includes(releaseType);
 }
 
-async function _publishPixUI(repoName, releaseType, responseUrl) {
-  if (_isReleaseTypeInvalid(releaseType)) {
-    releaseType = 'minor';
-  }
-  const releaseTagBeforeRelease = await githubServices.getLatestReleaseTag(repoName);
-  const releaseTagAfterRelease = await releasesService.publishPixRepo(repoName, releaseType);
-
-  if (releaseTagBeforeRelease === releaseTagAfterRelease) {
-    sendResponse(responseUrl, getErrorReleaseMessage(releaseTagAfterRelease, repoName));
-  } else {
-    const message = `[PIX-UI] App deployed (${releaseTagAfterRelease})`;
-    slackPostMessageService.postMessage({ message });
-    sendResponse(responseUrl, getSuccessMessage(releaseTagAfterRelease, repoName));
-  }
-}
-
 async function _publishAndDeployEmberTestingLibrary(repoName, releaseType, responseUrl) {
   if (_isReleaseTypeInvalid(releaseType)) {
     releaseType = 'minor';
@@ -155,10 +139,6 @@ async function createAndDeployPixLCMS(payload) {
   );
 }
 
-async function createAndDeployPixUI(payload) {
-  await _publishPixUI(config.PIX_UI_REPO_NAME, payload.text, payload.response_url);
-}
-
 async function createAndDeployEmberTestingLibrary(payload) {
   await _publishAndDeployEmberTestingLibrary(
     config.PIX_EMBER_TESTING_LIBRARY_REPO_NAME,
@@ -247,7 +227,6 @@ export {
   createAndDeployPixSiteRelease,
   createAndDeployPixTutosRelease,
   createAndDeployPixSecurixRelease,
-  createAndDeployPixUI,
   deployAirflow,
   deployDBT,
   deployPixExploitRelease,

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -49,13 +49,6 @@ describe('Acceptance | Run | Manifest', function () {
               should_escape: false,
             },
             {
-              command: '/publish-pix-ui',
-              url: `http://${hostname}/slack/commands/create-and-deploy-pix-ui-release`,
-              description: 'Crée une release de Pix-UI et la déploie sur les Github pages !',
-              usage_hint: '[patch, minor, major]',
-              should_escape: false,
-            },
-            {
               command: '/deploy-ember-testing-library',
               url: `http://${hostname}/slack/commands/create-and-deploy-ember-testing-library-release`,
               description: 'Crée une release de Ember-testing-library',

--- a/test/unit/run/services/slack/commands_test.js
+++ b/test/unit/run/services/slack/commands_test.js
@@ -13,7 +13,6 @@ import {
   createAndDeployPixSiteRelease,
   createAndDeployPixTutosRelease,
   createAndDeployPixSecurixRelease,
-  createAndDeployPixUI,
   getAndDeployLastVersion,
 } from '../../../../../run/services/slack/commands.js';
 import { catchErr, sinon } from '../../../../test-helper.js';
@@ -77,41 +76,6 @@ describe('Unit | Run | Services | Slack | Commands', function () {
           text: 'Erreur lors du déploiement de pix-site, pix-pro en production.',
         });
       });
-    });
-  });
-
-  describe('#createAndDeployPixUI', function () {
-    it('should publish a new release', async function () {
-      // given
-      const payload = { text: 'minor' };
-
-      // when
-      await createAndDeployPixUI(payload);
-
-      // then
-      sinon.assert.calledWith(releasesService.publishPixRepo, 'pix-ui', 'minor');
-    });
-
-    it('should retrieve the last release tag from GitHub', async function () {
-      // given
-      const payload = { text: 'minor' };
-
-      // when
-      await createAndDeployPixUI(payload);
-
-      // then
-      sinon.assert.calledOnceWithExactly(githubServices.getLatestReleaseTag, 'pix-ui');
-    });
-
-    it('should create a minor version if no version is given', async function () {
-      // given
-      const payload = { text: '' };
-
-      // when
-      await createAndDeployPixUI(payload);
-
-      // then
-      sinon.assert.calledWith(releasesService.publishPixRepo, 'pix-ui', 'minor');
     });
   });
 


### PR DESCRIPTION
## 🔆 Problème

La commande slack `/publish-pix-ui` n’est plus utilisée.

## ⛱️ Proposition

Supprimer la commande.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
