### PR TITLE
Add deployment auto logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ It offers the following services:
 - create a Review App;
 - shut down and restart Review Apps, at the time you want, every day of the week;
 - deploy a specific release into production via a secured API;
-- deploy a specific release into production via a Slack command or shortcut;
+- deploy a specific release into production via a Slack command or shortcut (deprecated);
 - call external service after a deployment (CDN invalidation).
 
 Pix Bot is deployed into two apps:
 - Pix Bot Build: contains the commands for the development tools
 - Pix Bot Run: contains the commands related to the releases
+
+[More details about deployment functionnality](https://1024pix.atlassian.net/wiki/spaces/TC1/blog/6097108994/D+ploiements+d+application+sur+Scalingo+avec+Pix+Bot)
 
 ## Run locally
 
@@ -106,6 +108,7 @@ Create a webhook on Github organization (or repository) :
 - Which events would you like to trigger this webhook? send me everything
 
 Perform some action on Github and check
+
 - ngrok receive Github request
 - pix-bot API process them
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pix-bot",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pix-bot",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pix-bot",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "Automating development actions",
   "engines": {
     "node": "^22.18.0"

--- a/run/controllers/github.js
+++ b/run/controllers/github.js
@@ -20,6 +20,10 @@ async function releaseWebhook(request, repoAppMapping = config.repoAppNames, inj
   const tag = request.payload.release.tag_name;
 
   if (!appNames) {
+      logger.info({
+        event: 'release',
+        message: `Github repository ${repository} has been released, but any deployement is configured . To enable deployment, please configure repo in REPO_APP_NAMES_MAPPING env var.`,
+      });
     return 'No Scalingo app configured for this repository';
   }
 
@@ -28,15 +32,28 @@ async function releaseWebhook(request, repoAppMapping = config.repoAppNames, inj
 
 async function deployFromArchive(appNames, tag, repository, scalingoClient) {
   logger.info({
-    event: 'deployFromArchive',
-    message: `Starting ${appNames} deployment of ${tag} from ${repository}.`,
+    event: 'release',
+    message: `Github repository ${repository} has been released. Starting ${appNames} deployment of ${tag}.`,
   });
   return Promise.all(
     appNames.map(async (appName) => {
-      const appNameFragment = appName.split('-');
-      const instance = appNameFragment[appNameFragment.length - 1];
-      const client = await scalingoClient.getInstance(instance);
-      return client.deployFromArchive(appName, tag, repository, { withEnvSuffix: false });
+      try{
+        const appNameFragment = appName.split('-');
+        const instance = appNameFragment[appNameFragment.length - 1];
+        const client = await scalingoClient.getInstance(instance);
+        return client.deployFromArchive(appName, tag, repository, { withEnvSuffix: false });
+      } catch (error) {
+        logger.error({
+          event: 'release',
+          stack: error.stack,
+          message: `${appName} deployment failed : ${error.message}. Please create the github release again to reload deployment.`,        
+          data: {
+            repository,
+            tag,
+            appName,
+          },
+        });
+      }
     }),
   );
 }

--- a/run/controllers/github.js
+++ b/run/controllers/github.js
@@ -20,10 +20,10 @@ async function releaseWebhook(request, repoAppMapping = config.repoAppNames, inj
   const tag = request.payload.release.tag_name;
 
   if (!appNames) {
-      logger.info({
-        event: 'release',
-        message: `Github repository ${repository} has been released, but any deployement is configured . To enable deployment, please configure repo in REPO_APP_NAMES_MAPPING env var.`,
-      });
+    logger.info({
+      event: 'release',
+      message: `Github repository ${repository} has been released, but any deployement is configured . To enable deployment, please configure repo in REPO_APP_NAMES_MAPPING env var.`,
+    });
     return 'No Scalingo app configured for this repository';
   }
 
@@ -37,7 +37,7 @@ async function deployFromArchive(appNames, tag, repository, scalingoClient) {
   });
   return Promise.all(
     appNames.map(async (appName) => {
-      try{
+      try {
         const appNameFragment = appName.split('-');
         const instance = appNameFragment[appNameFragment.length - 1];
         const client = await scalingoClient.getInstance(instance);
@@ -46,7 +46,7 @@ async function deployFromArchive(appNames, tag, repository, scalingoClient) {
         logger.error({
           event: 'release',
           stack: error.stack,
-          message: `${appName} deployment failed : ${error.message}. Please create the github release again to reload deployment.`,        
+          message: `${appName} deployment failed : ${error.message}. Please create the github release again to reload deployment.`,
           data: {
             repository,
             tag,


### PR DESCRIPTION
## 🚙 Problème

La méthode de déploiement auto est celle que nous souhaitons garder. Les autres sont obsolètes.
Actuellement, les logs ne sont pas suffisant.

## 🍃 Proposition

Ajout de logs sur la méthode de déploiement auto de pix-bot.

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
