### PR TITLE
[BUGFIX] Corrige le nom de repo utilisé pour l'application `pix-jobs-dashboard`

### DIFF
--- a/config.js
+++ b/config.js
@@ -215,8 +215,8 @@ const configuration = (function () {
     PIX_EXPLOIT_REPO_NAME: 'pix-exploit',
     PIX_EXPLOIT_APP_NAME: 'pix-exploit-production',
 
-    PIX_JOBS_DASHBOARD_REPO_NAME: 'pix-jobs-dashboard',
-    PIX_JOBS_DASHBOARD_APP_NAME: 'pix-jobs-dashboard-production',
+    PIX_JOBS_DASHBOARD_REPO_NAME: 'pix-jobs',
+    PIX_JOBS_DASHBOARD_APP_NAME: 'pix-jobs-production',
 
     repoAppNames: _getJSON(process.env.REPO_APP_NAMES_MAPPING) || {},
   };


### PR DESCRIPTION
## 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Le nom du repo de l'application `pix-jobs-dashboard` n'est pas le bon, ce qui entraine une 404 lors du lancement de la commande de déploiement.

## 👩‍🚀 Proposition

Remplacer le nom du repo par `pix-jobs`

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
