### PR TITLE
[TECH] Éviter les doubles déploiements sur pix-epreuves

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -28,6 +28,7 @@ const repositoryToScalingoAppsReview = {
         },
         { label: 'Ancien viewer', href: `https://epreuves-pr${pullRequestNumber}.review.pix.fr/viewer.html` },
       ],
+      shouldRemovePostgresAddon: true,
     },
   ],
   'pix-exploit': [{ appName: 'pix-exploit-review' }],


### PR DESCRIPTION
## ☔ Problème

On a quasi systématiquement des doubles déploiements sur pix-epreuves.

## 🧥 Proposition

Mettre en place le contournement pour éviter les doubles déploiements sur pix-epreuves.

## 🍂 Remarques

N/A

## 🎃 Pour tester

Test sur 1024pix/pix-epreuves#2690