### PR TITLE
[FEATURE] Ajouter le deploiement auto des reviews app basé sur le titre de la PR pour renovate

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -10,6 +10,7 @@ import * as reviewAppRepo from '../repositories/review-app-repository.js';
 import { MERGE_STATUS, mergeQueue as _mergeQueue } from '../services/merge-queue.js';
 import { updateCheckRADeployment } from '../usecases/updateCheckRADeployment.js';
 
+const userPixBot = 'pix-bot-github';
 const repositoryToScalingoAppsReview = {
   'pix-bot': [{ appName: 'pix-bot-review' }],
   'pix-data': [{ appName: 'pix-airflow-review', label: 'Airflow' }],
@@ -59,12 +60,14 @@ const repositoryToScalingoAppsReview = {
   pix: [
     {
       appName: 'pix-api-review',
+      folderName: 'api',
       getLinks: (pullRequestNumber) => [
         { label: 'API', href: `https://api-pr${pullRequestNumber}.review.pix.fr/api/` },
       ],
     },
     {
       appName: 'pix-app-review',
+      folderName: 'mon-pix',
       getLinks: (pullRequestNumber) => [
         { label: 'App (.fr)', href: `https://app-pr${pullRequestNumber}.review.pix.fr` },
         { label: 'App (.org)', href: `https://app-pr${pullRequestNumber}.review.pix.org` },
@@ -73,6 +76,7 @@ const repositoryToScalingoAppsReview = {
     },
     {
       appName: 'pix-orga-review',
+      folderName: 'orga',
       getLinks: (pullRequestNumber) => [
         { label: 'Orga (.fr)', href: `https://orga-pr${pullRequestNumber}.review.pix.fr` },
         { label: 'Orga (.org)', href: `https://orga-pr${pullRequestNumber}.review.pix.org` },
@@ -81,6 +85,7 @@ const repositoryToScalingoAppsReview = {
     },
     {
       appName: 'pix-certif-review',
+      folderName: 'certif',
       getLinks: (pullRequestNumber) => [
         { label: 'Certif (.fr)', href: `https://certif-pr${pullRequestNumber}.review.pix.fr` },
         { label: 'Certif (.org)', href: `https://certif-pr${pullRequestNumber}.review.pix.org` },
@@ -89,6 +94,7 @@ const repositoryToScalingoAppsReview = {
     },
     {
       appName: 'pix-junior-review',
+      folderName: 'junior',
       getLinks: (pullRequestNumber) => [
         { label: 'Junior', href: `https://junior-pr${pullRequestNumber}.review.pix.fr` },
       ],
@@ -96,17 +102,20 @@ const repositoryToScalingoAppsReview = {
     },
     {
       appName: 'pix-admin-review',
+      folderName: 'admin',
       getLinks: (pullRequestNumber) => [{ label: 'Admin', href: `https://admin-pr${pullRequestNumber}.review.pix.fr` }],
       shouldRemovePostgresAddon: true,
     },
     {
       appName: 'pix-api-maddo-review',
+      folderName: 'api',
       getLinks: (pullRequestNumber) => [
         { label: 'API MaDDo', href: `https://pix-api-maddo-review-pr${pullRequestNumber}.osc-fr1.scalingo.io/api/` },
       ],
     },
     {
       appName: 'pix-audit-logger-review',
+      folderName: 'audit-logger',
       getLinks: (pullRequestNumber) => [
         {
           label: 'Audit Logger',
@@ -132,7 +141,7 @@ function getMessageTemplate(repositoryName) {
   return messageTemplate;
 }
 
-function getMessage(pullRequestId, scalingoReviewApps, messageTemplate) {
+function getMessage(pullRequestId, scalingoReviewApps, messageTemplate, reviewAppsToDeploy) {
   const checkboxesForReviewAppsToBeDeployed = scalingoReviewApps
     .map(({ appName, label, getLinks }) => {
       let links;
@@ -146,7 +155,7 @@ function getMessage(pullRequestId, scalingoReviewApps, messageTemplate) {
 
       const scalingoDashboardLink = `[👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/${appName}-pr${pullRequestId}/environment)`;
 
-      return `- [ ] ${links} | ${scalingoDashboardLink} <!-- ${appName} -->`;
+      return `- [${reviewAppsToDeploy?.includes(appName) ? 'x' : ' '}] ${links} | ${scalingoDashboardLink} <!-- ${appName} -->`;
     })
     .join('\n');
   const message = messageTemplate
@@ -443,7 +452,7 @@ function shouldHandleIssueComment(request, pullRequest) {
     return { shouldContinue: false, message: 'Repository is not managed by Pix Bot.' };
   }
 
-  if (request.payload.comment.user.login !== 'pix-bot-github') {
+  if (request.payload.comment.user.login !== userPixBot) {
     return { shouldContinue: false, message: `Ignoring ${request.payload.comment.user.login} comment edition` };
   }
 
@@ -504,13 +513,71 @@ async function _handlePullRequest(
   return `Action ${payload.action} not handled`;
 }
 
+async function findDeploymentComment({ repositoryName, pullRequestNumber, githubService }) {
+  const comments = await githubService.getPullRequestComments({ repositoryName, pullRequestNumber });
+
+  return comments.find((comment) => comment.user.login === userPixBot);
+}
+
+async function autoDeployReviewAppsFromTitle({ prTitle, reviewApps, pullRequestNumber, repository, githubService }) {
+  const appFromTitle = prTitle.match(/\(([^)]+)\)/)?.[1];
+
+  if (!appFromTitle) {
+    logger.info({
+      event: 'review-app',
+      message: `No folder name found in title of PR ${pullRequestNumber} in repository ${repository}, no review app to deploy`,
+    });
+    return;
+  }
+
+  const reviewAppsToDeploy = reviewApps
+    .filter(({ folderName }) => folderName === appFromTitle)
+    .map(({ appName }) => appName);
+
+  if (reviewAppsToDeploy.length === 0) {
+    logger.info({
+      event: 'review-app',
+      message: `No review app found for folder ${appFromTitle} in PR ${pullRequestNumber} in repository ${repository}, no review app to deploy`,
+    });
+    return;
+  }
+
+  const messageWithRAtoDeploy = getMessage(
+    pullRequestNumber,
+    reviewApps,
+    getMessageTemplate(repository),
+    reviewAppsToDeploy,
+  );
+  const deploymentRAComment = await findDeploymentComment({
+    repositoryName: repository,
+    pullRequestNumber,
+    githubService,
+  });
+
+  if (!deploymentRAComment) {
+    logger.info({
+      event: 'review-app',
+      message: `No deployment comment found on PR ${pullRequestNumber} in repository ${repository}, no review app to deploy`,
+    });
+    return;
+  }
+
+  await githubService.editPullRequestComment({
+    repositoryName: repository,
+    commentId: deploymentRAComment.id,
+    newComment: messageWithRAtoDeploy,
+  });
+}
+
 async function handlePullRequestOpened(
   request,
-  dependencies = { addMessageToPullRequest, githubService: commonGithubService },
+  dependencies = { addMessageToPullRequest, githubService: commonGithubService, autoDeployReviewAppsFromTitle },
 ) {
   const pullRequestNumber = request.payload.number;
   const repository = request.payload.pull_request.head.repo.name;
   const sha = request.payload.pull_request.head.sha;
+  const creator = request.payload.pull_request.user.login;
+  const prTitle = request.payload.pull_request.title;
 
   const reviewApps = repositoryToScalingoAppsReview[repository];
 
@@ -526,6 +593,24 @@ async function handlePullRequestOpened(
     status: 'success',
     sha,
   });
+
+  if (creator === 'renovate[bot]') {
+    try {
+      await dependencies.autoDeployReviewAppsFromTitle({
+        prTitle,
+        reviewApps,
+        pullRequestNumber,
+        repository,
+        githubService: dependencies.githubService,
+      });
+    } catch (error) {
+      logger.error({
+        event: 'review-app',
+        message: `Auto deploy of review apps failed on PR ${pullRequestNumber} in repository ${repository} : ${error.message}`,
+        stack: error.stack,
+      });
+    }
+  }
 
   logger.info({
     event: 'review-app',
@@ -618,9 +703,11 @@ async function updateMessageToPullRequest(
   { repositoryName, reviewApps, pullRequestNumber },
   dependencies = { githubService: commonGithubService },
 ) {
-  const comments = await dependencies.githubService.getPullRequestComments({ repositoryName, pullRequestNumber });
-
-  const deploymentRAComment = comments.find((comment) => comment.user.login === 'pix-bot-github');
+  const deploymentRAComment = await findDeploymentComment({
+    repositoryName,
+    pullRequestNumber,
+    githubService: dependencies.githubService,
+  });
   const template = getMessageTemplate(repositoryName, true);
   const message = getMessage(pullRequestNumber, reviewApps, template);
 
@@ -758,6 +845,7 @@ export {
   getMessage,
   getMessageTemplate,
   processWebhook,
+  autoDeployReviewAppsFromTitle,
   _processWebhookAsync,
   _pushOnDefaultBranchWebhook as pushOnDefaultBranchWebhook,
   _handleCloseRA as handleCloseRA,

--- a/test/acceptance/build/github_test.js
+++ b/test/acceptance/build/github_test.js
@@ -274,6 +274,7 @@ describe('Acceptance | Build | Github', function () {
                   fork: false,
                 },
               },
+              user: { login: 'user' },
             },
           };
           const createComment = createPullRequestCommentNock({ repository: 'pix', prNumber: 2 });

--- a/test/unit/build/controllers/github_test.js
+++ b/test/unit/build/controllers/github_test.js
@@ -68,9 +68,12 @@ describe('Unit | Controller | Github', function () {
   describe('#getMessage', function () {
     it('replace template placeholders with params', function () {
       const template = 'Choisir les applications à déployer :\n{{checkboxesForReviewAppsToBeDeployed}}';
-      expect(githubController.getMessage('42', [{ appName: 'pix-review' }, { appName: 'pix-review2' }], template)).to
-        .equal(`Choisir les applications à déployer :
-- [ ] [pix](https://pix-review-pr42.osc-fr1.scalingo.io/) | [👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/pix-review-pr42/environment) <!-- pix-review -->
+      expect(
+        githubController.getMessage('42', [{ appName: 'pix-review' }, { appName: 'pix-review2' }], template, [
+          'pix-review',
+        ]),
+      ).to.equal(`Choisir les applications à déployer :
+- [x] [pix](https://pix-review-pr42.osc-fr1.scalingo.io/) | [👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/pix-review-pr42/environment) <!-- pix-review -->
 - [ ] [pix2](https://pix-review2-pr42.osc-fr1.scalingo.io/) | [👩‍💻 Dashboard Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/pix-review2-pr42/environment) <!-- pix-review2 -->`);
     });
 
@@ -945,6 +948,8 @@ describe('Unit | Controller | Github', function () {
               },
               sha: 'abc123',
             },
+            title: 'PR title',
+            user: { login: 'user' },
           },
         },
       };
@@ -967,6 +972,98 @@ describe('Unit | Controller | Github', function () {
         prNumber: 123,
         status: 'success',
         sha: 'abc123',
+      });
+    });
+
+    describe('when user is renovate[bot]', function () {
+      it('should call _autoDeployReviewAppsFromTitle method', async function () {
+        // given
+        const request = {
+          payload: {
+            number: 123,
+            pull_request: {
+              head: {
+                repo: {
+                  name: 'pix',
+                },
+                sha: 'abc123',
+              },
+              title: 'PR title',
+              user: { login: 'renovate[bot]' },
+            },
+          },
+        };
+        const addMessageToPullRequest = sinon.stub().resolves();
+        const autoDeployReviewAppsFromTitle = sinon.stub().resolves();
+        const githubService = {
+          addRADeploymentCheck: sinon.stub().resolves(),
+          editPullRequestComment: sinon.stub().resolves(),
+        };
+
+        // when
+        await githubController.handlePullRequestOpened(request, {
+          addMessageToPullRequest,
+          githubService,
+          autoDeployReviewAppsFromTitle,
+        });
+
+        // then
+        expect(addMessageToPullRequest).to.have.been.calledWithExactly({
+          repositoryName: 'pix',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+        });
+        expect(githubService.addRADeploymentCheck).to.have.been.calledOnceWithExactly({
+          repository: 'pix',
+          prNumber: 123,
+          status: 'success',
+          sha: 'abc123',
+        });
+        expect(autoDeployReviewAppsFromTitle).to.have.been.calledOnceWithExactly({
+          prTitle: 'PR title',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+          repository: 'pix',
+          githubService,
+        });
+      });
+
+      describe('when the auto deploy fails', function () {
+        it('should not fail the whole pull request handling', async function () {
+          // given
+          const request = {
+            payload: {
+              number: 123,
+              pull_request: {
+                head: {
+                  repo: {
+                    name: 'pix',
+                  },
+                  sha: 'abc123',
+                },
+                title: 'PR title',
+                user: { login: 'renovate[bot]' },
+              },
+            },
+          };
+          const addMessageToPullRequest = sinon.stub().resolves();
+          const autoDeployReviewAppsFromTitle = sinon.stub().rejects(new Error('Github API error'));
+          const githubService = {
+            addRADeploymentCheck: sinon.stub().resolves(),
+            editPullRequestComment: sinon.stub().resolves(),
+          };
+
+          // when
+          const result = await githubController.handlePullRequestOpened(request, {
+            addMessageToPullRequest,
+            githubService,
+            autoDeployReviewAppsFromTitle,
+          });
+
+          // then
+          expect(autoDeployReviewAppsFromTitle).to.have.been.calledOnce;
+          expect(result).to.equal('Commented on PR 123 in repository pix');
+        });
       });
     });
   });
@@ -1627,6 +1724,157 @@ Removed review apps: pix-api-maddo-review-pr123`);
         repositoryName,
         pullRequestId: pullRequestNumber,
         comment: COMMENT,
+      });
+    });
+  });
+
+  describe('#autoDeployReviewAppsFromTitle', function () {
+    function getCheckedAppNames(comment) {
+      return [...comment.matchAll(/^- \[x\] .*<!-- (.+) -->$/gm)].map(([, appName]) => appName);
+    }
+
+    it('should check the review apps whose folder name is the one given in the pull request title', async function () {
+      // given
+      const githubService = {
+        getPullRequestComments: sinon.stub().resolves([{ user: { login: 'pix-bot-github' }, id: 2 }]),
+        editPullRequestComment: sinon.stub().resolves(),
+      };
+
+      // when
+      await githubController.autoDeployReviewAppsFromTitle({
+        prTitle: '[BUMP] Update dependency axios to v1.19.0 (api)',
+        reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+        pullRequestNumber: 123,
+        repository: 'pix',
+        githubService,
+      });
+
+      // then
+      expect(githubService.getPullRequestComments).to.have.been.calledOnceWithExactly({
+        repositoryName: 'pix',
+        pullRequestNumber: 123,
+      });
+      expect(githubService.editPullRequestComment).to.have.been.calledOnce;
+      const { repositoryName, commentId, newComment } = githubService.editPullRequestComment.firstCall.args[0];
+      expect({ repositoryName, commentId }).to.deep.equal({ repositoryName: 'pix', commentId: 2 });
+      expect(getCheckedAppNames(newComment)).to.deep.equal(['pix-api-review', 'pix-api-maddo-review']);
+    });
+
+    it('should edit the pix-bot-github comment only', async function () {
+      // given
+      const githubService = {
+        getPullRequestComments: sinon.stub().resolves([
+          { user: { login: 'renovate[bot]' }, id: 1 },
+          { user: { login: 'pix-bot-github' }, id: 42 },
+          { user: { login: 'a-reviewer' }, id: 3 },
+        ]),
+        editPullRequestComment: sinon.stub().resolves(),
+      };
+
+      // when
+      await githubController.autoDeployReviewAppsFromTitle({
+        prTitle: '[BUMP] Update dependency axios to v1.19.0 (junior)',
+        reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+        pullRequestNumber: 123,
+        repository: 'pix',
+        githubService,
+      });
+
+      // then
+      expect(githubService.editPullRequestComment).to.have.been.calledOnce;
+      expect(githubService.editPullRequestComment.firstCall.args[0].commentId).to.equal(42);
+    });
+
+    describe('when the pull request title has several parentheses', function () {
+      it('should only use the first parentheses to find the folder name', async function () {
+        // given
+        // renovate can append the update type after the folder name, e.g. "(api) (major)"
+        const githubService = {
+          getPullRequestComments: sinon.stub().resolves([{ user: { login: 'pix-bot-github' }, id: 2 }]),
+          editPullRequestComment: sinon.stub().resolves(),
+        };
+
+        // when
+        await githubController.autoDeployReviewAppsFromTitle({
+          prTitle: '[BUMP] Update dependency axios to v2.0.0 (api) (major)',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+          repository: 'pix',
+          githubService,
+        });
+
+        // then
+        expect(githubService.editPullRequestComment).to.have.been.calledOnce;
+        const { newComment } = githubService.editPullRequestComment.firstCall.args[0];
+        expect(getCheckedAppNames(newComment)).to.deep.equal(['pix-api-review', 'pix-api-maddo-review']);
+      });
+    });
+
+    describe('when the pull request title has no folder name', function () {
+      it('should not edit any comment', async function () {
+        // given
+        const githubService = {
+          getPullRequestComments: sinon.stub().resolves([{ user: { login: 'pix-bot-github' }, id: 2 }]),
+          editPullRequestComment: sinon.stub().resolves(),
+        };
+
+        // when
+        await githubController.autoDeployReviewAppsFromTitle({
+          prTitle: '[BUMP] Update dependency axios to v1.19.0',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+          repository: 'pix',
+          githubService,
+        });
+
+        // then
+        expect(githubService.getPullRequestComments).to.not.have.been.called;
+        expect(githubService.editPullRequestComment).to.not.have.been.called;
+      });
+    });
+
+    describe('when no review app matches the folder name of the pull request title', function () {
+      it('should not fetch nor edit any comment', async function () {
+        // given
+        const githubService = {
+          getPullRequestComments: sinon.stub().resolves([{ user: { login: 'pix-bot-github' }, id: 2 }]),
+          editPullRequestComment: sinon.stub().resolves(),
+        };
+
+        // when
+        await githubController.autoDeployReviewAppsFromTitle({
+          prTitle: '[BUMP] Update dependency axios to v1.19.0 (dossier racine)',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+          repository: 'pix',
+          githubService,
+        });
+
+        // then
+        expect(githubService.getPullRequestComments).to.not.have.been.called;
+        expect(githubService.editPullRequestComment).to.not.have.been.called;
+      });
+    });
+
+    describe('when the pull request has no deployment comment', function () {
+      it('should not edit any comment', async function () {
+        // given
+        const githubService = {
+          getPullRequestComments: sinon.stub().resolves([{ user: { login: 'a-reviewer' }, id: 1 }]),
+          editPullRequestComment: sinon.stub().resolves(),
+        };
+
+        // when
+        await githubController.autoDeployReviewAppsFromTitle({
+          prTitle: '[BUMP] Update dependency axios to v1.19.0 (api)',
+          reviewApps: githubController.repositoryToScalingoAppsReview.pix,
+          pullRequestNumber: 123,
+          repository: 'pix',
+          githubService,
+        });
+
+        // then
+        expect(githubService.editPullRequestComment).to.not.have.been.called;
       });
     });
   });


### PR DESCRIPTION
## ☀️ Problème

Les PR ouvertes par renovate sur `pix` indiquent déjà le dossier concerné entre parenthèses dans leur titre : `[BUMP] Update dependency axios to v1.19.0 (api)`. Pourtant, il faut aller cocher à la main les cases des review apps correspondantes dans le commentaire de Pix Bot pour les déployer, alors que l'information est disponible dès l'ouverture de la PR.

## ⛱️ Proposition

À l'ouverture d'une PR créée par `renovate[bot]`, on lit le nom de dossier entre parenthèses dans le titre, on en déduit les review apps concernées via leur `folderName` et on édite le commentaire de déploiement de Pix Bot avec les cases déjà cochées. Le déploiement est ensuite déclenché par le mécanisme existant d'édition de commentaire.

Dans le détail :
- `getMessage` accepte un paramètre `reviewAppsToDeploy` qui coche les cases des applications concernées ;
- `autoDeployReviewAppsFromTitle` ne fait rien (avec un log) si le titre ne contient pas de parenthèses, si aucune review app ne correspond au dossier, ou si le commentaire de déploiement est introuvable ;
- l'appel est encadré d'un `try/catch` : l'auto-déploiement est un bonus, il ne doit pas faire échouer le traitement du webhook ;
- au passage, extraction de `findDeploymentComment` (mutualisée avec `updateMessageToPullRequest`) et de la constante `userPixBot`.

## 🧴 Remarques

On prend volontairement la **première** parenthèse du titre pour cette v1. Le cas où renovate suffixe le type de mise à jour (`(api) (major)`) est donc couvert. Si un jour renovate inverse l'ordre (`(major) (api)`), rien ne sera déployé — sans crash ni blocage du workflow — et on fera évoluer la détection à ce moment-là.

Seules les applications du repo `pix` ont un `folderName` renseigné : la fonctionnalité est sans effet sur les autres repos.

## 🏊 Pour tester

Difficilement testable manuellement, le comportement est couvert par les tests unitaires de `#autoDeployReviewAppsFromTitle` et `#handlePullRequestOpened`.

Sinon, sur la review app de Pix Bot, rejouer un webhook `pull_request` / `opened` avec un payload dont `pull_request.user.login` vaut `renovate[bot]` et dont le titre contient `(api)`, puis vérifier que les cases `API` et `API MaDDo` du commentaire de déploiement sont cochées.