### PR TITLE
[BUGFIX] Ne pas annuler un merge en cours si la check suite n'est pas failed.

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -342,7 +342,7 @@ async function _processWebhookAsync(
       }
 
       const prNumber = request.payload.check_suite.pull_requests[0].number;
-      if (request.payload.check_suite.conclusion !== 'success') {
+      if (['failure', 'startup_failure', 'cancelled', 'timed_out'].includes(request.payload.check_suite.conclusion)) {
         await mergeQueue.unmanagePullRequest({ repositoryName, number: prNumber, status: MERGE_STATUS.ABORTED });
       } else {
         const hasReadyToMergeLabel = await githubService.isPrLabelledWith({


### PR DESCRIPTION
## 🚙 Problème

Quand la check suite notifie pix bot de la fin de la check suite, on supprime la PR de la merge queue même quand celle-ci n'est pas failed.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🍃 Proposition

Limiter la suppression de la PR de la merge queue aux seuls status de failure.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
