### PR TITLE
[TECH] Passer sur la configuration par défaut de Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>1024pix/renovate-config:aggressive"],
+  "extends": ["github>1024pix/renovate-config:default"],
   "enabled": true
 }


### PR DESCRIPTION
## ☀️ Problème
Nous allons supprimer les configurations `auto-minor`, `aggressive`, `auto-patch` et `no-auto` de renovate-config.

## ⛱️ Proposition
Passer sur la configuration par défaut de Renovate config