### PR TITLE
[BUGFIX] Correction des URL des RA pour pix-site et pix-pro sur le TLD .org

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -38,14 +38,14 @@ const repositoryToScalingoAppsReview = {
       appName: 'pix-site-review',
       getLinks: (pullRequestNumber) => [
         { label: 'Pix Site (.fr)', href: `https://site-pr${pullRequestNumber}.review.pix.fr` },
-        { label: 'Pix Site (.org)', href: `https://site-pr${pullRequestNumber}.review.pix.fr` },
+        { label: 'Pix Site (.org)', href: `https://site-pr${pullRequestNumber}.review.pix.org` },
       ],
     },
     {
       appName: 'pix-pro-review',
       getLinks: (pullRequestNumber) => [
         { label: 'Pix Pro (.fr)', href: `https://pro-pr${pullRequestNumber}.review.pix.fr` },
-        { label: 'Pix Pro (.org)', href: `https://pro-pr${pullRequestNumber}.review.pix.fr` },
+        { label: 'Pix Pro (.org)', href: `https://pro-pr${pullRequestNumber}.review.pix.org` },
       ],
     },
   ],


### PR DESCRIPTION
## 🪧 Problème

Les URL des RA pour pix-site et pix-pro pour le TLD `.org` sont en `.fr`.

On peut voir ces mauvais liens par exemple dans la PR https://github.com/1024pix/pix-site/pull/814#issuecomment-5118851288 : les liens sur `Pix Site (.org)` et `Pix Pro (.org)` ne sont pas les bons.

## 🌈 Proposition

Modifier les URL erronés.

## ✊ Remarques

RAS

## 🎉 Pour tester

Je ne crois pas qu’on puisse.