### PR TITLE
[FEATURE] Ajoute la commande de déploiement de Pix Jobs Dashboard.

### DIFF
--- a/config.js
+++ b/config.js
@@ -215,6 +215,9 @@ const configuration = (function () {
     PIX_EXPLOIT_REPO_NAME: 'pix-exploit',
     PIX_EXPLOIT_APP_NAME: 'pix-exploit-production',
 
+    PIX_JOBS_DASHBOARD_REPO_NAME: 'pix-jobs-dashboard',
+    PIX_JOBS_DASHBOARD_APP_NAME: 'pix-jobs-dashboard-production',
+
     repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING) || {},
   };
 

--- a/run/controllers/slack.js
+++ b/run/controllers/slack.js
@@ -169,6 +169,14 @@ const slack = {
     };
   },
 
+  async deployPixJobsDashboardRelease() {
+    commands.deployPixJobsDashboardRelease();
+
+    return {
+      text: 'Commande de déploiement sur la production bien reçue.',
+    };
+  },
+
   async unlockRelease(request) {
     const payload = request.pre.payload;
     commands.unlockRelease(payload);

--- a/run/manifest.js
+++ b/run/manifest.js
@@ -120,6 +120,13 @@ manifest.registerSlashCommand({
   handler: slackbotController.deployPixExploitRelease,
 });
 
+manifest.registerSlashCommand({
+  command: '/deploy-pix-jobs-dashboard',
+  path: '/slack/commands/deploy-pix-jobs-dashboard-release',
+  description: 'Déploie la dernière release de pix-jobs-dashboard en production',
+  should_escape: false,
+  handler: slackbotController.deployPixJobsDashboardRelease,
+});
 manifest.registerShortcut({
   name: 'MEP/Déployer une version',
   type: 'global',

--- a/run/services/slack/commands.js
+++ b/run/services/slack/commands.js
@@ -210,6 +210,11 @@ async function deployPixExploitRelease() {
   await deployTagUsingSCM([config.PIX_EXPLOIT_APP_NAME], releaseTag);
 }
 
+export async function deployPixJobsDashboardRelease() {
+  const releaseTag = await github.getLatestReleaseTag(config.PIX_JOBS_DASHBOARD_REPO_NAME);
+  await deployTagUsingSCM([config.PIX_JOBS_DASHBOARD_APP_NAME], releaseTag);
+}
+
 async function unlockRelease(payload) {
   await updateStatus({ repositoryName: 'pix', environment: 'production', authorizeDeployment: true });
   const message = `La mise en production a été débloquée par <@${payload.user_id}> 😅 il est de nouveau possible de la lancer.`;

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -133,6 +133,12 @@ describe('Acceptance | Run | Manifest', function () {
               should_escape: false,
             },
             {
+              command: '/deploy-pix-jobs-dashboard',
+              url: `http://${hostname}/slack/commands/deploy-pix-jobs-dashboard-release`,
+              description: 'Déploie la dernière release de pix-jobs-dashboard en production',
+              should_escape: false,
+            },
+            {
               command: '/deploy-pix-api-to-pg',
               description: 'Déploie la version précisée de pix-api-to-pg en production',
               should_escape: false,


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

La nouvelle application `Pix Jobs Dashboard` n'est pas déployable via Pix Bot.

## 👩‍🚀 Proposition

On ajoute la commande `/deploy-pix-jobs-dashboard` pour déployer la dernière release en production.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
