### PR TITLE
[BUGFIX] Renommer pix-data-api-pix en pix-api-to-pg

### DIFF
--- a/build/controllers/github.js
+++ b/build/controllers/github.js
@@ -14,7 +14,7 @@ const userPixBot = 'pix-bot-github';
 const repositoryToScalingoAppsReview = {
   'pix-bot': [{ appName: 'pix-bot-review' }],
   'pix-data': [{ appName: 'pix-airflow-review', label: 'Airflow' }],
-  'pix-api-to-pg': [{ appName: 'pix-data-api-pix-integration' }],
+  'pix-api-to-pg': [{ appName: 'pix-api-to-pg-integration' }],
   'pix-db-replication': [{ appName: 'pix-datawarehouse-review' }],
   'pix-db-stats': [{ appName: 'pix-db-stats-review' }],
   'pix-editor': [{ appName: 'pix-lcms-review' }],


### PR DESCRIPTION
## ☀️ Problème

Par le passé le repository pix-data-api-pix a été renommé en pix-api-to-pg. Il reste une occurence de l'ancien nom empéchant le déploiement de l'intégration (utilisée dans les PR).

## ⛱️ Proposition

Renommer pix-data-api-pix en pix-api-to-pg.

## 🧴 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
