### PR TITLE
[TECH] Supprime le déploiement de PrivateBin

### DIFF
--- a/run/deploy-configuration.js
+++ b/run/deploy-configuration.js
@@ -16,15 +16,6 @@ const deployConfiguration = [
   },
   {
     slashCommand: {
-      command: '/deploy-privatebin',
-      description: 'Déploie privatebin',
-      usage_hint: '/deploy-privatebin',
-    },
-    slackReturnText: 'Commande de déploiement de PrivateBin en production bien reçue.',
-    deployFunction: fromBranch('privatebin-deploy', ['pix-privatebin-production'], 'main'),
-  },
-  {
-    slashCommand: {
       command: '/deploy-pix-apim',
       description: 'Pour déployer les applications Pix APIM depuis la branche main',
       usage_hint: '/deploy-pix-apim',

--- a/test/acceptance/run/manifest_test.js
+++ b/test/acceptance/run/manifest_test.js
@@ -159,13 +159,6 @@ describe('Acceptance | Run | Manifest', function () {
               usage_hint: '/deploy-metabase',
             },
             {
-              command: '/deploy-privatebin',
-              description: 'Déploie privatebin',
-              should_escape: false,
-              url: `http://${hostname}/slack/commands/deploy-privatebin`,
-              usage_hint: '/deploy-privatebin',
-            },
-            {
               command: '/deploy-pix-apim',
               description: 'Pour déployer les applications Pix APIM depuis la branche main',
               should_escape: false,

--- a/test/acceptance/run/slashcommand_test.js
+++ b/test/acceptance/run/slashcommand_test.js
@@ -16,20 +16,6 @@ describe('Acceptance | Run | SlashCommand', function () {
     });
   });
 
-  describe('POST /slack/commands/deploy-privatebin', function () {
-    it('responds with 200', async function () {
-      const body = {};
-      const res = await server.inject({
-        method: 'POST',
-        url: '/slack/commands/deploy-privatebin',
-        headers: createSlackWebhookSignatureHeaders(JSON.stringify(body)),
-        payload: body,
-      });
-      expect(res.statusCode).to.equal(200);
-      expect(res.result.text).to.equal('Commande de déploiement de PrivateBin en production bien reçue.');
-    });
-  });
-
   describe('POST /slack/commands/deploy-pix-apim', function () {
     it('responds with 200', async function () {
       const body = {};


### PR DESCRIPTION
## ☀️ Problème

L'application PrivateBin n'est plus déployée chez Scalingo. Elle a été migré vers notre cluster Kubernetes. La commande slash `/deploy-privatebin` et sa configuration de déploiement associée sont donc devenues obsolètes.

## ⛱️ Proposition

Suppression de l'entrée `/deploy-privatebin` dans `run/deploy-configuration.js` (déploiement de `privatebin-deploy` vers `pix-privatebin-production` depuis `main`), ainsi que des tests d'acceptance correspondants.

La route Slack et l'entrée du manifest étant générées à partir de `deployConfiguration`, il n'y a rien d'autre à retirer : la commande disparaît automatiquement du manifest et l'endpoint n'est plus exposé.

## 🏊 Pour tester

- [ ] `npm test` : les tests d'acceptance `manifest_test.js` et `slashcommand_test.js` passent sans l'entrée PrivateBin.
- [ ] Vérifier que la commande `/deploy-privatebin` n'apparaît plus dans le manifest Slack généré (`GET /run/manifest`), et que les autres commandes de déploiement sont inchangées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
